### PR TITLE
Previne sobrecarga de processamento se necessário

### DIFF
--- a/src/core/AuthProvider.php
+++ b/src/core/AuthProvider.php
@@ -30,8 +30,8 @@ abstract class AuthProvider {
         $app->hook('auth.successful', function() use($app){
             $user = $app->user;
 
-            $preventNotifications = (bool) $user->metadata['prevent_notifications'] ?? false;
-            if (!$preventNotifications) {
+            $preventOverhead = (bool) $user->metadata['preventOverhead'] ?? false;
+            if (!$preventOverhead) {
                 $user->getEntitiesNotifications($app);
             }
 

--- a/src/core/AuthProvider.php
+++ b/src/core/AuthProvider.php
@@ -29,7 +29,12 @@ abstract class AuthProvider {
 
         $app->hook('auth.successful', function() use($app){
             $user = $app->user;
-            $user->getEntitiesNotifications($app);
+
+            $preventNotifications = (bool) $user->metadata['prevent_notifications'] ?? false;
+            if (!$preventNotifications) {
+                $user->getEntitiesNotifications($app);
+            }
+
             $user->lastLoginTimestamp = new \DateTime;
             $user->save(true);
         });

--- a/src/core/AuthProvider.php
+++ b/src/core/AuthProvider.php
@@ -30,7 +30,7 @@ abstract class AuthProvider {
         $app->hook('auth.successful', function() use($app){
             $user = $app->user;
 
-            $preventOverhead = (bool) $user->metadata['preventOverhead'] ?? false;
+            $preventOverhead = (bool) ($user->metadata['preventOverhead'] ?? false);
             if (!$preventOverhead) {
                 $user->getEntitiesNotifications($app);
             }


### PR DESCRIPTION
### Contexto

O trecho alterado gera notificação para todos as entidades vinculadas ao acesso corrente durante o login. Ocorre que usuários com muitos vínculos são impactados com um processamento pesado e acabam obtendo estouro de tempo (timeout) e falha durante o login, a exemplo da Secretaria de Cidadania e Diversidade Cultural (SCDC) do Ministério da Cultura que não conseguia completar o login por agregar milhares de agentes.

### Intervenção

Consideramos a existência de uma _flag_ chamada "preventOverhead" e inibimos este processamento no caso dessa flag estar ativada.

### Retrocompatibilidade

Para garantir **retrocompatibilidade** em ambientes que não tenham essa _flag_, mantivemos o processamento nos demais casos, ou seja, o trecho continua como antes se a _flag_ não existir.