### PR TITLE
Correção na criaç~~ao da pasta de controle de sessoes 

### DIFF
--- a/src/protected/application/bootstrap-common.php
+++ b/src/protected/application/bootstrap-common.php
@@ -20,7 +20,7 @@ if(!is_dir(PRIVATE_FILES_PATH)){
     mkdir(PRIVATE_FILES_PATH);
 }
 
-if(!is_dir(SESSIONS_SAVE_PATH)){
+if(!is_dir(SESSIONS_SAVE_PATH) &&  strpos(SESSIONS_SAVE_PATH,'tcp://') === false){
     mkdir(SESSIONS_SAVE_PATH);
 }
 


### PR DESCRIPTION
Somente cria nova pasta para controle de sessao quando o  save_path n…ao é uma url e o diretorio nao existe. para casos que utilizam redis como controle de sessao