### PR TITLE
Corrigir links nos arquivos de README

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,7 +92,7 @@ Lista dos principais softwares que compõe e aplicação. Maiores detalhes, ver 
 - [Ubuntu Server >= 18.04](http://www.ubuntu.com) ou [Debian Server >= 10](https://www.debian.org.)
 - [PHP = 7.2](http://php.net)
   - [php-gd](http://php.net/manual/pt_BR/book.image.php)
-  - [php-cli] (https://packages.debian.org/pt-br/jessie/php5-cli)
+  - [php-cli](https://packages.debian.org/pt-br/jessie/php5-cli)
   - [php-json](http://php.net/manual/pt_BR/book.json.php)
   - [php-curl](http://php.net/manual/pt_BR/book.curl.php)
   - [php-pgsql](http://php.net/manual/pt_BR/book.pgsql.php)
@@ -104,8 +104,8 @@ Lista dos principais softwares que compõe e aplicação. Maiores detalhes, ver 
   - [NPM](https://www.npmjs.com/)
   - [Terser](https://terser.org/)
   - [UglifyCSS](https://www.npmjs.com/package/gulp-uglifycss)
-- [Ruby] (https://www.ruby-lang.org/pt)
-  - [Sass gem] (https://rubygems.org/gems/sass/versions/3.4.22)
+- [Ruby](https://www.ruby-lang.org/pt)
+  - [Sass gem](https://rubygems.org/gems/sass/versions/3.4.22)
 
 ### [Hardware] Requisitos para instalação
 

--- a/README_español.md
+++ b/README_español.md
@@ -32,7 +32,7 @@ Lista de los principales softwares que componen la aplicación. Más detalles, v
 - [Ubuntu Server >= 14.04](http://www.ubuntu.com) ou [Debian Server >= 8](https://www.debian.org.)
 - [PHP >= 5.4](http://php.net)
   - [php5-gd](http://php.net/manual/pt_BR/book.image.php)
-  - [php5-cli] (https://packages.debian.org/pt-br/jessie/php5-cli)
+  - [php5-cli](https://packages.debian.org/pt-br/jessie/php5-cli)
   - [php5-json](http://php.net/manual/pt_BR/book.json.php)
   - [php5-curl](http://php.net/manual/pt_BR/book.curl.php)
   - [php5-pgsql](http://php.net/manual/pt_BR/book.pgsql.php)
@@ -45,8 +45,8 @@ Lista de los principales softwares que componen la aplicación. Más detalles, v
   - [NPM](https://www.npmjs.com/)
   - [UglifyJS](https://www.npmjs.com/package/uglify-js)
   - [UglifyCSS](https://www.npmjs.com/package/gulp-uglifycss)
-- [Ruby] (https://www.ruby-lang.org/pt)
-  - [Sass gem] (https://rubygems.org/gems/sass/versions/3.4.22)
+- [Ruby](https://www.ruby-lang.org/pt)
+  - [Sass gem](https://rubygems.org/gems/sass/versions/3.4.22)
 
 ### [Hardware] Requisitos de instalación
 


### PR DESCRIPTION
Notei que nos READMEs haviam espaços sobrando no markdown dos links da seção de "Softwares", está PR corrige isso.