### PR TITLE
Implementa opção de login guiado

### DIFF
--- a/config/authentication.php
+++ b/config/authentication.php
@@ -8,6 +8,7 @@ return [
 
     'auth.config' => [
         'salt' => env('AUTH_SALT', 'SECURITY_SALT'),
+        'wizard' => 'true',
         'timeout' => '24 hours',
         'strategies' => [
            'Facebook' => [

--- a/dev/config.d/auth.php
+++ b/dev/config.d/auth.php
@@ -6,7 +6,7 @@ return [
     'auth.config' => [
         'salt' => env('AUTH_SALT', null),
         'wizard' => 'true',
-	'timeout' => '24 hours',
+        'timeout' => '24 hours',
         'strategies' => [
             'Facebook' => [
                 'app_id' => env('AUTH_FACEBOOK_APP_ID', null),

--- a/dev/config.d/auth.php
+++ b/dev/config.d/auth.php
@@ -5,7 +5,8 @@ return [
     // 'auth.provider' => '\MultipleLocalAuth\Provider',
     'auth.config' => [
         'salt' => env('AUTH_SALT', null),
-        'timeout' => '24 hours',
+        'wizard' => 'true',
+	'timeout' => '24 hours',
         'strategies' => [
             'Facebook' => [
                 'app_id' => env('AUTH_FACEBOOK_APP_ID', null),


### PR DESCRIPTION
### Contexto

O Ministério da Cultura possui um elevado número de usuários cadastrados e, durante uma grande atualização de versão (v5 para v7) abandonou-se o login intermediado pelo ID Cultura e adotou-se o login direto com e-mail e senha, porém havia um desafio: cada usuária(o) precisaria gerar uma nova senha no primeiro acesso ao sistema.

### Intervenção

Implementou-se um fluxo **opcional** de login guiado para facilitar a geração de novas senhas e minimizar demandas ao suporte. Esse acesso basicamente divide a tela de login em duas, sendo a primeira para informar o e-mail ou o CPF, momento em que se verifica se já existe senha criada e avança para a segunda tela para digitação da senha. Caso aquele email ou CPF ainda não tenha uma senha associada, o fluxo é desviado para criação da senha. Caso aquele e-mail ou CPF ainda não esteja cadastrado, o fluxo é desviado para criação de uma nova conta.

#### NOTA: neste PR atualiza-se apenas o exemplo de como ativar o novo fluxo de login.

### Retrocompatibilidade

Para garantir **retrocompatibilidade** do plugin com ambientes que utilizam o login tradicional, o fluxo anterior é seguido quando a _flag_ de ativação não existe.