### PR TITLE
feat: adiciona pesquisa de evento preset mês atual

### DIFF
--- a/src/modules/Search/components/search-filter-event/script.js
+++ b/src/modules/Search/components/search-filter-event/script.js
@@ -83,6 +83,10 @@ app.component('search-filter-event', {
                 label: __('próximos 30 dias', 'search-filter-event'), 
                 range: [today, Dates.addDays(today,30)]
             },
+            thisCurrentMonth: {
+                label: __('este mês', 'search-filter-event'),
+                range: [startOfMonth, endOfMonth],
+            },
             thisMonth: {
                 label: Utils.ucfirst(mctoday.month()),
                 range: [startOfMonth, endOfMonth],
@@ -141,6 +145,7 @@ app.component('search-filter-event', {
             this.ranges.tomorrow,
             this.ranges.thisWeek,
             this.ranges.thisWeekend,
+            this.ranges.thisCurrentMonth,
             this.ranges.nextWeekend,
             this.ranges.next7days,
             this.ranges.next30days,

--- a/src/modules/Search/components/search-filter-event/texts.php
+++ b/src/modules/Search/components/search-filter-event/texts.php
@@ -10,6 +10,7 @@ return [
     'próxima semana' => i::__('Próxima semana'),
     'fim de semana passado' => i::__('Fim de semana passado'),
     'este fim de semana' => i::__('Este fim de semana'),
+    'este mês' => i::__('Este mês'),
     'próximo fim de semana' => i::__('Próximo fim de semana'),
     'últimos 7 dias' => i::__('Últimos 7 dias'),
     'próximos 7 dias' => i::__('Próximos 7 dias'),


### PR DESCRIPTION
## Descrição

Adiciona no filtro de pesquisa dos eventos a busca pelo "preset" de período mês atual "Este mês".

## Screenshots solução (gif)

![Gravaodetelade06-05-2024092935-ezgif com-video-to-gif-converter](https://github.com/mapasculturais/mapasculturais/assets/3487411/7b55caa6-6c0b-46a1-a026-d4fac5ef50c1)

## Checklist de Revisão

- [x] Acessar listagem de eventos
- [x] Adicionar filtro "Este mês" e buscar eventos baseados nos filtros especificados

## Issues Relacionadas

https://github.com/LabCDBr/gestao/issues/222

