### PR TITLE
Simplifica criação de Entity no JS a partir do retorno da API

### DIFF
--- a/src/modules/Components/assets/js/components-base/Entity.js
+++ b/src/modules/Components/assets/js/components-base/Entity.js
@@ -2,7 +2,7 @@ class Entity {
     constructor(objectType, id, scope = 'default') {
         this.__objectType = objectType;
         this.id = id;
-        this.__scope = scope;
+        this.__scope = (scope || 'default');
         this.__validationErrors = {};
         
         this.__messagesEnabled = true;

--- a/src/modules/Components/assets/js/components-base/Entity.js
+++ b/src/modules/Components/assets/js/components-base/Entity.js
@@ -1,8 +1,8 @@
 class Entity {
-    constructor(objectType, id, scope) {
+    constructor(objectType, id, scope = 'default') {
         this.__objectType = objectType;
         this.id = id;
-        this.__scope = (scope || 'default');
+        this.__scope = scope;
         this.__validationErrors = {};
         
         this.__messagesEnabled = true;
@@ -12,6 +12,12 @@ class Entity {
 
         // as traduções estão no arquivo texts.php do componente <entity>
         this.text = Utils.getTexts('mc-entity');
+    }
+
+    static fromJson(object, scope = 'default') {
+        const entity = new Entity(object['@entityType'], object.id, scope);
+        entity.populate(object);
+        return entity;
     }
 
     populate(obj, preserveValues = true) {


### PR DESCRIPTION
A vasta maioria das chamadas ao método `Entity.populate` é, na minha visão, boilerplate.

Esse PR simplifica o seguinte padrão

```js
const entity = new Entity(data['@entityType'])
entity.populate(data)
```

em

```js
const entity = Entity.fromJson(data)
```

Posso substituir os casos neste PR ou num posterior.