### PR TITLE
Remote uses cache

### DIFF
--- a/src/protected/application/lib/MapasCulturais/Entity.php
+++ b/src/protected/application/lib/MapasCulturais/Entity.php
@@ -1080,7 +1080,6 @@ abstract class Entity implements \JsonSerializable{
      */
     public function postRemove($args = null){
         $app = App::i();
-        $repo = $app->repo($this->className);
 
         $hook_prefix = $this->getHookPrefix();
 

--- a/src/protected/application/lib/MapasCulturais/Entity.php
+++ b/src/protected/application/lib/MapasCulturais/Entity.php
@@ -1039,9 +1039,6 @@ abstract class Entity implements \JsonSerializable{
         $hook_prefix = $this->getHookPrefix();
 
         $repo = $app->repo($this->className);
-        if($repo->usesCache()){
-            $repo->deleteEntityCache($this->id);
-        }
 
         $app->applyHookBoundTo($this, "{$hook_prefix}.insert:after", $args);
         $app->applyHookBoundTo($this, "{$hook_prefix}.save:after", $args);
@@ -1085,10 +1082,6 @@ abstract class Entity implements \JsonSerializable{
         $app = App::i();
         $repo = $app->repo($this->className);
 
-        if ($repo->usesCache()) {
-            $repo->deleteEntityCache($this->id);
-        }
-        
         $hook_prefix = $this->getHookPrefix();
 
         $app->applyHookBoundTo($this, "{$hook_prefix}.remove:after", $args);


### PR DESCRIPTION
**Contexto** 
Removido o método usesCache de toda a classe Entity.php, pois esse método está depreciado devido as ultimas alterações.