### PR TITLE
Repasse 6779/gestao de modelos

### DIFF
--- a/src/conf/opportunity-types.php
+++ b/src/conf/opportunity-types.php
@@ -246,6 +246,16 @@ return array(
             'label' => \MapasCulturais\i::__('Total de vagas'),
             // 'description' => \MapasCulturais\i::__("Quantidades de vagas que esse edital irá disponibilizar."),
         ),
+
+        'isModel' => array(
+            'type' => 'integer',
+            'label' => \MapasCulturais\i::__('É modelo?'),
+            'default_value' => 0
+        ),
+        'isModelPublic' => array(
+            'type' => 'integer',
+            'label' => \MapasCulturais\i::__('É modelo público?'),
+        ),
         
         'requestAgentAvatar' => array(
             'label' => \MapasCulturais\i::__('Solicitar avatar'),

--- a/src/core/ApiQuery.php
+++ b/src/core/ApiQuery.php
@@ -1453,7 +1453,10 @@ class ApiQuery {
             $entity_id = $entity[$this->pk];
             
             if (isset($metadata[$entity_id])) {
-                
+                if (isset($permissions[$entity_id])) {
+                    $can_view = $permissions[$entity_id];
+                }
+
                 $can_view = $permissions[$entity_id] ?? false;
                 
                 $meta = $metadata[$entity_id];

--- a/src/core/Controllers/Opportunity.php
+++ b/src/core/Controllers/Opportunity.php
@@ -34,6 +34,8 @@ class Opportunity extends EntityController {
         Traits\ControllerArchive,
         Traits\ControllerAPI,
         Traits\ControllerAPINested,
+        Traits\EntityOpportunityDuplicator,
+        Traits\EntityManagerModel,
         Traits\ControllerLock,
         Traits\ControllerEntityActions {
             Traits\ControllerEntityActions::PATCH_single as _PATCH_single;

--- a/src/core/Traits/EntityManagerModel.php
+++ b/src/core/Traits/EntityManagerModel.php
@@ -1,0 +1,332 @@
+<?php
+namespace MapasCulturais\Traits;
+
+use MapasCulturais\App;
+use MapasCulturais\Entity;
+
+trait EntityManagerModel {
+
+    private $entityOpportunity;
+    private $entityOpportunityModel;
+
+    function ALL_generatemodel(){
+        $app = App::i();
+
+        $this->requireAuthentication();
+        $this->entityOpportunity = $this->requestedEntity;
+        $this->entityOpportunityModel = $this->generateModel();
+
+        $this->generateEvaluationMethods();
+        $this->generatePhases();
+        $this->generateMetadata();
+        $this->generateRegistrationFieldsAndFiles($this->entityOpportunity, $this->entityOpportunityModel);
+        $this->generateSealsRelations();
+
+        $this->entityOpportunityModel->save(true);
+        
+        if($this->isAjax()){
+            $this->json($this->entityOpportunity);
+        }else{
+            $app->redirect($app->request->getReferer());
+        }
+    }
+
+    function ALL_generateopportunity(){
+        $app = App::i();
+
+        $this->requireAuthentication();
+        $this->entityOpportunity = $this->requestedEntity;
+
+        $app->disableAccessControl();
+        $this->entityOpportunityModel = $this->generateOpportunity();
+
+        $this->generateEvaluationMethods();
+        $this->generatePhases();
+        $this->generateMetadata(0, 0);
+        $this->generateRegistrationFieldsAndFiles($this->entityOpportunity, $this->entityOpportunityModel);
+
+        $this->entityOpportunityModel->save(true);
+       
+        $app->enableAccessControl();
+
+        $this->json($this->entityOpportunityModel); 
+    }
+
+    function GET_findOpportunitiesModels()
+    {
+        $app = App::i();
+        $dataModels = [];
+        
+        $opportunities = $app->em->createQuery("
+            SELECT 
+                o.id
+            FROM
+                MapasCulturais\Entities\OpportunityMeta om
+                JOIN MapasCulturais\Entities\Opportunity o WITH om.owner=o
+            WHERE om.key = 'isModel' AND om.value = '1'
+        ");
+
+        foreach ($opportunities->getResult() as $opportunity) {
+            $opp = $app->repo('Opportunity')->find($opportunity['id']);
+            $phases = $opp->phases;
+
+            $lastPhase = array_pop($phases);
+
+            $modelIsOfficial = false;
+            foreach ($opp->getSealRelations() as $sealRelation) {
+                if ( in_array($sealRelation->seal->id, $app->config['app.verifiedSealsIds'])) {
+                    $modelIsOfficial = true;
+                }
+            }
+            
+            $days = !is_null($opp->registrationFrom) && !is_null($lastPhase->publishTimestamp) ? $lastPhase->publishTimestamp->diff($opp->registrationFrom)->days . " Dia(s)" : 'N/A';
+            $tipoAgente = $opp->registrationProponentTypes ? implode(', ', $opp->registrationProponentTypes) : 'N/A';
+            $dataModels[] = [
+                'id' => $opp->id,
+                'numeroFases' => count($opp->phases),
+                'descricao' => $opp->shortDescription,
+                'tempoEstimado' => $days,
+                'tipoAgente'   =>  $tipoAgente,
+                'modelIsOfficial' => $modelIsOfficial
+            ];
+        }
+        
+        $this->json($dataModels);
+    }
+
+    function POST_modelpublic(){
+        $app = App::i();
+
+        $this->requireAuthentication();
+        $this->entityOpportunity = $this->requestedEntity;
+
+        $isModelPublic = $this->postData['isModelPublic'];
+    
+        $this->entityOpportunity->setMetadata('isModelPublic', $isModelPublic);
+        $this->entityOpportunity->saveTerms();
+        $this->entityOpportunity->save(true);
+       
+        $this->json($isModelPublic); 
+    }
+
+    private function generateModel()
+    {
+        $app = App::i();
+
+        $postData = $this->postData;
+
+        $name = $postData['name'];
+        $description = $postData['description'];
+
+        $this->entityOpportunityModel = clone $this->entityOpportunity;
+
+        $this->entityOpportunityModel->name = $name;
+        $this->entityOpportunityModel->status = -1;
+        $this->entityOpportunityModel->shortDescription = $description;
+
+        $now = new \DateTime('now');
+        $this->entityOpportunityModel->createTimestamp = $now;
+
+        $app->em->persist($this->entityOpportunityModel);
+        $app->em->flush();
+
+        // necessário adicionar as categorias, proponetes e ranges após salvar devido a trigger public.fn_propagate_opportunity_insert
+        $this->entityOpportunityModel->registrationCategories = $this->entityOpportunity->registrationCategories;
+        $this->entityOpportunityModel->registrationProponentTypes = $this->entityOpportunity->registrationProponentTypes;
+        $this->entityOpportunityModel->registrationRanges = $this->entityOpportunity->registrationRanges;
+        $this->entityOpportunityModel->save(true);
+
+        return $this->entityOpportunityModel;
+
+        
+    }
+
+    private function generateOpportunity()
+    {
+        $app = App::i();
+        $postData = $this->postData;
+
+        $name = $postData['name'];
+        
+        $this->entityOpportunityModel = clone $this->entityOpportunity;
+        $this->entityOpportunityModel->name = $name;
+        $this->entityOpportunityModel->status = Entity::STATUS_DRAFT;
+        $this->entityOpportunityModel->owner = $app->user->profile;
+
+        $now = new \DateTime('now');
+        $this->entityOpportunityModel->createTimestamp = $now;
+
+        $app->em->persist($this->entityOpportunityModel);
+        $app->em->flush();
+
+        // necessário adicionar as categorias, proponetes e ranges após salvar devido a trigger public.fn_propagate_opportunity_insert
+        $this->entityOpportunityModel->registrationCategories = $this->entityOpportunity->registrationCategories;
+        $this->entityOpportunityModel->registrationProponentTypes = $this->entityOpportunity->registrationProponentTypes;
+        $this->entityOpportunityModel->registrationRanges = $this->entityOpportunity->registrationRanges;
+        
+        $this->changeObjectType($this->entityOpportunityModel->id);
+        
+        $this->entityOpportunityModel->save(true);
+
+        return $this->entityOpportunityModel;
+    }
+
+    private function changeObjectType($id)
+    {
+        $app = App::i();
+        $postData = $this->postData;
+
+        if (isset($postData['objectType']) && isset($postData['ownerEntity'])) {
+            $ownerEntity = $app->repo($postData['objectType'])->find($postData['ownerEntity']);
+            $app->em->beginTransaction();            
+            $app->em->getConnection()->update('opportunity', [
+                    'object_type' => $ownerEntity->getClassName(), 
+                    'object_id' => $ownerEntity->id
+                ], ['id' => $id]);
+
+            $app->em->commit();
+        }
+    }
+
+    private function generateEvaluationMethods() : void
+    {
+        $app = App::i();
+
+        // duplica o método de avaliação para a oportunidade primária
+        $evaluationMethodConfigurations = $app->repo('EvaluationMethodConfiguration')->findBy([
+            'opportunity' => $this->entityOpportunity
+        ]);
+        foreach ($evaluationMethodConfigurations as $evaluationMethodConfiguration) {
+            $newMethodConfiguration = clone $evaluationMethodConfiguration;
+            $newMethodConfiguration->setOpportunity($this->entityOpportunityModel);
+            $newMethodConfiguration->save(true);
+
+            // duplica os metadados das configurações do modelo de avaliação
+            foreach ($evaluationMethodConfiguration->getMetadata() as $metadataKey => $metadataValue) {
+                $newMethodConfiguration->setMetadata($metadataKey, $metadataValue);
+                $newMethodConfiguration->save(true);
+            }
+        }
+    }
+
+    private function generatePhases() : void
+    {
+        $app = App::i();
+        $postData = $this->postData;
+
+        $phases = $app->repo('Opportunity')->findBy([
+            'parent' => $this->entityOpportunity
+        ]);
+        foreach ($phases as $phase) {
+            
+            if (!$phase->getMetadata('isLastPhase')) {
+                $newPhase = clone $phase;
+                $newPhase->setParent($this->entityOpportunityModel);
+                $newPhase->owner = $app->user->profile;
+
+                foreach ($phase->getMetadata() as $metadataKey => $metadataValue) {
+                    if (!is_null($metadataValue) && $metadataValue != '') {
+                        $newPhase->setMetadata($metadataKey, $metadataValue);
+                        $newPhase->save(true);
+                    }
+                }
+
+                $this->generateRegistrationFieldsAndFiles($phase, $newPhase);
+
+                $now = new \DateTime('now');
+                $newPhase->createTimestamp = $now;
+                $newPhase->subsite = $phase->subsite;
+
+                $newPhase->save(true);
+
+                $this->changeObjectType($newPhase->id);
+
+                $evaluationMethodConfigurations = $app->repo('EvaluationMethodConfiguration')->findBy([
+                    'opportunity' => $phase
+                ]);
+
+                foreach ($evaluationMethodConfigurations as $evaluationMethodConfiguration) {
+                    $newMethodConfiguration = clone $evaluationMethodConfiguration;
+                    $newMethodConfiguration->setOpportunity($newPhase);
+                    $newMethodConfiguration->save(true);
+
+                    // duplica os metadados das configurações do modelo de avaliação para a fase
+                    foreach ($evaluationMethodConfiguration->getMetadata() as $metadataKey => $metadataValue) {
+                        $newMethodConfiguration->setMetadata($metadataKey, $metadataValue);
+                        $newMethodConfiguration->save(true);
+                    }
+                }
+            }
+            
+
+            if ($phase->getMetadata('isLastPhase')) {
+                $publishDate = $phase->publishTimestamp;
+                $subsite = $phase->subsite;
+            }
+        }
+
+        if (isset($publishDate)) {
+            $phases = $app->repo('Opportunity')->findBy([
+                'parent' => $this->entityOpportunityModel
+            ]);
+    
+            foreach ($phases as $phase) {
+                if ($phase->getMetadata('isLastPhase')) {
+                    $phase->setPublishTimestamp($publishDate);
+                    $phase->subsite = $subsite;
+                    $phase->save(true);
+
+                    $this->changeObjectType($phase->id);
+                }
+            }
+        }   
+    }
+
+
+    private function generateMetadata($isModel = 1, $isModelPublic = 0) : void
+    {
+        $app = App::i();
+        $em = $app->em;
+        $conn = $em->getConnection();
+
+        $sql = "
+            SELECT 
+                om.*
+            FROM
+                opportunity_meta om
+            WHERE om.object_id = {$this->entityOpportunity->id}
+        ";
+        $stmt = $conn->query($sql);
+
+        while (($row = $stmt->fetchAssociative()) !== false) {
+            $this->entityOpportunityModel->setMetadata($row['key'], $row['value']);
+        }
+
+        $this->entityOpportunityModel->setMetadata('isModel', $isModel);
+        $this->entityOpportunityModel->setMetadata('isModelPublic', $isModelPublic);
+
+        $this->entityOpportunityModel->saveTerms();
+    }
+
+    private function generateRegistrationFieldsAndFiles($opportunityCurrent, $opportunityNew) : void
+    {
+        foreach ($opportunityCurrent->getRegistrationFieldConfigurations() as $registrationFieldConfiguration) {
+            $fieldConfiguration = clone $registrationFieldConfiguration;
+            $fieldConfiguration->setOwnerId($opportunityNew->id);
+            $fieldConfiguration->save(true);
+        }
+
+        foreach ($opportunityCurrent->getRegistrationFileConfigurations() as $registrationFileConfiguration) {
+            $fileConfiguration = clone $registrationFileConfiguration;
+            $fileConfiguration->setOwnerId($opportunityNew->id);
+            $fileConfiguration->save(true);
+        }
+    }
+
+    private function generateSealsRelations() : void
+    {
+        foreach ($this->entityOpportunity->getSealRelations() as $sealRelation) {
+            $this->entityOpportunityModel->createSealRelation($sealRelation->seal, true, true);
+        }
+    }
+}

--- a/src/core/Traits/EntityOpportunityDuplicator.php
+++ b/src/core/Traits/EntityOpportunityDuplicator.php
@@ -1,0 +1,223 @@
+<?php
+namespace MapasCulturais\Traits;
+
+use MapasCulturais\App;
+use MapasCulturais\Entity;
+
+trait EntityOpportunityDuplicator {
+
+    private $entityOpportunity;
+    private $entityNewOpportunity;
+
+    function ALL_duplicate(){
+        $app = App::i();
+
+        $this->requireAuthentication();
+        $this->entityOpportunity = $this->requestedEntity;
+        $this->entityNewOpportunity = $this->cloneOpportunity();
+
+
+        $this->duplicateEvaluationMethods();
+        $this->duplicatePhases();
+        $this->duplicateMetadata();
+        $this->duplicateRegistrationFieldsAndFiles();
+        $this->duplicateMetalist();
+        $this->duplicateFiles();
+        $this->duplicateAgentRelations();
+        $this->duplicateSealsRelations();
+
+        $this->entityNewOpportunity->save(true);
+       
+        if($this->isAjax()){
+            $this->json($this->entityOpportunity);
+        }else{
+            $app->redirect($app->request->getReferer());
+        }
+    }
+
+    private function cloneOpportunity()
+    {
+        $app = App::i();
+
+        $this->entityNewOpportunity = clone $this->entityOpportunity;
+
+        $dateTime = new \DateTime();
+        $now = $dateTime->format('d-m-Y H:i:s');
+        $name = $this->entityOpportunity->name;
+        $this->entityNewOpportunity->name = "$name  - [Cópia][$now]";
+        $this->entityNewOpportunity->status = Entity::STATUS_DRAFT;
+        $app->em->persist($this->entityNewOpportunity);
+        $app->em->flush();
+
+        $this->entityNewOpportunity->registrationCategories = $this->entityOpportunity->registrationCategories;
+        $this->entityNewOpportunity->registrationProponentTypes = $this->entityOpportunity->registrationProponentTypes;
+        $this->entityNewOpportunity->registrationRanges = $this->entityOpportunity->registrationRanges;
+        $this->entityNewOpportunity->save(true);
+
+        return $this->entityNewOpportunity;
+    }
+
+    private function duplicateEvaluationMethods() : void
+    {
+        $app = App::i();
+
+        // duplica o método de avaliação para a oportunidade primária
+        $evaluationMethodConfigurations = $app->repo('EvaluationMethodConfiguration')->findBy([
+            'opportunity' => $this->entityOpportunity
+        ]);
+        foreach ($evaluationMethodConfigurations as $evaluationMethodConfiguration) {
+            $newMethodConfiguration = clone $evaluationMethodConfiguration;
+            $newMethodConfiguration->setOpportunity($this->entityNewOpportunity);
+            $newMethodConfiguration->save(true);
+
+            // duplica os metadados das configurações do modelo de avaliação
+            foreach ($evaluationMethodConfiguration->getMetadata() as $metadataKey => $metadataValue) {
+                $newMethodConfiguration->setMetadata($metadataKey, $metadataValue);
+                $newMethodConfiguration->save(true);
+            }
+
+            foreach ($evaluationMethodConfiguration->getAgentRelations() as $agentRelation_) {
+                $agentRelation = clone $agentRelation_;
+                $agentRelation->owner = $newMethodConfiguration;
+                $agentRelation->save(true);
+            }
+        }
+    }
+
+    private function duplicatePhases() : void
+    {
+        $app = App::i();
+
+        $phases = $app->repo('Opportunity')->findBy([
+            'parent' => $this->entityOpportunity
+        ]);
+        foreach ($phases as $phase) {
+            if (!$phase->getMetadata('isLastPhase')) {
+                $newPhase = clone $phase;
+                $newPhase->setParent($this->entityNewOpportunity);
+
+                // duplica os metadados das fases
+                foreach ($phase->getMetadata() as $metadataKey => $metadataValue) {
+                    if (!is_null($metadataValue) && $metadataValue != '') {
+                        $newPhase->setMetadata($metadataKey, $metadataValue);
+                        $newPhase->save(true);
+                    }
+                }
+
+                $newPhase->save(true);
+
+                // duplica os modelos de avaliações das fases
+                $evaluationMethodConfigurations = $app->repo('EvaluationMethodConfiguration')->findBy([
+                    'opportunity' => $phase
+                ]);
+
+                foreach ($evaluationMethodConfigurations as $evaluationMethodConfiguration) {
+                    $newMethodConfiguration = clone $evaluationMethodConfiguration;
+                    $newMethodConfiguration->setOpportunity($newPhase);
+                    $newMethodConfiguration->save(true);
+
+                    // duplica os metadados das configurações do modelo de avaliação para a fase
+                    foreach ($evaluationMethodConfiguration->getMetadata() as $metadataKey => $metadataValue) {
+                        $newMethodConfiguration->setMetadata($metadataKey, $metadataValue);
+                        $newMethodConfiguration->save(true);
+                    }
+
+                    foreach ($evaluationMethodConfiguration->getAgentRelations() as $agentRelation_) {
+                        $agentRelation = clone $agentRelation_;
+                        $agentRelation->owner = $newMethodConfiguration;
+                        $agentRelation->save(true);
+                    }
+                }
+            }
+
+            if ($phase->getMetadata('isLastPhase')) {
+                $publishDate = $phase->publishTimestamp;
+            }
+        }
+
+        if (isset($publishDate)) {
+            $phases = $app->repo('Opportunity')->findBy([
+                'parent' => $this->entityNewOpportunity
+            ]);
+    
+            foreach ($phases as $phase) {
+                if ($phase->getMetadata('isLastPhase')) {
+                    $phase->setPublishTimestamp($publishDate);
+                    $phase->save(true);
+                }
+            }
+        }       
+    }
+
+    private function duplicateMetadata() : void
+    {
+        foreach ($this->entityOpportunity->getMetadata() as $metadataKey => $metadataValue) {
+            if (!is_null($metadataValue) && $metadataValue != '') {
+                $this->entityNewOpportunity->setMetadata($metadataKey, $metadataValue);
+            }
+        }
+
+        $this->entityNewOpportunity->setTerms(['area' => $this->entityOpportunity->terms['area']]);
+        $this->entityNewOpportunity->setTerms(['tag' => $this->entityOpportunity->terms['tag']]);
+        $this->entityNewOpportunity->saveTerms();
+    }
+   
+    private function duplicateRegistrationFieldsAndFiles() : void
+    {
+        foreach ($this->entityOpportunity->getRegistrationFieldConfigurations() as $registrationFieldConfiguration) {
+            $fieldConfiguration = clone $registrationFieldConfiguration;
+            $fieldConfiguration->setOwnerId($this->entityNewOpportunity->id);
+            $fieldConfiguration->save(true);
+        }
+
+        foreach ($this->entityOpportunity->getRegistrationFileConfigurations() as $registrationFileConfiguration) {
+            $fileConfiguration = clone $registrationFileConfiguration;
+            $fileConfiguration->setOwnerId($this->entityNewOpportunity->id);
+            $fileConfiguration->save(true);
+        }
+
+    }
+
+    private function duplicateMetalist() : void
+    {
+        foreach ($this->entityOpportunity->getMetaLists() as $metaList_) {
+            foreach ($metaList_ as $metaList__) {
+                $metalist = clone $metaList__;
+                $metalist->setOwner($this->entityNewOpportunity);
+            
+                $metalist->save(true);
+            }
+        }
+    }
+
+    private function duplicateFiles() : void
+    {
+        $app = App::i();
+
+        $opportunityFiles = $app->repo('OpportunityFile')->findBy([
+            'owner' => $this->entityOpportunity
+        ]);
+
+        foreach ($opportunityFiles as $opportunityFile) {
+            $newMethodOpportunityFile = clone $opportunityFile;
+            $newMethodOpportunityFile->owner = $this->entityNewOpportunity;
+            $newMethodOpportunityFile->save(true);
+        }
+    }
+
+    private function duplicateAgentRelations() : void
+    {
+        foreach ($this->entityOpportunity->getAgentRelations() as $agentRelation_) {
+            $agentRelation = clone $agentRelation_;
+            $agentRelation->owner = $this->entityNewOpportunity;
+            $agentRelation->save(true);
+        }
+    }
+
+    private function duplicateSealsRelations() : void
+    {
+        foreach ($this->entityOpportunity->getSealRelations() as $sealRelation) {
+            $this->entityNewOpportunity->createSealRelation($sealRelation->seal, true, true);
+        }
+    }
+}

--- a/src/core/Traits/EntityOpportunityDuplicator.php
+++ b/src/core/Traits/EntityOpportunityDuplicator.php
@@ -162,20 +162,49 @@ trait EntityOpportunityDuplicator {
         $this->entityNewOpportunity->saveTerms();
     }
    
-    private function duplicateRegistrationFieldsAndFiles() : void
+    private function duplicateRegistrationFieldsAndFiles(): void
     {
+        // Criando um mapa de steps originais para os novos steps
+        $stepMap = [];
+
+        // Mapeando os steps existentes na nova Oportunidade
+        $existingSteps = array_column($this->entityNewOpportunity->registrationSteps->toArray(), null, 'id');
+
+        foreach ($this->entityOpportunity->registrationSteps as $oldStep) {
+            // Reutilizando step existente ou criar um novo
+            $stepMap[$oldStep->id] = $existingSteps[$oldStep->id] ?? (function () use ($oldStep) {
+                $newStep = clone $oldStep;
+                $newStep->setOpportunity($this->entityNewOpportunity);
+                $newStep->save(true);
+                return $newStep;
+            })();
+        }
+
+        // Clonando os RegistrationFieldConfigurations e associar aos novos steps
         foreach ($this->entityOpportunity->getRegistrationFieldConfigurations() as $registrationFieldConfiguration) {
             $fieldConfiguration = clone $registrationFieldConfiguration;
             $fieldConfiguration->setOwnerId($this->entityNewOpportunity->id);
+
+            // Atualizando o Step garantindo a correspondência correta
+            if (isset($stepMap[$registrationFieldConfiguration->step->id])) {
+                $fieldConfiguration->setStep($stepMap[$registrationFieldConfiguration->step->id]);
+            }
+
             $fieldConfiguration->save(true);
         }
 
+        // Clonando os RegistrationFileConfigurations e associar aos novos steps
         foreach ($this->entityOpportunity->getRegistrationFileConfigurations() as $registrationFileConfiguration) {
             $fileConfiguration = clone $registrationFileConfiguration;
             $fileConfiguration->setOwnerId($this->entityNewOpportunity->id);
+
+            // Atualizando o Step garantindo a correspondência correta
+            if (isset($stepMap[$registrationFileConfiguration->step->id])) {
+                $fileConfiguration->setStep($stepMap[$registrationFileConfiguration->step->id]);
+            }
+
             $fileConfiguration->save(true);
         }
-
     }
 
     private function duplicateMetalist() : void

--- a/src/db-updates.php
+++ b/src/db-updates.php
@@ -2596,6 +2596,18 @@ $$
                 AND emc.type = 'qualification'
                 AND r.consolidated_result IN ('Habilitado', 'Inabilitado')
         ");
+    },
+
+    "Removendo os campos e anexos de formulário erroneamente duplicados pela funcionalidade 'Duplicar Oportunidade'" => function() {
+        __try("DELETE FROM registration_field_configuration rfc
+                     USING registration_step rs
+                     WHERE rs.id = rfc.step_id
+                       AND rs.opportunity_id != rfc.opportunity_id;");
+
+        __try("DELETE FROM registration_file_configuration rfc
+                     USING registration_step rs
+                     WHERE rs.id = rfc.step_id
+                       AND rs.opportunity_id != rfc.opportunity_id;");
     }
     
 ] + $updates ;   

--- a/src/modules/Components/assets/js/components-base/API.js
+++ b/src/modules/Components/assets/js/components-base/API.js
@@ -245,6 +245,12 @@ class API {
         }
     }
 
+    async duplicateEntity(entity) {
+        if (entity[this.$PK]) {
+            return this.POST(entity.getUrl('duplicate'));   
+        }
+    }
+
     async unpublishEntity(entity) {
         if (entity[this.$PK]) {
             return this.POST(entity.getUrl('unpublish'));

--- a/src/modules/Components/assets/js/components-base/Entity.js
+++ b/src/modules/Components/assets/js/components-base/Entity.js
@@ -540,6 +540,22 @@ class Entity {
         }
     }
 
+    async duplicate(removeFromLists) {
+        this.__processing = this.text('duplicando');
+
+        try {
+            const res = await this.API.duplicateEntity(this);
+            return this.doPromise(res, (entity) => {
+                this.sendMessage(this.text('entidade duplicada'));
+                this.populate(entity);
+
+                window.open('/minhas-oportunidades/#draft', '_blank').focus();
+            });
+        } catch (error) {
+            return this.doCatch(error);
+        }
+    }
+
     async archive(removeFromLists) {
         this.__processing = this.text('arquivando');
 

--- a/src/modules/Components/components/mc-entity/texts.php
+++ b/src/modules/Components/components/mc-entity/texts.php
@@ -10,6 +10,7 @@ return [
     'criando' => i::__('Criando'),
     'salvando' => i::__('Salvando a entidade'),
     'publicando' => i::__('Publicando a entidade'),
+    'duplicando' => i::__('Duplicando a entidade'),
     'arquivando' => i::__('Arquivando a entidade'),
     'excluindo' => i::__('Excluindo a entidade'),
     'excluindo definitivamente' => i::__('Excluindo a entidade definitivamente'),

--- a/src/modules/Entities/components/entity-actions/template.php
+++ b/src/modules/Entities/components/entity-actions/template.php
@@ -9,6 +9,8 @@ use MapasCulturais\i;
 $this->import('
     mc-confirm-button
     mc-loading
+    opportunity-create-model
+    opportunity-create-based-model
 ');
 ?>
 <div v-if="!empty" class="entity-actions">
@@ -44,6 +46,22 @@ $this->import('
                         <?php i::_e('Você está certo que deseja excluir?') ?>
                     </template>
                 </mc-confirm-button>
+                <mc-confirm-button v-if="entity.currentUserPermissions?.modify && entity.status != -2 && entity.__objectType == 'opportunity' && entity.isModel != 1" @confirm="entity.duplicate()" no="Cancelar" yes="Continuar">
+                    <template #button="modal">
+                        <button @click="modal.open()" class="button button--icon button--sm">
+                            <?php i::_e("Duplicar oportunidade") ?>
+                        </button>
+                    </template>
+                    <template #message="message">
+                        <h4><b><?php i::_e('Duplicar modelo'); ?></b></h4>
+                        <br>
+                        <p><?php i::_e('Todas as configurações atuais da oportunidade, incluindo o vínculo<br> com a entidade associada e os campos de formulário criados, serão<br> duplicadas.') ?></p>
+                        <p><?php i::_e('Deseja continuar?') ?></p>
+                    </template>
+                </mc-confirm-button>
+                <div v-if="entity.currentUserPermissions?.modify && entity.status != -2 && entity.__objectType == 'opportunity' && entity.isModel != 1">
+                    <opportunity-create-model :entity="entity" classes="col-12"></opportunity-create-model>
+                </div> 
                 <?php $this->applyTemplateHook('entity-actions--primary', 'end') ?>
             </div>
             <?php $this->applyTemplateHook('entity-actions--leftGroupBtn', 'after'); ?>

--- a/src/modules/Entities/components/opportunity-create-based-model/README.md
+++ b/src/modules/Entities/components/opportunity-create-based-model/README.md
@@ -1,0 +1,11 @@
+# Componente `<opportunity-create-based-model>`
+
+### Importando componente
+```PHP
+<?php 
+$this->import('opportunity-create-based-model');
+?>
+```
+### Exemplos de uso
+```HTML
+<opportunity-create-based-model :entity="entity"></opportunity-create-based-model>

--- a/src/modules/Entities/components/opportunity-create-based-model/script.js
+++ b/src/modules/Entities/components/opportunity-create-based-model/script.js
@@ -1,0 +1,156 @@
+app.component('opportunity-create-based-model', {
+    template: $TEMPLATES['opportunity-create-based-model'],
+    setup() {
+        const messages = useMessages();
+        const text = Utils.getTexts('opportunity-create-based-model')
+        return { text, messages }
+    },
+    props: {
+        entitydefault: {
+            type: Entity,
+            required: true,
+        },
+    },
+
+    data() {
+        let sendSuccess = false;
+        let formData = {
+            name: ''
+        }
+
+        return {
+            fields: [],
+            entity: null,
+            entityTypeSelected: null,
+            sendSuccess,
+            formData
+        }
+    },
+    computed: {
+        areaClasses() {
+            return this.areaErrors ? 'field error' : 'field';
+        },
+        
+        modalTitle() {
+            if (!this.entity?.id) {
+                return __('criarOportunidade', 'opportunity-create-based-model');
+            }
+            if(this.entity.status==0){
+                return __('oportunidadeCriada', 'opportunity-create-based-model');
+
+            }
+        },
+
+        entityType(){
+            switch(this.entity.ownerEntity.__objectType) {
+                case 'project':
+                    return __('projeto', 'opportunity-create-based-model');
+                case 'event':
+                    return __('evento', 'opportunity-create-based-model');
+                case 'space':
+                    return __('espaço', 'opportunity-create-based-model');
+                case 'agent':
+                    return __('agente', 'opportunity-create-based-model');
+            }
+        },
+
+        entityColorClass() {
+            switch(this.entity.ownerEntity.__objectType) {
+                case 'project':
+                    return 'project__color';
+                case 'event':
+                    return 'event__color';
+                case 'space':
+                    return 'space__color';
+                case 'agent':
+                    return 'agent__color--dark';
+            }
+        },
+
+        entityColorBorder() {
+            switch(this.entity.ownerEntity.__objectType) {
+                case 'project':
+                    return 'project__border';
+                case 'event':
+                    return 'event__border';
+                case 'space':
+                    return 'space__border';
+                case 'agent':
+                    return 'agent__border--dark';
+            }
+        },
+    },
+    methods: {
+        async save() {
+            const api = new API(this.entitydefault.__objectType);
+
+            let objt = this.formData;
+            objt.entityId = this.entitydefault.id;
+            objt.objectType = this.entity?.ownerEntity?.__objectType;
+            objt.ownerEntity = this.entity?.ownerEntity?._id;
+            
+            let error = null;
+
+            if (error = this.validade(objt)) {
+                let mess = "";
+                mess = this.text('Todos os campos são obrigatórios.');
+                this.messages.error(mess);
+                return;
+            }
+
+            await api.POST(`/opportunity/generateopportunity/${objt.entityId}`, objt).then(response => response.json().then(dataReturn => {
+                this.messages.success(this.text('Aguarde. Estamos gerando a oportunidade baseada no modelo.'), 6000);
+
+                this.sendSuccess = true;
+
+                setTimeout(() => {
+                    window.location.href = `/gestao-de-oportunidade/${dataReturn.id}/#info`;
+                }, "5000");                
+            }));
+        },
+        validade(objt) {
+            let result = null;
+            let ignore = [];
+
+            Object.keys(objt).forEach(function (item) {
+                if (!objt[item] && !ignore.includes(item)) {
+                    result = item;
+                    return;
+                }
+            });
+            return result;
+        },
+        handleSubmit(event) {
+            event.preventDefault();
+        },    
+
+        createEntity() {
+            this.entity = new Entity('opportunity');
+        },
+
+        setEntity(Entity) {
+            this.entity.ownerEntity = Entity;
+        },
+
+        resetEntity() {
+            this.entity.ownerEntity = null;
+            this.entityTypeSelected = null;
+        },
+
+        destroyEntity() {
+            // para o conteúdo da modal não sumir antes dela fechar
+            setTimeout(() => {
+                this.entity = null;
+                this.entityTypeSelected = null;
+            }, 200);
+        },
+
+        hasObjectTypeErrors() {
+            return !this.entity.ownerEntity && this.entity.__validationErrors?.objectType;
+        },
+
+        getObjectTypeErrors() {
+            return this.hasObjectTypeErrors() ? this.entity.__validationErrors?.objectType : [];
+        },
+    },
+});

--- a/src/modules/Entities/components/opportunity-create-based-model/template.php
+++ b/src/modules/Entities/components/opportunity-create-based-model/template.php
@@ -1,0 +1,122 @@
+<?php
+/**
+ * @var MapasCulturais\App $app
+ * @var MapasCulturais\Themes\BaseV2\Theme $this
+ */
+
+use MapasCulturais\i;
+
+$this->import(" 
+    mc-modal
+    entity-field
+    select-entity
+");
+?>
+<div>
+    <mc-modal classes="create-modal create-opportunity-modal" title="<?= i::__('Título do edital') ?>" @open="createEntity()">
+        <template #default>
+            <div class="create-modal__fields">
+                <div class="field">
+                    <label><?= i::__('Defina um título para o Edital que deseja criar') ?><span class="required">*</span></label>
+                    <input type="text" v-model="formData.name">
+                </div><br>
+
+                <div v-if="!entity.ownerEntity" class="select-list">
+                    <label class="select-list__label"><?php i::_e('Vincule o edital a uma entidade: ') ?><br></label>
+                    <div class="select-list__item">
+                        <select-entity type="project" @select="setEntity($event)" openside="down-right">
+                            <template #button="{ toggle }">
+                                <label class="inner" :class="{'inner--error': hasObjectTypeErrors()}">
+                                    <span class="itemLabel">
+                                        <input v-model="entityTypeSelected" @click="toggle()" type="radio" name="inputName" value="project" />
+                                        <span><?php i::_e('Projeto') ?> </span>
+                                    </span>
+
+                                    <a :class="{'disabled': entityTypeSelected!='project'}" class="selectButton"><?php i::_e('Selecionar') ?> </a>
+                                </label>
+                            </template>
+                        </select-entity>
+                    </div>
+                    <div class="select-list__item">
+                        <select-entity type="event" @select="setEntity($event)" openside="down-right">
+                            <template #button="{ toggle }">
+                                <label class="inner" :class="{'inner--error': hasObjectTypeErrors()}">
+                                    <span class="itemLabel">
+                                        <input v-model="entityTypeSelected" @click="toggle()" type="radio" name="inputName" value="event" />
+                                        <span><?php i::_e('Evento') ?> </span>
+                                    </span>
+
+                                    <a :class="{'disabled': entityTypeSelected!='event'}" class="selectButton"><?php i::_e('Selecionar') ?> </a>
+                                </label>
+                            </template>
+                        </select-entity>
+                    </div>
+                    <div class="select-list__item">
+                        <select-entity type="space" @select="setEntity($event)" openside="down-right">
+                            <template #button="{ toggle }">
+                                <label class="inner" :class="{'inner--error': hasObjectTypeErrors()}">
+                                    <span class="itemLabel">
+                                        <input v-model="entityTypeSelected" @click="toggle()" type="radio" name="inputName" value="space" />
+                                        <span><?php i::_e('Espaço') ?> </span>
+                                    </span>
+
+                                    <a :class="{'disabled': entityTypeSelected!='space'}" class="selectButton"><?php i::_e('Selecionar') ?> </a>
+                                </label>
+                            </template>
+                        </select-entity>
+                    </div>
+                    <div class="select-list__item">
+                        <select-entity type="agent" @select="setEntity($event)" openside="down-right">
+                            <template #button="{ toggle }">
+                                <label class="inner" :class="{'inner--error': hasObjectTypeErrors()}">
+                                    <span class="itemLabel">
+                                        <input v-model="entityTypeSelected" @click="toggle()" type="radio" name="inputName" value="agent" />
+                                        <span><?php i::_e('Agente') ?> </span>
+                                    </span>
+
+                                    <a :class="{'disabled': entityTypeSelected!='agent'}" class="selectButton"><?php i::_e('Selecionar') ?> </a>
+                                </label>
+                            </template>
+                        </select-entity>
+                    </div>
+                </div>
+
+                <small v-if="hasObjectTypeErrors()" class="field__error">{{getObjectTypeErrors().join('; ')}}</small>
+
+                <div v-if="entity.ownerEntity" class="create-modal__fields--selected">
+                    <label class="create-modal__fields--selected-label"><?php i::_e('Vincule o edital a uma entidade: ') ?><span class="required">*</span><br></label>
+                    <div class="entity-selected">
+                        <div class="entity-selected__entity" :class="entityColorBorder">
+                            <mc-avatar :entity="entity.ownerEntity" size="xsmall"></mc-avatar>
+                            <span class="name" :class="entityColorClass"><?php i::_e('{{entity.ownerEntity.name}}') ?></span>
+                        </div>
+                        <div class="entity-selected__info">
+                            <select-entity :type="entityTypeSelected" @select="setEntity($event)" openside="right-down">
+                                <template #button="{ toggle }">
+                                    <a class="entity-selected__info--btn" :class="entityColorClass" @click="toggle()">
+                                        <mc-icon :class="entityColorClass" name="exchange"></mc-icon>
+                                        <h4 :class="entityColorClass"><?php i::_e('Alterar') ?> {{entityType}}</h4>
+                                    </a>
+                                </template>
+                            </select-entity>
+
+                            <a class="entity-selected__info--btn helper__color" @click="resetEntity()">
+                                <mc-icon class="helper__color" name="exchange"></mc-icon>
+                                <h4 class="helper__color"><?php i::_e('Alterar entidade') ?></h4>
+                            </a>
+                        </div>
+                    </div>
+                </div>
+            </div>
+        </template>
+
+        <template v-if="!sendSuccess"  #actions="modal">
+            <button class="button button--text button--text-del" @click="modal.close()"><?= i::__('cancelar') ?></button>
+            <button class="button button--primary" @click="save(modal)"><?= i::__('Começar') ?></button>
+        </template>
+
+        <template #button="modal">
+            <button type="button" @click="modal.open();" class="button button--primary button--icon"><?= i::__('Usar modelo') ?></button>
+        </template>
+    </mc-modal>
+</div>

--- a/src/modules/Entities/components/opportunity-create-based-model/texts.php
+++ b/src/modules/Entities/components/opportunity-create-based-model/texts.php
@@ -1,0 +1,13 @@
+<?php
+
+use MapasCulturais\i;
+
+return [
+    'Todos os campos são obrigatórios.' => i::__('Todos os campos são obrigatórios.'),
+    'Oportunidade gerada com sucesso, você será redirecionado...' => i::__('Oportunidade gerada com sucesso, você será redirecionado...'),
+    'Aguarde. Estamos gerando a oportunidade baseada no modelo.' => i::__('Aguarde. Estamos gerando a oportunidade baseada no modelo.'),
+    'agente' => i::__('agente'),
+    'espaço' => i::__('espaço'),
+    'evento' => i::__('evento'),
+    'projeto' => i::__('projeto'),
+];

--- a/src/modules/Entities/components/opportunity-create-model/README.md
+++ b/src/modules/Entities/components/opportunity-create-model/README.md
@@ -1,0 +1,11 @@
+# Componente `<opportunity-create-model>`
+
+### Importando componente
+```PHP
+<?php 
+$this->import('opportunity-create-model');
+?>
+```
+### Exemplos de uso
+```HTML
+<opportunity-create-model :entity="entity"></opportunity-create-model>

--- a/src/modules/Entities/components/opportunity-create-model/script.js
+++ b/src/modules/Entities/components/opportunity-create-model/script.js
@@ -1,0 +1,62 @@
+app.component('opportunity-create-model', {
+    template: $TEMPLATES['opportunity-create-model'],
+    setup() {
+        const messages = useMessages();
+        const text = Utils.getTexts('opportunity-create-model')
+        return { text, messages }
+    },
+    props: {
+        entity: {
+            type: Entity,
+            required: true,
+        },
+    },
+
+    data() {
+        let sendSuccess = false;
+        let formData = {
+            name: this.entity.name,
+            description: '',
+        }
+
+        return { sendSuccess, formData }
+    },
+
+    methods: {
+        async save() {
+            this.__processing = this.text('Gerando modelo...');
+
+            const api = new API(this.entity.__objectType);
+
+            let objt = this.formData;
+            objt.entityId = this.entity.id;
+            
+            let error = null;
+
+            if (error = this.validade(objt)) {
+                let mess = "";
+                mess = this.text('Todos os campos são obrigatórios.');
+                this.messages.error(mess);
+                return;
+            }
+
+            await api.POST(`/opportunity/generatemodel/${objt.entityId}`, objt).then(res => {
+                this.messages.success(this.text('Modelo gerado com sucesso'));
+                this.sendSuccess = true;
+                window.location.href = '/minhas-oportunidades/#mymodels';
+            });
+        },
+        validade(objt) {
+            let result = null;
+            let ignore = [];
+
+            Object.keys(objt).forEach(function (item) {
+                if (!objt[item] && !ignore.includes(item)) {
+                    result = item;
+                    return;
+                }
+            });
+            return result;
+        },
+    },
+});

--- a/src/modules/Entities/components/opportunity-create-model/template.php
+++ b/src/modules/Entities/components/opportunity-create-model/template.php
@@ -1,0 +1,39 @@
+<?php
+/**
+ * @var MapasCulturais\App $app
+ * @var MapasCulturais\Themes\BaseV2\Theme $this
+ */
+
+use MapasCulturais\i;
+
+$this->import(" 
+    mc-modal
+");
+?>
+<div class="col-12">
+    <mc-modal title="<?= i::__('Salvar modelo') ?>">
+        <template #default>
+            <p>Para salvar um modelo, preencha os campos abaixo.</p><br>
+            <div>
+                <div class="field">
+                    <label><?= i::__('Nome do modelo') ?><span class="required">*</span></label>
+                    <input type="text" v-model="formData.name">
+                </div><br>
+
+                <div class="field">
+                    <label><?= i::__('Breve descrição do modelo') ?><span class="required">*</span></label>
+                    <textarea placeholder="Breve descrição" v-model="formData.description"></textarea>
+                </div>
+            </div>
+        </template>
+
+        <template v-if="!sendSuccess"  #actions="modal">
+            <button class="button button--primary" @click="save(modal)"><?= i::__('Salvar modelo') ?></button>
+            <button class="button button--text button--text-del" @click="modal.close()"><?= i::__('cancelar') ?></button>
+        </template>
+
+        <template #button="modal">
+            <button type="button" @click="modal.open();" class="button button--icon button--sm"><?= i::__('Salvar modelo') ?></button>
+        </template>
+    </mc-modal>
+</div>

--- a/src/modules/Entities/components/opportunity-create-model/texts.php
+++ b/src/modules/Entities/components/opportunity-create-model/texts.php
@@ -1,0 +1,10 @@
+<?php
+
+use MapasCulturais\i;
+
+return [
+    'Recaptcha inválida' => i::__('Recaptcha inválida'),
+    'Todos os campos são obrigatórios.' => i::__('Todos os campos são obrigatórios.'),
+    'Modelo gerado com sucesso' => i::__('Modelo gerado com sucesso'),
+    'Gerando modelo...' => i::__('Gerando modelo...'),
+];

--- a/src/modules/Opportunities/Module.php
+++ b/src/modules/Opportunities/Module.php
@@ -47,6 +47,10 @@ class Module extends \MapasCulturais\Module{
         });
 
         $app->hook('entity(Opportunity).insert:after', function() {
+            if ($this->registrationSteps && count($this->registrationSteps) > 0) {
+                return;
+            }
+
             $step = new RegistrationStep();
             $step->name = '';
             $step->opportunity = $this;

--- a/src/modules/Opportunities/components/opportunity-basic-info/template.php
+++ b/src/modules/Opportunities/components/opportunity-basic-info/template.php
@@ -29,7 +29,7 @@ $this->import('
 ');
 ?>
 <div class="opportunity-basic-info__container">
-    <entity-status :entity="entity"></entity-status>
+    <entity-status v-if="!entity.isModel" :entity="entity"></entity-status>
 </div>
 
 <mc-container>

--- a/src/modules/Panel/components/panel--entity-actions/script.js
+++ b/src/modules/Panel/components/panel--entity-actions/script.js
@@ -45,6 +45,12 @@ app.component('panel--entity-actions', {
             const promise = entity.archive();
             this.$emit('archived', {entity, modal, promise});
         },
+
+        duplicateEntity(modal) {
+            const entity = this.entity;
+            const promise = entity.duplicate();
+            this.$emit('duplicate', {entity, modal, promise});
+        },
         
         deleteEntity(modal) {
             const entity = this.entity;

--- a/src/modules/Panel/components/panel--entity-models-card/script.js
+++ b/src/modules/Panel/components/panel--entity-models-card/script.js
@@ -1,0 +1,104 @@
+app.component('panel--entity-models-card', {
+    template: $TEMPLATES['panel--entity-models-card'],
+    emits: ['deleted'],
+    setup() {
+        const messages = useMessages();
+        const text = Utils.getTexts('panel--entity-models-card')
+        return { text, messages }
+    },
+    props: {
+        class: {
+            type: [String, Array, Object],
+            default: ''
+        },
+        entity: {
+            type: Entity,
+            required: true
+        },
+
+        onDeleteRemoveFromLists: {
+            type: Boolean,
+            default: true
+        }
+    },
+    data() {        
+        const api = new API(this.entity.__objectType);
+        const response = api.GET('/opportunity/findOpportunitiesModels');
+        response.then((r) => r.json().then((r) => {
+           this.models = r;
+        }));
+
+        let isModelPublic = this.entity.isModelPublic == 1 ? true : false;
+
+
+        const MODEL_OFFICIAL = 'MODELO OFICIAL';
+        const MODEL_PRIVATE = 'MODELO PRIVADO';
+        const MODEL_PUBLIC = 'MODELO PÚBLICO';
+
+        const typeModels = {
+            MODEL_OFFICIAL,
+            MODEL_PRIVATE,
+            MODEL_PUBLIC
+        };
+
+        return {
+            isModelPublic,
+            models: [],
+            typeModels
+        }
+    },
+
+    watch: {
+        'isModelPublic'(_new,_old){
+            if(_new != _old){
+                this.isActive(_new);
+            }
+        },
+    },
+    methods: {
+        isActive(active) {
+            this.entity.isModelPublic = active ? 1 : 0;
+            this.modelPublic();
+        },
+        async modelPublic(){
+            const api = new API(this.entity.__objectType);
+            let objt = {
+                isModelPublic: this.entity.isModelPublic
+            };
+
+            await api.POST(`/opportunity/modelpublic/${this.entity.id}`, objt).then(res => {
+                this.messages.success(this.text('Modelo atualizado com sucesso'));
+            });
+        }
+    },
+    computed: {
+        classes() {
+            return this.class;
+        }, 
+        leftButtons() {
+            return 'delete';
+        },
+        showModel() {
+            let showModel = false;
+            if (this.entity.owner._id == $MAPAS.user.profile._id || this.entity.isModelPublic) {
+                showModel = true;
+            }
+
+            return showModel;
+        },
+        getTypeModel() {
+
+            let model_ = this.models.filter((model) => {
+                return this.entity.id == model.id;
+            });
+
+            if (model_[0] != 'undefined') {
+                if (model_[0]?.modelIsOfficial) {
+                    return this.typeModels.MODEL_OFFICIAL;
+                }
+            }          
+
+            return this.entity.isModelPublic == 0 ? this.typeModels.MODEL_PRIVATE : this.typeModels.MODEL_PUBLIC;
+        },
+    }
+})

--- a/src/modules/Panel/components/panel--entity-models-card/template.php
+++ b/src/modules/Panel/components/panel--entity-models-card/template.php
@@ -1,0 +1,112 @@
+<?php
+/**
+ * @var MapasCulturais\App $app
+ * @var MapasCulturais\Themes\BaseV2\Theme $this
+ */
+
+use MapasCulturais\i;
+
+$this->import('
+    mc-avatar
+    mc-icon
+    mc-title
+    panel--entity-actions
+    opportunity-create-based-model 
+
+');
+?>
+<article class="panel__row panel-entity-models-card" v-if="showModel">
+    <header class="panel-entity-models-card__header">
+        <div class="left">
+            <slot name="picture" :entity="entity">
+                <mc-avatar :entity="entity" size="medium"></mc-avatar>
+            </slot>
+            <div class="panel-entity-models-card__header--info">
+                <slot name="title" :entity="entity">
+
+                    <a v-if="entity.currentUserPermissions?.modify" :href="entity.singleUrl" class="panel-entity-models-card__header--info-link">
+                        <mc-title tag="h2" :shortLength="100" :longLength="110">
+                            {{ entity.name }}
+                        </mc-title>
+                    </a>
+                    <mc-title v-if="!entity.currentUserPermissions?.modify" tag="h2" :shortLength="100" :longLength="110">
+                        {{ entity.name }}
+                    </mc-title>          
+                </slot>
+            </div>
+        </div>
+        <div class="right">
+            <div class="panel-entity-models-card__header-actions">
+                <slot name="header-actions" :entity="entity">
+                    <li v-if="getTypeModel == typeModels.MODEL_OFFICIAL" class="tag-official mc-tag-list__tag">    
+                        {{ typeModels.MODEL_OFFICIAL }}
+                    </li>
+                    <li v-if="getTypeModel == typeModels.MODEL_PUBLIC" class="tag-public mc-tag-list__tag">    
+                        {{ typeModels.MODEL_PUBLIC }}
+                    </li>
+                    <li v-if="getTypeModel == typeModels.MODEL_PRIVATE" class="tag-private mc-tag-list__tag">    
+                        {{ typeModels.MODEL_PRIVATE }}
+                    </li>
+                </slot>
+            </div>
+        </div>
+    </header>
+    <main class="panel-entity-models-card__main">
+        <span class="card-info"></span>
+        <div class="card-desc">
+            <div v-for="model in models" :key="model.id">
+                <span v-if="model.id == entity.id">
+                    <p>{{ model.descricao.substring(0, 150) }}</p>
+                    <mc-icon name="project" class="icon-model"></mc-icon> 
+                    <strong><?=i::__('Tipo de Oportunidade: ')?></strong>{{ entity.type.name }}
+                    <br>
+                    <mc-icon name="circle-checked" class="icon-model"></mc-icon>
+                    <strong><?=i::__('Número de fases: ')?></strong>{{ model.numeroFases }}
+                    <br>
+                    <mc-icon name="date" class="icon-model"></mc-icon>
+                    <strong><?=i::__('Tempo estimado: ')?></strong>{{ model.tempoEstimado }}
+                    <br>
+                    <mc-icon name="agent" class="icon-model"></mc-icon>
+                    <strong><?=i::__('Tipo de agente: ')?></strong> {{ model.tipoAgente }}
+                    <br><br>
+                    <?php if($app->user->is('admin')): ?>
+                        <div v-if="entity.currentUserPermissions?.modify">
+                            <label class="switch" >
+                                <input type="checkbox" v-model="isModelPublic" />
+                                <span class="slider round"></span>
+                            </label>
+                            <span class="switch-text"><?= i::__("Modelo público") ?></span>
+                        </div>
+                        <br><br>
+                    <?php endif; ?>
+                </span>
+            </div>
+        </div>
+    </main>
+    <footer class="panel-entity-models-card__footer">
+        <div class="panel-entity-models-card__footer-actions">
+            <slot name="footer-actions">
+                <div class="panel-entity-models-card__footer-actions left">
+                    <slot name="entity-actions-left" :entity="entity">
+                        <panel--entity-actions 
+                            :entity="entity" 
+                            @deleted="$emit('deleted', $event)"
+                            :on-delete-remove-from-lists="onDeleteRemoveFromLists"
+                            :buttons="leftButtons"
+                        ></panel--entity-actions>
+                    </slot>
+                </div>
+                <div class="panel-entity-models-card__footer-actions right">
+                    <slot name="entity-actions-center" >
+                    </slot>
+                    <slot name="entity-actions-right" >
+                        <div v-if="showModel && entity.status != -2 && entity.__objectType == 'opportunity' && entity.isModel == 1">
+                            <opportunity-create-based-model :entitydefault="entity" classes="col-12"></opportunity-create-based-model>
+                        </div>
+                    </slot>
+                </div>
+            </slot>
+        </div>
+    </footer>
+
+</article>

--- a/src/modules/Panel/components/panel--entity-models-card/texts.php
+++ b/src/modules/Panel/components/panel--entity-models-card/texts.php
@@ -1,0 +1,7 @@
+<?php
+
+use MapasCulturais\i;
+
+return [
+    'Modelo atualizado com sucesso' => i::__('Modelo atualizado com sucesso'),
+];

--- a/src/modules/Panel/components/panel--entity-tabs/template.php
+++ b/src/modules/Panel/components/panel--entity-tabs/template.php
@@ -84,7 +84,7 @@ $this->applyComponentHook('.sortOptions', [&$tabs]);
                             <slot name="entity-actions-left" :entity="entity"></slot>
                         </template>
                     </registration-card>
-                    <panel--entity-card v-if="entity.__objectType != 'registration' && (entity.type && entity.isModel != 1)" :key="entity.id" :entity="entity" 
+                    <panel--entity-card v-if="(entity.__objectType != 'registration' && entity.__objectType != 'opportunity') || (entity.__objectType == 'opportunity' && entity.isModel != 1)" :key="entity.id" :entity="entity" 
                         @undeleted="moveEntity(entity, $event)" 
                         @deleted="moveEntity(entity, $event)" 
                         @archived="moveEntity(entity, $event)" 
@@ -111,7 +111,7 @@ $this->applyComponentHook('.sortOptions', [&$tabs]);
                             <slot name="entity-actions-right" :entity="entity"></slot>
                         </template>
                     </panel--entity-card>
-                    <panel--entity-models-card v-if="entity.__objectType != 'registration' && (entity.type && entity.isModel == 1)" :key="entity.id" :entity="entity"></panel--entity-models-card>
+                    <panel--entity-models-card v-if="entity.__objectType == 'opportunity' && entity.isModel == 1" :key="entity.id" :entity="entity"></panel--entity-models-card>
                 </slot>
                 <slot name='after-list' :entities="entities" :query="queries['<?=$status?>']"></slot>
             </template>

--- a/src/modules/Panel/components/panel--entity-tabs/template.php
+++ b/src/modules/Panel/components/panel--entity-tabs/template.php
@@ -11,6 +11,7 @@ $this->import('
     mc-tab
     mc-tabs
     panel--entity-card
+    panel--entity-models-card
     registration-card
 ');
 
@@ -18,6 +19,7 @@ $tabs = $tabs ?? [
     'publish' => i::esc_attr__('Publicados'),
     'draft' => i::esc_attr__('Em rascunho'),
     'granted' => i::esc_attr__('Com permissão'),
+    'mymodels' => i::esc_attr__('Meus modelos'),
     'archived' => i::esc_attr__('Arquivados'),
     'trash' => i::esc_attr__('Lixeira'),
 ];
@@ -35,7 +37,7 @@ $sort_options = [
 $this->applyComponentHook('.sortOptions', [&$tabs]);
 
 ?>
-<mc-tabs class="entity-tabs" sync-hash>
+<mc-tabs class="entity-tabs models" sync-hash>
     <?php $this->applyComponentHook('begin') ?>
     <template #header="{ tab }">
         <?php $this->applyComponentHook('tab', 'begin') ?>
@@ -70,7 +72,6 @@ $this->applyComponentHook('.sortOptions', [&$tabs]);
                                 <?php endforeach ?>
                             </select>
                         </label>
-
                     </slot>
                 </form>
             </template>
@@ -78,12 +79,12 @@ $this->applyComponentHook('.sortOptions', [&$tabs]);
             <template #default="{entities}">
                 <slot name='before-list' :entities="entities" :query="queries['<?=$status?>']"></slot>
                 <slot v-for="entity in entities" :key="entity.__objectId" :entity="entity" :moveEntity="moveEntity">
-                    <registration-card v-if="entity.__objectType=='registration'" :entity="entity" pictureCard hasBorders class="panel__row">
+                    <registration-card v-if="entity.__objectType == 'registration'" :entity="entity" pictureCard hasBorders class="panel__row">
                         <template #entity-actions-left>
                             <slot name="entity-actions-left" :entity="entity"></slot>
                         </template>
                     </registration-card>
-                    <panel--entity-card  v-if="entity.__objectType!='registration'" :key="entity.id" :entity="entity" 
+                    <panel--entity-card v-if="entity.__objectType != 'registration' && (entity.type && entity.isModel != 1)" :key="entity.id" :entity="entity" 
                         @undeleted="moveEntity(entity, $event)" 
                         @deleted="moveEntity(entity, $event)" 
                         @archived="moveEntity(entity, $event)" 
@@ -93,15 +94,13 @@ $this->applyComponentHook('.sortOptions', [&$tabs]);
                         <template #title="{ entity }">
                             <slot name="card-title" :entity="entity"></slot>
                         </template>
-                        <?php if($app->config['app.panelEtityCardFields']['type']):?>
                         <template #subtitle="{ entity }">
-                            <slot name="card-content"  :entity="entity">
+                            <slot name="card-content" :entity="entity">
                                 <span v-if="entity.type">
                                     <?=i::__('Tipo: ')?> <strong>{{ entity.type.name }}</strong>
                                 </span>
                             </slot>
                         </template>
-                        <?php endif?>
                         <template #entity-actions-left>
                             <slot name="entity-actions-left" :entity="entity"></slot>
                         </template>
@@ -112,9 +111,10 @@ $this->applyComponentHook('.sortOptions', [&$tabs]);
                             <slot name="entity-actions-right" :entity="entity"></slot>
                         </template>
                     </panel--entity-card>
+                    <panel--entity-models-card v-if="entity.__objectType != 'registration' && (entity.type && entity.isModel == 1)" :key="entity.id" :entity="entity"></panel--entity-models-card>
                 </slot>
                 <slot name='after-list' :entities="entities" :query="queries['<?=$status?>']"></slot>
-           </template>
+            </template>
         </mc-entities>
         <?php $this->applyComponentHook($status, 'end') ?>
     </mc-tab>

--- a/src/themes/BaseV2/assets-src/sass/2.components/_entity-models-card.scss
+++ b/src/themes/BaseV2/assets-src/sass/2.components/_entity-models-card.scss
@@ -1,0 +1,788 @@
+@use '../0.settings/mixins' as *;
+
+.entity-card {
+	background-color: var(--mc-white);
+	border-radius: var(--mc-border-radius-sm);
+	padding: size(16);
+	user-select: none;
+	width: 100%;
+	.entity-card__slot {
+		display: flex;
+		flex-direction: row;
+		align-items: center;
+		gap: size(24);
+	}
+	
+	&__header {
+		align-items: stretch;
+		display: flex;
+		flex-wrap: nowrap;
+		justify-content: space-between;
+		position: relative;
+
+		&.user-details {
+			display: flex;
+			width: 100%;
+			justify-content: flex-start;
+			gap: size(4) size(16);
+			align-items: flex-start;
+			padding-top: size(6);
+			.user-image {
+				align-items: center;
+				background-color: var(--mc-gray-300);
+				border-radius: 50%;
+				display: flex;
+				height: size(48);
+				justify-content: center;
+				min-width: size(48);
+				overflow: hidden;
+				width: size(48);
+
+				img {
+					width: 100%;
+				}
+
+				.iconify {
+					font-size: size(24);
+					color: var(--mc-gray-700);
+				}
+			}
+
+			.user-info {
+				align-items: flex-start;
+				display: flex;
+				flex-direction: column;
+				gap: size(8);
+				margin: size(4) 0;
+				text-align: left;
+
+				&.with-labels {
+					max-width: size(700);
+				}
+
+				&.without-labels {
+					max-width: size(700);
+				}
+
+				width: 100%;
+
+				&__name {
+					align-items: center;
+					display: flex;
+					font-size: size(25.5);
+					font-weight: 700;
+					line-height: size(30);
+				}
+
+				&__attr {
+					display: flex;
+					flex-direction: column;
+					gap: size(4) 0;
+
+					.lb-agent {
+						font-style: bold;
+					}
+
+					.lb-agent-type {
+						color: var(--mc-agents-500);
+					}
+				}
+			}
+
+		}
+
+		&.with-labels & {
+			
+			&.user-slot {
+				.entity-card__slot {
+					position: absolute;
+					right: 0;
+					display: grid;
+					grid-template-columns: size(48) size(160);
+					@media (max-width: size(500)) {
+						gap: size(9);
+					}
+					&.no-id {
+						position: relative;
+						display: flex;
+					}
+				}
+				.entity-card__id {
+					font-size:var(--mc-font-size-xxs);
+					display: flex;
+					flex-direction: row;
+					align-items: center;
+				}
+
+			}
+		}
+
+		&.user-slot {
+			align-items: flex-start;
+			position: absolute;
+			right: 0;
+			max-width: size(280);
+			top: size(-11.6);
+
+			.entityType {
+				align-items: center;
+				border-radius: var(--mc-border-radius-pill);
+				display: table;
+				font-size: size(12);
+				font-weight: 700;
+				line-height: size(16);
+				min-width: size(137);
+				padding: size(8) size(16);
+				text-transform: capitalize;
+				text-align: center;
+				vertical-align: middle;
+
+				.iconify {
+					float: left;
+					font-size: size(16);
+					line-height: size(16);
+				}
+			}
+			
+			.openSubscriptions {
+				color: var(--mc-low-700);
+				display: flex;
+				font-size: size(14);
+				font-weight: 700;
+				gap: size(6);
+				line-height: size(19);
+
+				.iconify {
+					color: #008739;
+					font-size: size(21);
+				}
+
+			}
+		}
+
+		&--highlight {
+			padding: size(6) size(16);
+			border-radius: var(--mc-border-radius-pill);
+			min-width: size(137);
+			display: block;
+			text-align: center;
+			color: var(--mc-high-500);
+			font-weight: 700;
+			font-size: size(12);
+			line-height: size(22);
+			text-transform: capitalize;
+
+			.iconify {
+				font-size: size(22);
+				float: left;
+				gap: size(8);
+			}
+		}
+	}
+
+	&__content {
+		display: flex;
+		flex-direction: column;
+		gap: size(8);
+		margin: size(16) 0 size(8);
+		text-align: left;
+
+		&-shortDescription {
+			word-break:break-word;
+			font-size: size(14);
+		}
+
+		&--occurrence {
+			&-data {
+				font-weight: 700;
+				font-size: size(14);
+				line-height: size(19);
+				display: flex;
+				align-items: center;
+				gap: size(10);
+
+				.iconify {
+					font-size: size(18);
+				}
+			}
+
+
+			&-space {
+				font-weight: 700;
+				font-size: size(14);
+				line-height: size(19);
+				display: flex;
+				align-items: center;
+				gap: size(11);
+
+				.link {
+					align-items: center;
+					display: flex;
+					gap: size(10);
+					text-decoration: none;
+					font-size: size(18);
+				}
+
+				.space-adress {
+					a {
+						text-decoration: none;
+					}
+
+					&__adress {
+						margin-left: size(10);
+
+						@media (max-width:size(600)) {
+							word-break: break-word;
+						}
+					}
+				}
+
+				@media (max-width:size(500)) {
+					align-items: flex-start;
+				}
+			}
+
+			&-info {
+				display: flex;
+				align-items: center;
+				gap: size(40);
+
+				.ageRating {
+
+					&__class {
+
+						font-weight: 500;
+						font-size: size(14);
+						line-height: size(16);
+						text-transform: uppercase;
+						color: var(--mc-low-700);
+					}
+
+					&__value {
+						font-weight: 700;
+						font-size: size(14);
+						line-height: size(16);
+					}
+
+					@media (max-width:size(700)) {
+						display: flex;
+						flex-direction: column;
+					}
+				}
+
+			}
+		}
+
+		&--description {
+			font-weight: 400;
+			font-size: size(12);
+			line-height: size(16);
+			color: var(--mc-low-700);
+			word-break: break-word;
+
+			&-local,
+			&-adress {
+				color: var(--mc-low-500);
+				line-height: size(22);
+				font-weight: 600;
+				font-size: size(14);
+			}
+		}
+
+		&--terms {
+
+			&-area,
+			&-tag,
+			&-linguagem {
+				display: flex;
+				align-items: flex-start;
+				flex-direction: column;
+
+				.area__title,
+				.tag__title,
+				.linguagem__title {
+					font-weight: 500;
+					font-size: size(12);
+					line-height: size(16);
+					display: flex;
+					align-items: center;
+					text-transform: uppercase;
+					color: var(--mc-low-700);
+				}
+			}
+
+			.terms {
+				font-weight: 700;
+				font-size: size(12);
+				line-height: size(16);
+				margin: size(4) 0 size(8);
+				text-align: left;
+			}
+		}
+	}
+
+	&__footer {
+		display: flex;
+		flex-wrap: nowrap;
+		gap: size(24) 0;
+
+		@media (max-width: size(500)) {
+			flex-direction: column;
+		}
+
+		&--info {
+			min-width: size(200);
+
+			.seals {
+				display: flex;
+				flex-wrap: wrap;
+				gap: size(5);
+
+				&__title {
+					align-items: center;
+					display: flex;
+					font-size: size(12);
+					line-height: size(16);
+					text-transform: uppercase;
+					width: 100%;
+				}
+
+				&__seal {
+					align-items: center;
+					background: var(--mc-high-300);
+					border-radius: var(--mc-border-radius-xs);
+					display: flex;
+					font-size: size(12);
+					font-weight: 400;
+					height: size(32);
+					justify-content: center;
+					line-height: size(16);
+					width: size(32);
+					
+					.sealImage {
+						max-width: 100%;
+						border-radius: size(8);
+					}
+				}
+			}
+		}
+
+		&--action {
+			align-items: flex-end;
+			display: flex;
+			justify-content: flex-end;
+			width: 100%;
+
+			.button {
+				display: block;
+				max-width: size(500);
+				text-align: center;
+
+				.iconify {
+					float: right;
+				}
+			}
+		}
+	}
+
+	&.portrait {
+		display: flex;
+    	flex-direction: column;
+    	justify-content: space-between;
+		.entity-card__header {
+			&.user-details {
+				flex-direction: column;
+			}
+		}
+		.entity-card__footer {
+			flex-direction: column;
+		}
+	}
+}
+
+.panel-entity-models-card {
+	background-color: var(--mc-white);
+	border-radius: var(--mc-border-radius-sm);
+	padding: size(24);
+
+	&__header {
+		align-items: flex-start;
+		display: flex;
+		justify-content: space-between;
+
+		.left {
+			display: grid;
+			grid-template-columns: size(70) 1fr;
+			gap: size(7) size(16);
+		}
+
+
+		&> :first-child {
+			align-items: start;
+			display: grid;
+			grid-template-columns: 70px 1fr;
+			gap: size(7) size(16);
+
+			@media (max-width: size(500)) {
+
+				display: flex;
+				flex-direction: column;
+				align-items: flex-start;
+
+				.panel-entity-models-card__main {
+					display: none;
+				}
+			}
+		}
+
+		&--picture {
+			display: flex;
+			align-items: center;
+			justify-content: center;
+			width: size(64);
+			height: size(64);
+			background-color: var(--mc-low-300);
+			border-radius: 50%;
+
+			svg {
+				font-size: size(32);
+			}
+
+			img {
+				border-radius: 50%;
+				width: 100%;
+			}
+
+			@media (max-width: size(500)) {
+				height: size(32);
+				width: size(32);
+
+				svg {
+					font-size: size(16);
+				}
+			}
+		}
+
+		&--info {
+			align-self: center;
+			align-items: flex-start;
+			display: flex;
+			flex-direction: column;
+			gap: size(10);
+
+			&-title {
+				display: inline-block;
+				font-weight: 700;
+				font-size: size(24);
+				line-height: size(28);
+				text-align: left;
+				word-break: break-word;
+
+				.icon-app {
+					margin-left: size(17);
+
+					color: var(--mc-primary-500);
+
+				}
+			}
+
+			&-subtitle {
+				font-weight: 500;
+				font-size: size(14);
+				line-height: size(19);
+				margin: 0;
+				text-transform: uppercase;
+			}
+		}
+	}
+
+	&__header-actions {
+		display: flex;
+		flex-wrap: wrap-reverse;
+
+		button {
+			align-items: center;
+			appearance: none;
+			background-color: transparent;
+			border: none;
+			border-radius: var(--mc-border-radius-sm);
+			display: flex;
+			padding: size(8);
+			flex-direction: row;
+			align-items: center;
+			gap: size(8);
+
+			&:focus,
+			&:hover {
+				background-color: var(--mc-gray-100);
+			}
+
+			.iconify {
+				height: size(20);
+				width: size(20);
+			}
+
+			span {
+				font-size: size(12);
+				font-weight: bold;
+
+				@include mobile {
+					@include sr-only;
+				}
+			}
+		}
+
+		.tag-official {
+			background-color: #FFB700;
+			color: #1E1E1E;
+			width: size(150);
+		}
+
+		.tag-public {
+			background-color: #FFB700;
+			color: #1E1E1E;
+			width: size(150);
+		}
+
+		.tag-private {
+			background-color: #fff;
+			color: #767676;
+			width: size(150);
+		}
+	}
+
+	&__main {
+		display: flex;
+		flex-wrap: wrap;
+		padding: size(16);
+		min-height: size(57);
+
+		dl {
+			font-size: size(14);
+			margin: 0 size(40) size(16) 0;
+			text-transform: uppercase;
+		}
+
+		dt {
+			display: inline;
+			margin: 0 1ch 0 0;
+			padding: 0;
+
+			&::after {
+				content: ':';
+			}
+		}
+
+		dd {
+			display: inline;
+			font-weight: bold;
+			margin: 0;
+			padding: 0;
+		}
+
+		@media (max-width:size(500)) {
+			padding: size(16) 0;
+		}
+	}
+
+	/* &__footer {
+		
+	} */
+
+	&__footer-actions {
+		display: flex;
+		justify-content: space-between;
+		align-items: flex-end;
+
+		.panel__entity-actions {
+			@media (max-width: size(500)) {
+
+				display: flex;
+				padding-top: size(16);
+				justify-content: center;
+				flex-wrap: wrap;
+
+			}
+		}
+
+		@media (max-width: size(500)) {
+			align-items: center;
+			flex-direction: column-reverse;
+		}
+
+		&.left {
+			.publish-archived.button {
+				color: var(--mc-primary-500);
+				border: none;
+				background-color: white;
+				font-weight: 700;
+				font-size: 14px;
+				line-height: 19px;
+			}
+			.models &{
+				position: absolute;
+				bottom: 30px;
+				left: 15px;
+			}
+		}
+
+		&.right {
+			display: flex;
+			gap: size(32);
+
+			@media (max-width: size(500)) {
+				.button-action{
+					width: size(297);
+					max-width: 100%;
+					height: size(48);
+					display: flex;
+					justify-content: flex-end;
+					align-items: center;
+					flex-direction: row;
+					gap: size(100)
+				}
+
+				.editdraft {
+					justify-content: flex-start;
+				}
+
+				.recover {
+					justify-content: center;
+				}
+
+				.publish-archived {
+					justify-content: center;
+				}
+			}
+			.models &{
+				position: absolute;
+				bottom: 30px;
+				right: 25px;
+			}
+		}
+
+		button {
+			margin-left: size(4);
+		}
+
+		.button {
+			font-family: "Open Sans";
+
+			&.archive {
+				color: var(--mc-low-500);
+				font-family: "Open Sans";
+
+				.iconify {
+					color: var(--mc-warning);
+				}
+			}
+
+			&.delete {
+				color: var(--mc-low-500);
+
+				.iconify {
+					color: var(--mc-error);
+				}
+			}
+
+			@include mobile {
+				padding: size(8);
+
+				span {
+					// @include sr-only;
+
+				}
+			}
+		}
+	}
+}
+
+article.panel-entity-models-card.col-6{
+	max-width: 450px;
+	min-height: 530px;
+	box-shadow: 0 2px 4px rgba(0, 0, 0, 0.2);
+	.panel-entity-models-card__header--info{
+		margin-top: 85px;
+		margin-left: -80px;
+
+		@include mobile {
+			margin-top: 0;
+			margin-left: 0;
+		}
+	}
+}
+.icon-model{
+	font-size: size(20) !important;
+	color: #117C83;
+	margin-right: 8px;
+	margin-top: 15px;
+	vertical-align: text-bottom;
+}
+
+/* The switch - the box around the slider */
+.switch {
+  position: relative;
+  display: inline-block;
+  width: 30px;
+  height: 17px;
+}
+
+/* Hide default HTML checkbox */
+.switch input {
+  opacity: 0;
+  width: 0;
+  height: 0;
+}
+
+/* The slider */
+.slider {
+  position: absolute;
+  cursor: pointer;
+  top: 0;
+  left: 0;
+  right: 0;
+  bottom: 0;
+  background-color: #ccc;
+  -webkit-transition: .4s;
+  transition: .4s;
+}
+
+.slider:before {
+  position: absolute;
+  content: "";
+  height: 13px;
+  width: 13px;
+  left: 2px;
+  bottom: 2px;
+  background-color: white;
+  -webkit-transition: .4s;
+  transition: .4s;
+}
+
+input:checked + .slider {
+  background-color: var(--mc-primary-500);
+}
+
+input:focus + .slider {
+  box-shadow: 0 0 1px var(--mc-primary-500);
+}
+
+input:checked + .slider:before {
+  -webkit-transform: translateX(13px);
+  -ms-transform: translateX(13px);
+  transform: translateX(13px);
+}
+
+/* Rounded sliders */
+.slider.round {
+  border-radius: 17px;
+}
+
+.slider.round:before {
+  border-radius: 50%;
+}
+
+.switch-text {
+	margin-left: 8px;
+	font-weight: 600;
+}

--- a/src/themes/BaseV2/assets-src/sass/theme-BaseV2.scss
+++ b/src/themes/BaseV2/assets-src/sass/theme-BaseV2.scss
@@ -36,6 +36,7 @@
 @import '2.components/entity-actions';
 @import '2.components/entity-activity-card';
 @import '2.components/entity-card';
+@import '2.components/entity-models-card';
 @import '2.components/entity-cover';
 @import '2.components/entity-data';
 @import '2.components/entity-file';


### PR DESCRIPTION

## Integração da funcionalidade de gestão de modelos

Este PR faz parte das entregas de evoluções implementadas no Mapa da Cultura do MinC, realizadas por meio do Termo de Execução Descentralizada - TED GSE, celebrado entre a Secretaria Executiva do Ministério da Cultura e a Universidade Federal do Paraná, contemplando as funcionalidades mínimas necessárias para atender à demanda por ferramentas digitais de mapeamento, monitoramento, prestação de contas, avaliação, cadastro e inscrição de propostas da Política Nacional de Fomento à Cultura Aldir Blanc.

### Contexto e Objetivo  
Este PR realiza o repasse e integração da funcionalidade de gestão de modelos originalmente implementada nos PR's [#24](https://github.com/culturagovbr/mapadacultura/pull/24) e [#33](https://github.com/culturagovbr/mapadacultura/pull/33) do [RedeMapas](https://github.com/RedeMapas/mapas). Por algum motivo, o PR#24 contempla o PR#23, para tanto torna-se necessário as devidas correções propostas no PR [#58](https://github.com/culturagovbr/mapadacultura/pull/58). O objetivo é incorporar ao repositório original a funcionalidade completa e corrigida, garantindo aderência à arquitetura atual do sistema.

### Funcionalidade: Gestão de Modelos (PR [#24](https://github.com/culturagovbr/mapadacultura/pull/24))  
Implementa funcionalidades que permitem:

- Criar um modelo a partir de uma oportunidade;
- Listar modelos com detalhes (tipo, tempo de execução, proponentes);
- Criar uma nova oportunidade a partir de um modelo;
- Publicizar modelos para todos os usuários da plataforma;
- Tornar modelos públicos (administração);
- Tornar modelos oficiais quando vinculados ao selo verificado.

A operação pode ser realizada por meio do botão “Salvar modelo” no rodapé da oportunidade, que abre um modal para inserção do nome e descrição do modelo, redirecionando posteriormente para a lista de “Meus modelos”.

### Funcionalidade: Ajusta regra dos componentes de tabs das entidades quando Modelo (PR [#33](https://github.com/culturagovbr/mapadacultura/pull/33))

Muda regra dos componentes de exibição de abas compartilhado entre as entidades.
-   Componente mostra quando for apenas inscrições
-   Componente mostra se for diferente de registrations e opportunity ou quando for oportunidade e modelo
-   Mostra componente somente se for opportunity e quando for modelo

### Considerações Finais  
Este repasse consolida de forma coesa a entrega realizada no PR [#24](https://github.com/culturagovbr/mapadacultura/pull/24) e no PR [#33](https://github.com/culturagovbr/mapadacultura/pull/33), que incorporou também a funcionalidade de duplicação da entidade oportunidade (PR [#23](https://github.com/culturagovbr/mapadacultura/pull/23)). As correções adicionais, tratadas no PR [#58](https://github.com/culturagovbr/mapadacultura/pull/58), foram necessárias para garantir o funcionamento adequado da duplicação no cenário atual do sistema. Este trabalho concentra-se no repasse formal e estruturado das entregas validadas, sem reengenharia das soluções originais.
