### PR TITLE
Alterando formato de data do agent-owner e agent-collective

### DIFF
--- a/src/protected/application/themes/BaseV1/assets/js/ng.entity.module.opportunity.js
+++ b/src/protected/application/themes/BaseV1/assets/js/ng.entity.module.opportunity.js
@@ -1093,12 +1093,15 @@ module.controller('RegistrationFieldsController', ['$scope', '$rootScope', '$int
     $scope.printField = function(field, value){
 
         if (field.fieldType === 'date') {
-            return moment(value).format('DD-MM-YYYY');
+            return moment(value).format('DD/MM/YYYY');
         } else if (field.fieldType === 'url'){
             return '<a href="' + value + '" target="_blank" rel="noopener noreferrer">' + value + '</a>';
         } else if (field.fieldType === 'email'){
             return '<a href="mailto:' + value + '"  target="_blank" rel="noopener noreferrer">' + value + '</a>';
-        } else if (value instanceof Array) {
+        }  else if (field.fieldType === 'agent-owner-field' && typeof value ==='object' || field.fieldType === 'agent-collective-field' && typeof value ==='object'){
+            // FORMATANDO A DATA DE NASCIMENTO
+            return moment(value).format('DD/MM/YYYY');
+        }else if (value instanceof Array) {
             return value.join(', ');
         } else {
             return value;


### PR DESCRIPTION
*_Contexto_*

Ao se criar o formulário a partir do _form-build_ da oportunidade, com agente responsável ou agente coletivo, percebeu-se que, após a inscrição do candidato o formato da data era mostrado em formato semelhante ao _timestamp_, como pode ser observado na captura de tela a seguir: 

![Captura de tela de 2021-03-22 11-31-08](https://user-images.githubusercontent.com/44043740/112009091-db482300-8b04-11eb-81ae-e3c00faf0380.png)

*_Feature / Resolução_*

Adicionou-se uma verificação para que ao receber o objeto data fosse retornado no padrão: DD/MM/YYYY', conforme print a seguir: 

![Captura de tela de 2021-03-22 11-29-40](https://user-images.githubusercontent.com/44043740/112009409-1b0f0a80-8b05-11eb-8f78-a585056f08ba.png)
