### PR TITLE
Contar inscrições via SQL sem ocupar memória.

### DIFF
--- a/src/core/Entities/EvaluationMethodConfiguration.php
+++ b/src/core/Entities/EvaluationMethodConfiguration.php
@@ -323,8 +323,6 @@ class EvaluationMethodConfiguration extends \MapasCulturais\Entity {
             }
         }
 
-        // status das avaliações
-
         // Conta as inscrições avaliadas por consolidatedResult
         $query = $app->em->createQuery("
             SELECT 


### PR DESCRIPTION
### Contexto

A contagem original recuperava via SQL todos as inscrições do edital e contava na aplicação a quantidade registros recuperados. Essa abordagem causava estouro de memória no contexto do Ministério da Cultura dado o alto volume de inscrições a nível nacional.

### Correção

Eliminamos a matriz que armazenava as inscrições e passamos a totalizar diretamente na consulta SQL considerando apenas o código da oportunidade.