### PR TITLE
Aplica regex replace no varchar do resultado consolidado

### DIFF
--- a/src/protected/application/lib/modules/Reports/Module.php
+++ b/src/protected/application/lib/modules/Reports/Module.php
@@ -462,7 +462,7 @@ class Module extends \MapasCulturais\Module
             FROM registration r
             WHERE opportunity_id = :opportunity_id
             AND consolidated_result <> '0' AND
-            cast(consolidated_result as DECIMAL) BETWEEN {$i} AND {$b}";
+            cast(regexp_replace(consolidated_result, '[^-0-9.]+', '', 'g') as DECIMAL) BETWEEN {$i} AND {$b}";
 
             $label = "de " . $a . " a " . $b;
 


### PR DESCRIPTION
### Atualização

O teste foi realizado com uma oportunidade com avalição técnica valendo até 1000 pontos, foi identificado que ao lançar notas acima de 999.9 o sistema armazena o dado, entretanto ao acessar a oportunidade independente do perfil o sistema lança o erro:

![472de3e4-e967-406e-9a2c-3af38adf4ff8](https://user-images.githubusercontent.com/3487411/203787944-36d43dc5-a3a7-471f-beab-d6a496538920.png)

Teste realizado na versão [v5.3.33](https://github.com/mapasculturais/mapasculturais/releases/tag/v5.3.33)
![3a4f78ec-280d-4ea1-9043-db8238019712](https://user-images.githubusercontent.com/3487411/203788069-d2637f7d-4f34-4148-ae29-c637a5793acb.png)
