### PR TITLE
corrige link para inscrição no tab de avaliações para usuários admins

### DIFF
--- a/src/protected/application/themes/BaseV1/layouts/parts/singles/opportunity-evaluations--admin--table.php
+++ b/src/protected/application/themes/BaseV1/layouts/parts/singles/opportunity-evaluations--admin--table.php
@@ -42,7 +42,7 @@
 
         <tr ng-repeat="evaluation in data.evaluations" id="registration-{{evaluation.registration.id}}" >
             <td class="registration-id-col">
-                <a href='{{evaluation.evaluation.singleUrl}}' rel='noopener noreferrer'>
+                <a href='{{evaluation.evaluation.singleUrl || evaluation.registration.singleUrl}}' rel='noopener noreferrer'>
                     <strong>{{evaluation.registration.number}}</strong>
                 </a>
             </td>


### PR DESCRIPTION
Com esta alteração, o link da inscrição passa a ser utilizado como fallback para o link da avaliação, que não existe quando a inscrição está pendente de avaliação.