### PR TITLE
Desabilita suporte mobile para o flatpickr

### DIFF
--- a/src/protected/application/lib/modules/RegistrationFieldTypes/assets/js/rfc/datepicker.js
+++ b/src/protected/application/lib/modules/RegistrationFieldTypes/assets/js/rfc/datepicker.js
@@ -20,6 +20,7 @@ $(function () {
                         $this.trigger('blur')
                     }, 10);
                 },
+                disableMobile: "true",
             });
 
             setTimeout(function () { 


### PR DESCRIPTION
### Fix

Resolve problema de não carregamento da data ao selecionar a data de nascimento especificamente no momento da inscrição.

A oportunidade para teste se encontra em: https://mapasculturais.dev.org.br/oportunidade/1

- Abre o formulário de inscrição
![photo_2022-08-25_16-19-12](https://user-images.githubusercontent.com/3487411/186750288-61c37e50-95ae-4fd2-90ab-d7de20253b47.jpg)

- Seleciona a data de nascimento
![photo_2022-08-25_16-19-14](https://user-images.githubusercontent.com/3487411/186750286-e6931917-63be-41d9-8088-b7154cc08f4e.jpg)

- Ao selecionar o campo não é preenchido
![photo_2022-08-25_16-19-15](https://user-images.githubusercontent.com/3487411/186750281-262b5227-86fa-4b20-a4dd-6239e50e3651.jpg)

- Ao desabilitar o suporte, o campo de data passará a utilizar o campo padrão "date".

Ambiente de teste com o docker. 
Usando o comando `./dev-scripts/start-dev.sh`

Versão do mapa testado: v5.3.26


