### PR TITLE
corrige salvamento dos dados de geolocalização no agente (#1665)

### DIFF
--- a/src/protected/application/conf/conf-base.d/maps.php
+++ b/src/protected/application/conf/conf-base.d/maps.php
@@ -4,6 +4,7 @@ return [
     'maps.includeGoogleLayers'  => env('MAPS_USE_GOOGLE_LAYERS', false),
     'app.useGoogleGeocode'      => env('MAPS_USE_GOOGLE_GEOCODE', false),
     'app.googleApiKey'          => env('MAPS_GOOGLE_API_KEY', ''),
+    'app.enableLocationPatch'   => env('MAPS_ENABLE_LOCATION_PATCH', false),
 
     'maps.center'  => explode(',', env('MAPS_CENTER', '-14.2400732,-53.1805018')), 
     

--- a/src/protected/application/lib/MapasCulturais/Entities/EntityRevision.php
+++ b/src/protected/application/lib/MapasCulturais/Entities/EntityRevision.php
@@ -23,6 +23,7 @@ class EntityRevision extends \MapasCulturais\Entity{
     const ACTION_TRASHED        = 'delete';
     const ACTION_UNTRASHED      = 'undelete';
     const ACTION_DELETED        = 'delete';
+    const ACTION_AUTOUPDATED    = 'autoupdated'; // for implicit modifications
 
 
 

--- a/src/protected/application/lib/modules/RegistrationFieldTypes/assets/js/rfc/location.js
+++ b/src/protected/application/lib/modules/RegistrationFieldTypes/assets/js/rfc/location.js
@@ -1,5 +1,5 @@
-$(function(){
-    function setAddress($container){
+$(function() {
+    function setAddress($container) {
         clearTimeout(window._address_timeout);
 
         window._address_timeout = setTimeout(function(){
@@ -9,14 +9,16 @@ $(function(){
             var street = $container.find('.js-rfc-input-En_Nome_Logradouro').val();
             var neighborhood = $container.find('.js-rfc-input-En_Bairro').val();
             var number = $container.find('.js-rfc-input-En_Num').val();
-    
+
             if (state && city && street) {
-                var address = neighborhood ? 
-                    street + ' ' + number + ', ' + neighborhood + ', ' + city + ', ' + state + ', ' + country : 
+                var address = neighborhood ?
+                    street + ' ' + number + ', ' + neighborhood + ', ' + city + ', ' + state + ', ' + country :
                     street + ' ' + number + ', ' + city + ', ' + state + ', ' + country;
-    
-                
-                $container.find('.js-rfc-input-endereco').val(address).trigger('change');
+
+                var $scope = $container.scope();
+                var topAddr = $scope.entity[$scope.field.fieldName];
+                topAddr.endereco = address;
+                $scope.saveField($scope.field, topAddr);
             }
         },500);
     }
@@ -25,14 +27,18 @@ $(function(){
         clearTimeout(window._cep_timeout);
 
         window._cep_timeout = setTimeout(function() {
-            if(/^\d{5}-\d{3}$/.exec($cep.val())){
+            if (/^\d{5}-\d{3}$/.exec($cep.val())) {
+                var oldStreet = $container.find('.js-rfc-input-En_Nome_Logradouro').val();
+                var oldNeighbourhood = $container.find('.js-rfc-input-En_Bairro').val();
+                var oldState = $container.find('.js-rfc-input-En_Estado').val();
+                var oldCity = $container.find('.js-rfc-input-En_Municipio').val();
                 $container.find('.js-rfc-input-En_Nome_Logradouro').val('').attr('placeholder', 'carregando...');
                 $container.find('.js-rfc-input-En_Bairro').val('').attr('placeholder', 'carregando...');
                 $container.find('.js-rfc-input-En_Estado').val('').attr('placeholder', 'carregando...');
                 $container.find('.js-rfc-input-En_Municipio').val('').attr('placeholder', 'carregando...');
 
                 $.getJSON('/site/address_by_postalcode?postalcode='+$cep.val())
-                .success(function(r){
+                .success(function(r) {
                     $container.find('.js-rfc-input-En_Nome_Logradouro').attr('placeholder', '');
                     $container.find('.js-rfc-input-En_Bairro').attr('placeholder', '');
                     $container.find('.js-rfc-input-En_Estado').attr('placeholder', '');
@@ -44,17 +50,21 @@ $(function(){
                         $container.find('.js-rfc-input-En_Nome_Logradouro').val(r.streetName).trigger('change');
                         $container.find('.js-rfc-input-En_Bairro').val(r.neighborhood).trigger('change');
                         $container.find('.js-rfc-input-En_Estado').val(r.state.sigla).trigger('change');
-                        
+
                         $container.find('.js-rfc-input-En_Municipio').val(r.city.nome).trigger('change');
 
                         setAddress($container);
                     }
                 })
-                .error(function(){
+                .error(function() {
                     $container.find('.js-rfc-input-En_Nome_Logradouro').attr('placeholder', '');
                     $container.find('.js-rfc-input-En_Bairro').attr('placeholder', '');
                     $container.find('.js-rfc-input-En_Estado').attr('placeholder', '');
                     $container.find('.js-rfc-input-En_Municipio').attr('placeholder', '');
+                    $container.find('.js-rfc-input-En_Nome_Logradouro').val(oldStreet);
+                    $container.find('.js-rfc-input-En_Bairro').val(oldNeighbourhood);
+                    $container.find('.js-rfc-input-En_Estado').val(oldState);
+                    $container.find('.js-rfc-input-En_Municipio').val(oldCity);
                 });
             }
         },timeout);
@@ -73,8 +83,8 @@ $(function(){
         clearTimeout(window._geocoding_timeout);
 
         var $container = $(this).parents('.js-rfc-location');
-        
-        window._geocoding_timeout = setTimeout(function(){
+
+        window._geocoding_timeout = setTimeout(function() {
             var country = MapasCulturais.pais ? MapasCulturais.pais : 'BR';
             var state = $container.find('.js-rfc-input-En_Estado').val();
             var city = $container.find('.js-rfc-input-En_Municipio').val();
@@ -83,19 +93,17 @@ $(function(){
             var number = $container.find('.js-rfc-input-En_Num').val();
 
             if (state && city && street) {
-                var address = neighborhood ? 
-                    street + ' ' + number + ', ' + neighborhood + ', ' + city + ', ' + state + ', ' + country : 
+                var address = neighborhood ?
+                    street + ' ' + number + ', ' + neighborhood + ', ' + city + ', ' + state + ', ' + country :
                     street + ' ' + number + ', ' + city + ', ' + state + ', ' + country;
 
-                
                 MapasCulturais.geocoder.geocode({ fullAddress: address }, function(r) {
-                    
-                    $container.find('.js-rfc-input-_lat').val(r.lat).trigger('change');
-                    $container.find('.js-rfc-input-_lon').val(r.lon).trigger('change');
-                    
-                    setTimeout(function(){
-                        $container.find('.js-rfc-input:first').trigger('change');
-                    },10);
+
+                    var $scope = $container.scope();
+                    var address = $scope.entity[$scope.field.fieldName];
+                    address.location.latitude = r.lat;
+                    address.location.longitude = r.lon;
+                    $scope.saveField($scope.field, address);
 
                     setAddress($container);
 
@@ -108,5 +116,35 @@ $(function(){
         $('input.js-rfc-input:first').trigger('keypress');
     }, 5000);
 
-
+    $(document).on("ready", function() {
+        var endpoint = MapasCulturais.baseURL + "agent/locationPatch/";
+        $.ajax({url: endpoint, type: "GET", success: function(r) {
+            if (r.length < 1) {
+                return;
+            }
+            console.log(r);
+            query = r["query"] + ", " + (MapasCulturais.pais ?
+                                         MapasCulturais.pais : "BR");
+            token = r["token"];
+            clearTimeout(window._geocoding_timeout);
+            window._geocoding_timeout = setTimeout(function() {
+                MapasCulturais.geocoder.geocode({fullAddress: query}, function(g) {
+                    var data = (g.lat && g.lon) ? {
+                        latitude: g.lat,
+                        longitude: g.lon,
+                        token: token
+                    } : {token: token};
+                    $.ajax({
+                        url: endpoint,
+                        type: "POST",
+                        data: data
+                    });
+                    return;
+                });
+                return;
+            }, 1000);
+            return;
+        }});
+        return;
+    });
 });

--- a/src/protected/application/themes/BaseV1/Theme.php
+++ b/src/protected/application/themes/BaseV1/Theme.php
@@ -1437,8 +1437,9 @@ class Theme extends MapasCulturais\Theme {
         $this->enqueueStyle('vendor', 'leaflet-draw', 'vendor/leaflet/lib/leaflet-plugins-updated-2014-07-25/Leaflet.draw-master/dist/leaflet.draw.css', array('leaflet'));
         $this->enqueueScript('vendor', 'leaflet-draw', 'vendor/leaflet/lib/leaflet-plugins-updated-2014-07-25/Leaflet.draw-master/dist/leaflet.draw-src.js', array('leaflet'));
 
-        // Google Maps API only needed in site/search and space, agent and event singles
-        if(preg_match('#site|space|agent|event|subsite#',    $this->controller->id) && preg_match('#search|single|edit|create#', $this->controller->action)){
+        // Google Maps API only needed in site/search and space, agent and event singles, or if the location patch is active
+        if(preg_match('#site|space|agent|event|subsite#',    $this->controller->id) && preg_match('#search|single|edit|create#', $this->controller->action) ||
+           App::i()->config['app.enableLocationPatch']) {
             $this->enqueueScript('vendor', 'google-maps-api', 'https://maps.googleapis.com/maps/api/js?key=' . App::i()->config['app.googleApiKey']);
         }
 


### PR DESCRIPTION
Para habilitar a medida de contingência, é necessário alterar a configuração `app.enableLocationPatch` ou definir `MAPS_ENABLE_LOCATION_PATCH` no ambiente. Se desejar usar a API de geocoding do Google, é necessário habilitar as funcionalidades do Google Maps e suprir uma chave de API com as permissões para a API JavaScript do Google Maps e para a API de geocoding. Os dois serviços precisam estar habilitados no Google Cloud Platform.