### PR TITLE
Retirando metodo de cache - usesCache

### DIFF
--- a/src/protected/application/lib/MapasCulturais/Entity.php
+++ b/src/protected/application/lib/MapasCulturais/Entity.php
@@ -737,12 +737,6 @@ abstract class Entity implements \JsonSerializable{
                 }
             }
 
-            // delete the entity cache
-            $repo = $this->repo();
-            if($repo->usesCache()){
-                $repo->deleteEntityCache($this->id);
-            }
-
         }catch(Exceptions\PermissionDenied $e){
             if(!$requests)
                 throw $e;


### PR DESCRIPTION
Contexto:
Retirado da classe Entity.php o método usesCache que criava cache dos repository. Esse método está depreciado devido as ultimas alterações.