### PR TITLE
fix: resolve aplicar filtros para pesquisa de eventos

### DIFF
--- a/src/modules/Search/components/search-filter-event/script.js
+++ b/src/modules/Search/components/search-filter-event/script.js
@@ -160,8 +160,8 @@ app.component('search-filter-event', {
     methods: {
         clearFilters() {
             this.date = [this.defaultDateFrom, this.defaultDateTo];
-            this.pseudoQuery['@from'] = d0.date('sql');
-            this.pseudoQuery['@to'] = d1.date('sql');
+            this.pseudoQuery['@from'] = new McDate(new Date(this.date[0])).date('sql');
+            this.pseudoQuery['@to'] = new McDate(new Date(this.date[1])).date('sql');
             delete this.pseudoQuery['event:@verified'];
             this.pseudoQuery['event:classificacaoEtaria'].length = 0;
             this.pseudoQuery['event:term:linguagem'].length = 0;        


### PR DESCRIPTION
## Descrição do Bug

Na visualização dos eventos quando clica no botão (ação) "Limpar todos os filtros" os campos de "Filtros de eventos" não são limpos.


## Screenshots bug (gif)

Segue a seguir os testes realizado do problema: 
![hotfix-fix-clear-filters-to-events](https://github.com/mapasculturais/mapasculturais/assets/3487411/cece6d77-80a3-4c6f-ac8d-f734105b04f8)

## Screenshots solução (gif)

![hotfix-fix-clear-filters-to-events-ok](https://github.com/mapasculturais/mapasculturais/assets/3487411/a53e01eb-2080-4bee-a727-a380c3ed4907)


## Checklist de Revisão

- [x] Acessar listagem de eventos
- [x] Adicionar filtros e buscar eventos baseados nos filtros especificados
- [x] Ao clicar em "Limpar todos os filtros" deve ser limpos os filtros

## Notas de Implementação

Versão baseada na branch develop atualizada em 30/04/2024 as 08:15h.

![image](https://github.com/mapasculturais/mapasculturais/assets/3487411/9b43aea4-b260-4034-8ee8-5ef4a0ae7daa)


## Issues Relacionadas

- Não se aplica

