### PR TITLE
Repasse 6779/duplicacao oportunidade

### DIFF
--- a/src/core/Controllers/Opportunity.php
+++ b/src/core/Controllers/Opportunity.php
@@ -33,6 +33,7 @@ class Opportunity extends EntityController {
         Traits\ControllerDraft,
         Traits\ControllerArchive,
         Traits\ControllerAPI,
+        Traits\EntityOpportunityDuplicator,
         Traits\ControllerAPINested,
         Traits\ControllerLock,
         Traits\ControllerEntityActions {

--- a/src/core/Traits/EntityOpportunityDuplicator.php
+++ b/src/core/Traits/EntityOpportunityDuplicator.php
@@ -1,0 +1,284 @@
+<?php
+namespace MapasCulturais\Traits;
+
+use MapasCulturais\App;
+use MapasCulturais\Entity;
+use Exception;
+
+trait EntityOpportunityDuplicator {
+
+    private $entityOpportunity;
+    private $entityNewOpportunity;
+
+    function ALL_duplicate(){
+        $app = App::i();
+
+        $this->requireAuthentication();
+        $this->entityOpportunity = $this->requestedEntity;
+        $this->entityNewOpportunity = $this->cloneOpportunity();
+
+
+        $this->duplicateEvaluationMethods();
+        $this->duplicatePhases();
+        $this->duplicateMetadata();
+        $this->duplicateRegistrationFieldsAndFiles();
+        $this->duplicateMetalist();
+        $this->duplicateFiles();
+        $this->duplicateAgentRelations();
+        $this->duplicateSealsRelations();
+
+        $this->entityNewOpportunity->save(true);
+       
+        if($this->isAjax()){
+            $this->json($this->entityOpportunity);
+        }else{
+            $app->redirect($app->request->getReferer());
+        }
+    }
+
+    private function cloneOpportunity()
+    {
+        $app = App::i();
+
+        $this->entityNewOpportunity = clone $this->entityOpportunity;
+
+        $dateTime = new \DateTime();
+        $now = $dateTime->format('d-m-Y H:i:s');
+        $name = $this->entityOpportunity->name;
+        $this->entityNewOpportunity->name = "$name  - [Cópia][$now]";
+        $this->entityNewOpportunity->status = Entity::STATUS_DRAFT;
+        $app->em->persist($this->entityNewOpportunity);
+        $app->em->flush();
+
+        $this->entityNewOpportunity->registrationCategories = $this->entityOpportunity->registrationCategories;
+        $this->entityNewOpportunity->registrationProponentTypes = $this->entityOpportunity->registrationProponentTypes;
+        $this->entityNewOpportunity->registrationRanges = $this->entityOpportunity->registrationRanges;
+        $this->entityNewOpportunity->save(true);
+
+        return $this->entityNewOpportunity;
+    }
+
+    private function duplicateEvaluationMethods() : void
+    {
+        $app = App::i();
+
+        // duplica o método de avaliação para a oportunidade primária
+        $evaluationMethodConfigurations = $app->repo('EvaluationMethodConfiguration')->findBy([
+            'opportunity' => $this->entityOpportunity
+        ]);
+        foreach ($evaluationMethodConfigurations as $evaluationMethodConfiguration) {
+            $newMethodConfiguration = clone $evaluationMethodConfiguration;
+            $newMethodConfiguration->setOpportunity($this->entityNewOpportunity);
+            $newMethodConfiguration->save(true);
+
+            // duplica os metadados das configurações do modelo de avaliação
+            foreach ($evaluationMethodConfiguration->getMetadata() as $metadataKey => $metadataValue) {
+                $newMethodConfiguration->setMetadata($metadataKey, $metadataValue);
+                $newMethodConfiguration->save(true);
+            }
+
+            foreach ($evaluationMethodConfiguration->getAgentRelations() as $agentRelation_) {
+                $agentRelation = clone $agentRelation_;
+                $agentRelation->owner = $newMethodConfiguration;
+                $agentRelation->save(true);
+            }
+        }
+    }
+
+    private function duplicatePhases() : void
+    {
+        $app = App::i();
+
+        $phases = $app->repo('Opportunity')->findBy([
+            'parent' => $this->entityOpportunity
+        ]);
+        foreach ($phases as $phase) {
+            if (!$phase->getMetadata('isLastPhase')) {
+                $newPhase = clone $phase;
+                $newPhase->setParent($this->entityNewOpportunity);
+
+                // duplica os metadados das fases
+                foreach ($phase->getMetadata() as $metadataKey => $metadataValue) {
+                    if (!is_null($metadataValue) && $metadataValue != '') {
+                        $newPhase->setMetadata($metadataKey, $metadataValue);
+                        $newPhase->save(true);
+                    }
+                }
+
+                $newPhase->save(true);
+
+                // duplica os modelos de avaliações das fases
+                $evaluationMethodConfigurations = $app->repo('EvaluationMethodConfiguration')->findBy([
+                    'opportunity' => $phase
+                ]);
+
+                foreach ($evaluationMethodConfigurations as $evaluationMethodConfiguration) {
+                    $newMethodConfiguration = clone $evaluationMethodConfiguration;
+                    $newMethodConfiguration->setOpportunity($newPhase);
+                    $newMethodConfiguration->save(true);
+
+                    // duplica os metadados das configurações do modelo de avaliação para a fase
+                    foreach ($evaluationMethodConfiguration->getMetadata() as $metadataKey => $metadataValue) {
+                        $newMethodConfiguration->setMetadata($metadataKey, $metadataValue);
+                        $newMethodConfiguration->save(true);
+                    }
+
+                    foreach ($evaluationMethodConfiguration->getAgentRelations() as $agentRelation_) {
+                        $agentRelation = clone $agentRelation_;
+                        $agentRelation->owner = $newMethodConfiguration;
+                        $agentRelation->save(true);
+                    }
+                }
+            }
+
+            if ($phase->getMetadata('isLastPhase')) {
+                $publishDate = $phase->publishTimestamp;
+            }
+        }
+
+        if (isset($publishDate)) {
+            $phases = $app->repo('Opportunity')->findBy([
+                'parent' => $this->entityNewOpportunity
+            ]);
+    
+            foreach ($phases as $phase) {
+                if ($phase->getMetadata('isLastPhase')) {
+                    $phase->setPublishTimestamp($publishDate);
+                    $phase->save(true);
+                }
+            }
+        }       
+    }
+
+    private function duplicateMetadata() : void
+    {
+        foreach ($this->entityOpportunity->getMetadata() as $metadataKey => $metadataValue) {
+            if (!is_null($metadataValue) && $metadataValue != '') {
+                $this->entityNewOpportunity->setMetadata($metadataKey, $metadataValue);
+            }
+        }
+
+        $this->entityNewOpportunity->setTerms(['area' => $this->entityOpportunity->terms['area']]);
+        $this->entityNewOpportunity->setTerms(['tag' => $this->entityOpportunity->terms['tag']]);
+        $this->entityNewOpportunity->saveTerms();
+    }
+   
+    private function duplicateRegistrationFieldsAndFiles() : void
+    {
+        foreach ($this->entityOpportunity->getRegistrationFieldConfigurations() as $registrationFieldConfiguration) {
+            $fieldConfiguration = clone $registrationFieldConfiguration;
+            $fieldConfiguration->setOwnerId($this->entityNewOpportunity->id);
+            $fieldConfiguration->save(true);
+        }
+
+        foreach ($this->entityOpportunity->getRegistrationFileConfigurations() as $registrationFileConfiguration) {
+            $fileConfiguration = clone $registrationFileConfiguration;
+            $fileConfiguration->setOwnerId($this->entityNewOpportunity->id);
+            $fileConfiguration->save(true);
+        }
+
+    }
+
+    private function duplicateMetalist() : void
+    {
+        foreach ($this->entityOpportunity->getMetaLists() as $metaList_) {
+            foreach ($metaList_ as $metaList__) {
+                $metalist = clone $metaList__;
+                $metalist->setOwner($this->entityNewOpportunity);
+            
+                $metalist->save(true);
+            }
+        }
+    }
+
+    private function duplicateFiles() : void
+    {
+        $app = App::i();        
+
+        $src = PUBLIC_PATH . 'files/opportunity/' . $this->entityOpportunity->id;
+        $dst = PUBLIC_PATH . 'files/opportunity/' . $this->entityNewOpportunity->id;
+        $this->copyDir($src, $dst);
+        
+        $conn = $app->em->getConnection();
+        $files = $conn->fetchAll("SELECT * FROM file WHERE object_id = {$this->entityOpportunity->id} ORDER BY id ASC");
+        foreach ($files as $file) {
+            if (is_null($file['parent_id'])) {
+                $parentId = null;
+            } else if (isset($futureParentId)) {
+                $parentId = $futureParentId;
+            } else {
+                throw new Exception('File parent_id unexpected');
+            }
+
+            $sql = 'INSERT INTO file (md5, mime_type, name, object_type, object_id, create_timestamp, grp, description, parent_id, path) VALUES (:md5, :mime_type, :name, :object_type, :object_id, :create_timestamp, :grp, :description, :parent_id, :path)';
+            $stmt = $conn->prepare($sql);
+            $stmt->bindValue('md5', $file['md5']);
+            $stmt->bindValue('mime_type', $file['mime_type']);
+            $stmt->bindValue('name', $file['name']);
+            $stmt->bindValue('object_type', $file['object_type']);
+            $stmt->bindValue('object_id', $this->entityNewOpportunity->id);
+            $stmt->bindValue('create_timestamp', $file['create_timestamp']);
+            $stmt->bindValue('grp', $file['grp']);
+            $stmt->bindValue('description', $file['description']);
+            $stmt->bindValue('parent_id', $parentId);
+
+            $path = str_replace('opportunity/'.$this->entityOpportunity->id, 'opportunity/'.$this->entityNewOpportunity->id, $file['path']);
+            $path = str_replace('file/'.$file['parent_id'], 'file/'.$parentId, $path);
+
+            $diretorioAtual = $dst . '/file/' . $file['parent_id'];
+            $novoDiretorio = $dst . '/file/' . $parentId;
+            
+            if (is_dir($diretorioAtual)) {
+                if (!is_dir($novoDiretorio)) {
+                    if (rename($diretorioAtual, $novoDiretorio)) {
+                    }
+                } 
+            }
+
+            $stmt->bindValue('path', $path);
+            $stmt->execute();
+
+            if (is_null($file['parent_id'])) {
+                $futureParentId = $conn->lastInsertId();
+            }
+        }
+    }
+
+    private function copyDir($src, $dst) {
+        if (!file_exists($src)) {
+            return false;
+        }
+        if (!file_exists($dst)) {
+            mkdir($dst, 0755, true);
+        }
+        $dir = opendir($src);
+        while (($file = readdir($dir)) !== false) {
+            if ($file != '.' && $file != '..') {
+                if (is_dir($src . '/' . $file)) {
+                    $this->copyDir($src . '/' . $file, $dst . '/' . $file);
+                } else {
+                    copy($src . '/' . $file, $dst . '/' . $file);
+                }
+            }
+        }
+        closedir($dir);
+    
+        return true;
+    }
+
+    private function duplicateAgentRelations() : void
+    {
+        foreach ($this->entityOpportunity->getAgentRelations() as $agentRelation_) {
+            $agentRelation = clone $agentRelation_;
+            $agentRelation->owner = $this->entityNewOpportunity;
+            $agentRelation->save(true);
+        }
+    }
+
+    private function duplicateSealsRelations() : void
+    {
+        foreach ($this->entityOpportunity->getSealRelations() as $sealRelation) {
+            $this->entityNewOpportunity->createSealRelation($sealRelation->seal, true, true);
+        }
+    }
+}

--- a/src/db-updates.php
+++ b/src/db-updates.php
@@ -2596,6 +2596,18 @@ $$
                 AND emc.type = 'qualification'
                 AND r.consolidated_result IN ('Habilitado', 'Inabilitado')
         ");
+    },
+
+    "Removendo os campos e anexos de formulário erroneamente duplicados pela funcionalidade 'Duplicar Oportunidade'" => function() {
+        __try("DELETE FROM registration_field_configuration rfc
+                     USING registration_step rs
+                     WHERE rs.id = rfc.step_id
+                       AND rs.opportunity_id != rfc.opportunity_id;");
+
+        __try("DELETE FROM registration_file_configuration rfc
+                     USING registration_step rs
+                     WHERE rs.id = rfc.step_id
+                       AND rs.opportunity_id != rfc.opportunity_id;");
     }
     
 ] + $updates ;   

--- a/src/modules/Components/assets/js/components-base/API.js
+++ b/src/modules/Components/assets/js/components-base/API.js
@@ -245,6 +245,12 @@ class API {
         }
     }
 
+    async duplicateEntity(entity) {
+        if (entity[this.$PK]) {
+            return this.POST(entity.getUrl('duplicate'));   
+        }
+    }
+
     async unpublishEntity(entity) {
         if (entity[this.$PK]) {
             return this.POST(entity.getUrl('unpublish'));

--- a/src/modules/Components/assets/js/components-base/Entity.js
+++ b/src/modules/Components/assets/js/components-base/Entity.js
@@ -520,6 +520,22 @@ class Entity {
         }
     }
 
+    async duplicate(removeFromLists) {
+        this.__processing = this.text('duplicando');
+
+        try {
+            const res = await this.API.duplicateEntity(this);
+            return this.doPromise(res, (entity) => {
+                this.sendMessage(this.text('entidade duplicada'));
+                this.populate(entity);
+
+                window.open('/minhas-oportunidades/#draft', '_blank').focus();
+            });
+        } catch (error) {
+            return this.doCatch(error);
+        }
+    }
+
     async publish(removeFromLists) {
         this.__processing = this.text('publicando');
         try {

--- a/src/modules/Components/components/mc-entity/texts.php
+++ b/src/modules/Components/components/mc-entity/texts.php
@@ -10,6 +10,7 @@ return [
     'criando' => i::__('Criando'),
     'salvando' => i::__('Salvando a entidade'),
     'publicando' => i::__('Publicando a entidade'),
+    'duplicando' => i::__('Duplicando a entidade'),
     'arquivando' => i::__('Arquivando a entidade'),
     'excluindo' => i::__('Excluindo a entidade'),
     'excluindo definitivamente' => i::__('Excluindo a entidade definitivamente'),

--- a/src/modules/Entities/components/entity-actions/template.php
+++ b/src/modules/Entities/components/entity-actions/template.php
@@ -44,6 +44,19 @@ $this->import('
                         <?php i::_e('Você está certo que deseja excluir?') ?>
                     </template>
                 </mc-confirm-button>
+                <mc-confirm-button v-if="entity.currentUserPermissions?.modify && entity.status != -2 && entity.__objectType == 'opportunity' && entity.isModel != 1" @confirm="entity.duplicate()" no="Cancelar" yes="Continuar">
+                    <template #button="modal">
+                        <button @click="modal.open()" class="button button--icon button--sm">
+                            <?php i::_e("Duplicar oportunidade") ?>
+                        </button>
+                    </template>
+                    <template #message="message">
+                        <h4><b><?php i::_e('Duplicar oportunidade'); ?></b></h4>
+                        <br>
+                        <p><?php i::_e('Todas as configurações atuais da oportunidade, incluindo o vínculo<br> com a entidade associada e os campos de formulário criados, serão<br> duplicadas.') ?></p>
+                        <p><?php i::_e('Deseja continuar?') ?></p>
+                    </template>
+                </mc-confirm-button> 
                 <?php $this->applyTemplateHook('entity-actions--primary', 'end') ?>
             </div>
             <?php $this->applyTemplateHook('entity-actions--leftGroupBtn', 'after'); ?>

--- a/src/modules/Opportunities/Module.php
+++ b/src/modules/Opportunities/Module.php
@@ -47,6 +47,10 @@ class Module extends \MapasCulturais\Module{
         });
 
         $app->hook('entity(Opportunity).insert:after', function() {
+            if ($this->registrationSteps && count($this->registrationSteps) > 0) {
+                return;
+            }
+
             $step = new RegistrationStep();
             $step->name = '';
             $step->opportunity = $this;

--- a/src/modules/Panel/components/panel--entity-actions/script.js
+++ b/src/modules/Panel/components/panel--entity-actions/script.js
@@ -45,6 +45,12 @@ app.component('panel--entity-actions', {
             const promise = entity.archive();
             this.$emit('archived', {entity, modal, promise});
         },
+
+        duplicateEntity(modal) {
+            const entity = this.entity;
+            const promise = entity.duplicate();
+            this.$emit('duplicate', {entity, modal, promise});
+        },
         
         deleteEntity(modal) {
             const entity = this.entity;


### PR DESCRIPTION
## Integração da funcionalidade de duplicação de oportunidade com correções

Este PR faz parte das entregas de evoluções implementadas no Mapa da Cultura do MinC, realizadas por meio do Termo de Execução Descentralizada - TED GSE, celebrado entre a Secretaria Executiva do Ministério da Cultura e a Universidade Federal do Paraná, contemplando as funcionalidades mínimas necessárias para atender à demanda por ferramentas digitais de mapeamento, monitoramento, prestação de contas, avaliação, cadastro e inscrição de propostas da Política Nacional de Fomento à Cultura Aldir Blanc.

### Contexto e Objetivo  
Este PR realiza o repasse e integração da funcionalidade de duplicação de oportunidade originalmente implementada no PR [#23](https://github.com/culturagovbr/mapadacultura/pull/23) do [RedeMapas](https://github.com/RedeMapas/mapas), com as devidas correções propostas no PR [#58](https://github.com/culturagovbr/mapadacultura/pull/58). O objetivo é incorporar ao repositório original a funcionalidade completa e corrigida, garantindo aderência à arquitetura atual do sistema.

### Funcionalidade implementada (PR #23)  
A funcionalidade permite a duplicação de uma oportunidade existente, replicando todos os seus dados, incluindo as fases associadas. A operação pode ser realizada via interface, acessando o botão “Duplicar oportunidade” disponível no rodapé das ações da oportunidade, conforme demonstrado no vídeo abaixo:

![Demonstração da duplicação de oportunidade](https://github.com/user-attachments/assets/4945b035-587f-4b8a-a7a4-db9d335e92c6)

### Correções aplicadas (PR #58)  
Foram identificados e corrigidos os seguintes problemas críticos na implementação original:

- **Atualização incorreta do campo `step_id`:** corrigido para que os campos duplicados referenciem corretamente as etapas do novo formulário, evitando inconsistências na visualização e no preenchimento das inscrições.  
- **Criação indevida de fase inicial adicional:** ajustada a lógica para impedir a geração redundante dessa fase, preservando a sequência correta das etapas no formulário duplicado.

### Considerações Finais  
Ressalta-se que a implementação original precedeu a introdução do gerenciamento detalhado dos campos vinculados aos steps, o que motivou as correções aplicadas neste repasse.
