### PR TITLE
Corrige objeto Module para a chamada do método getChartsColors

### DIFF
--- a/src/protected/application/lib/modules/Reports/Controller.php
+++ b/src/protected/application/lib/modules/Reports/Controller.php
@@ -667,7 +667,7 @@ class Controller extends \MapasCulturais\Controller
         } else {
             foreach ($result as $item) {
                 
-                $color = $this->getChartColors();
+                $color = $module->getChartColors();
 
                 $color[] = $color[0];
                 $labels[] = $this->generateLabel($item["value0"], $typeA, $em);
@@ -1180,7 +1180,7 @@ class Controller extends \MapasCulturais\Controller
         $generate_colors = [];
         foreach (array_keys($series) as $label) {
 
-            $color = $this->getChartColors();
+            $color = $module->getChartColors();
 
             $current = [
                 "label" => $label,


### PR DESCRIPTION
### Fix

- Resolve problema de chamada de método não existente no $this.
Exemplo do erro:
![image](https://user-images.githubusercontent.com/3487411/179820288-855b17ae-3126-4a3a-8033-4448759de3bc.png)


Ambiente de teste com o docker. 
Usando o comando `./dev-scripts/start-dev.sh`

Versão do mapa testado: v5.3.19