### PR TITLE
Repasse 6779/plano de trabalho

### DIFF
--- a/config/workplan.php
+++ b/config/workplan.php
@@ -1,0 +1,7 @@
+<?php
+
+return [
+    'workplan' => [
+        'enable_workplan_tutorial' => env('ENABLE_WORKPLAN_TUTORIAL', false),
+    ]
+];

--- a/src/db-updates.php
+++ b/src/db-updates.php
@@ -2596,6 +2596,71 @@ $$
                 AND emc.type = 'qualification'
                 AND r.consolidated_result IN ('Habilitado', 'Inabilitado')
         ");
-    }
+    },
+
+    'create table workplan' => function () {
+        __exec("CREATE TABLE registration_workplan (
+          id SERIAL PRIMARY KEY,
+          agent_id INTEGER,          
+          registration_id INTEGER,
+          create_timestamp timestamp without time zone NOT NULL,
+          update_timestamp timestamp(0) without time zone
+      )");
+
+        __exec("ALTER TABLE registration_workplan ADD FOREIGN KEY (registration_id) REFERENCES registration(id) ON DELETE CASCADE");
+        __exec("ALTER TABLE registration_workplan ADD FOREIGN KEY (agent_id) REFERENCES agent(id) ON DELETE CASCADE");
+    },
+    'create table workplan_meta' => function () {
+        __exec("CREATE TABLE public.registration_workplan_meta (
+            object_id integer NOT NULL,
+            key character varying(255) NOT NULL,
+            value text,
+            id SERIAL NOT NULL
+        );");
+        __exec("ALTER TABLE registration_workplan_meta ADD FOREIGN KEY (object_id) REFERENCES registration_workplan(id) ON DELETE CASCADE");
+    },
+
+    'create table workplan goal' => function () {
+        __exec("CREATE TABLE registration_workplan_goal (
+            id SERIAL PRIMARY KEY,
+            agent_id INTEGER,          
+            workplan_id INTEGER,
+            create_timestamp timestamp without time zone NOT NULL,
+            update_timestamp timestamp(0) without time zone
+        )");
+
+        __exec("ALTER TABLE registration_workplan_goal ADD FOREIGN KEY (workplan_id) REFERENCES registration_workplan(id) ON DELETE CASCADE");
+        __exec("ALTER TABLE registration_workplan_goal ADD FOREIGN KEY (agent_id) REFERENCES agent(id) ON DELETE CASCADE");
+    },
+    'create table workplan_goal meta' => function () {
+        __exec("CREATE TABLE public.registration_workplan_goal_meta (
+              object_id integer NOT NULL,
+              key character varying(255) NOT NULL,
+              value text,
+              id SERIAL NOT NULL
+          );");
+        __exec("ALTER TABLE registration_workplan_goal_meta ADD FOREIGN KEY (object_id) REFERENCES registration_workplan_goal(id) ON DELETE CASCADE");
+    },
+    'create table workplan goal delivery' => function () {
+        __exec("CREATE TABLE registration_workplan_goal_delivery (
+            id SERIAL PRIMARY KEY,
+            agent_id INTEGER,     
+            goal_id INTEGER,     
+            create_timestamp timestamp without time zone NOT NULL,
+            update_timestamp timestamp(0) without time zone
+        )");
+
+        __exec("ALTER TABLE registration_workplan_goal_delivery ADD FOREIGN KEY (goal_id) REFERENCES registration_workplan_goal(id) ON DELETE CASCADE");
+        __exec("ALTER TABLE registration_workplan_goal_delivery ADD FOREIGN KEY (agent_id) REFERENCES agent(id) ON DELETE CASCADE");
+    },
+    'create table workplan_goal delivery meta' => function () {
+        __exec("CREATE TABLE public.registration_workplan_goal_delivery_meta (
+              object_id integer NOT NULL,
+              key character varying(255) NOT NULL,
+              value text,
+              id SERIAL NOT NULL
+          );");
+        __exec("ALTER TABLE registration_workplan_goal_delivery_meta ADD FOREIGN KEY (object_id) REFERENCES registration_workplan_goal_delivery(id) ON DELETE CASCADE");
+    },
     
 ] + $updates ;   

--- a/src/modules/Components/assets-src/js/vue-init.js
+++ b/src/modules/Components/assets-src/js/vue-init.js
@@ -17,7 +17,8 @@ import { vMaska } from 'maska'
 import { VueRecaptcha } from 'vue-recaptcha';
 import Slider from '@vueform/slider'
 import VueQrcode from '@chenfengyuan/vue-qrcode';
-
+import Shepherd from 'shepherd.js';
+import 'shepherd.js/dist/css/shepherd.css'
 
 
 const app = Vue.createApp({})
@@ -32,6 +33,7 @@ app.component('Datepicker', Datepicker);
 app.component('Slider', Slider);
 app.component('Draggable', VueDraggable);
 app.component('VueQrcode', VueQrcode);
+app.component('Shepherd', Shepherd);
 app.directive('maska', vMaska);
 app.use(MediaQuery)
 
@@ -50,7 +52,7 @@ globalThis.CurrencyInput = CurrencyInput
 globalThis.Dates = Dates;
 globalThis.VueRecaptcha = VueRecaptcha;
 globalThis.VueQrcode = VueQrcode;
-
+globalThis.Shepherd = Shepherd;
 
 globalThis.$MAPAS = typeof Mapas !== 'undefined' ? Mapas : MapasCulturais
 globalThis.$DESCRIPTIONS = $MAPAS.EntitiesDescription ?? []

--- a/src/modules/Components/components/mc-messages/script.js
+++ b/src/modules/Components/components/mc-messages/script.js
@@ -21,7 +21,7 @@ const useMessages = Pinia.defineStore('messages', {
             // caso o timeout não tenha sido definido e
             // caso a quantidade de palavras na mensagem seja maior que 16, 
             // o timeout terá um acrescimo de 1 segundo para cada 5.5 palavras
-            const messageWords = message.text?.split?.(' ') || message.split?.(' ') || [];
+            const messageWords = typeof message?.text === 'string' ? message.text.split(' ') : typeof message === 'string' ? message.split(' ') : [];
             const minTimeout = 3000;
             const wordPerSecond = 5.5;
             const aditionalTimeout = Math.ceil(messageWords.length / wordPerSecond) * 1000;

--- a/src/modules/Components/package.json
+++ b/src/modules/Components/package.json
@@ -20,6 +20,7 @@
         "leaflet.markercluster": "^1.5.3",
         "maska": "^2.1.11",
         "pinia": "^2.3.0",
+        "shepherd.js": "^14.4.0",
         "vue": "^3.5.13",
         "vue-advanced-cropper": "^2.8.9",
         "vue-currency-input": "^3.1.0",

--- a/src/modules/FAQ/questions/pt_BR/inscricao/preenchimento/plano-de-metas.md
+++ b/src/modules/FAQ/questions/pt_BR/inscricao/preenchimento/plano-de-metas.md
@@ -1,0 +1,3 @@
+# Preenchimento do plano de metas
+
+Para registrar as metas e entregas do plano de metas, preencha os campos obrigatórios e clique no botão "Salvar Meta"

--- a/src/modules/Opportunities/components/opportunity-phase-config-data-collection/template.php
+++ b/src/modules/Opportunities/components/opportunity-phase-config-data-collection/template.php
@@ -70,11 +70,15 @@ $this->import('
             <?php $this->applyComponentHook('bottom') ?>
         </div>
 
-         <div class="col-12 grid-12 opportunity-data-collection__config-button">
+        <?php $this->applyTemplateHook('opportunity-data-collection-config-form','before')?>
+        <div class="col-12 grid-12 opportunity-data-collection__config-button">
+            <?php $this->applyTemplateHook('opportunity-data-collection-config-form','begin')?>
             <mc-link :entity="phase" route='formBuilder' class="config-phase__info-button button--primary button col-6" icon="external" right-icon>
             <?= i::__("Configurar formulário") ?>
             </mc-link>
+            <?php $this->applyTemplateHook('opportunity-data-collection-config-form','end')?>
         </div>
+        <?php $this->applyTemplateHook('opportunity-data-collection-config-form',sufix: 'after')?>
 
         <template v-if="nextPhase?.__objectType != 'evaluationmethodconfiguration' && !firstPhase?.isContinuousFlow">
             <div class="opportunity-data-collection__horizontal-line col-12 "></div>

--- a/src/modules/Opportunities/components/registration-actions/script.js
+++ b/src/modules/Opportunities/components/registration-actions/script.js
@@ -138,6 +138,26 @@ app.component('registration-actions', {
                 return this.text('Espaço');
             }
 
+            if (field == 'workplan') {
+                return this.text('Plano de metas');
+            }
+
+            if (field == 'projectDuration') {
+                return this.text('Duração do projeto (meses)');
+            }
+
+            if (field == 'culturalArtisticSegment') {
+                return this.text('Segmento artistico-cultural');
+            }
+
+            if (field == 'goal') {
+                return this.text('Meta');
+            }
+
+            if (field == 'delivery') {
+                return this.text('Entrega');
+            }
+
             if (field.slice(0, 6) == 'field_') {
                 for (let regField of this.fields) {
                     if (regField.fieldName == field) {
@@ -251,6 +271,17 @@ app.component('registration-actions', {
                             validationErrors[field.step.id][fieldName] = fieldError;
                         }
                     }
+                }
+
+                if (['workplan', 'goal', 'delivery', 'projectDuration', 'culturalArtisticSegment'].includes(fieldName)) {
+                    const keys = Object.keys(validationErrors);
+                    const lastStep = keys[keys.length - 1]; 
+
+                   if (this.fields.length > 0) {
+                        validationErrors[lastStep][fieldName] = fieldError;
+                   } else {
+                        validationErrors[Object.keys(validationErrors)[0]][fieldName] = fieldError;
+                   }
                 }
             }
 

--- a/src/modules/Opportunities/components/registration-actions/texts.php
+++ b/src/modules/Opportunities/components/registration-actions/texts.php
@@ -11,4 +11,9 @@ return [
     'Corrija os erros indicados' => i::__('Corrija os erros indicados'),
     'Enviando' => i::__('Enviando'),
     'Validando' => i::__('Validando'),
+    'Plano de metas' => i::__('Plano de metas'),
+    'Duração do projeto (meses)' => i::__('Duração do projeto (meses)'),
+    'Segmento artistico-cultural' => i::__('Segmento artistico-cultural'),
+    'Meta' => i::__('Meta'),
+    'Entrega' => i::__('Entrega'),
 ];

--- a/src/modules/Opportunities/components/registration-autosave-notification/template.php
+++ b/src/modules/Opportunities/components/registration-autosave-notification/template.php
@@ -13,6 +13,7 @@ mc-alert
 ?>
 <div>
     <mc-alert type="warning">
-        <p class="warning"> <?= $this->text('registration_alert_message', i::__('Os dados da sua inscrição serão salvos automaticamente a cada {{resultTime}} segundos.'))?></p>
+    <p class="warning" v-if="!registration.opportunity.enableWorkplan"> <?php i::_e('Os dados da sua inscrição serão salvos automaticamente a cada {{resultTime}} segundos.')?></p>
+    <p class="warning" v-if="registration.opportunity.enableWorkplan"> <?php i::_e('Os dados da sua inscrição serão salvos automaticamente a cada {{resultTime}} segundos, exceto o plano de metas.')?></p>
     </mc-alert>
 </div>

--- a/src/modules/Opportunities/views/registration/registration-print.php
+++ b/src/modules/Opportunities/views/registration/registration-print.php
@@ -35,6 +35,7 @@ $this->enqueueScript('app-v2', 'registration-print', 'js/registration-print.js')
     <mc-summary-project :entity="entity" classes="col-12"></mc-summary-project>
 
     <section class="col-12 section">
+        <?php $this->applyTemplateHook('section', 'begin') ?>
         <div class="section__content">
             <div class="card owner">
 
@@ -53,5 +54,6 @@ $this->enqueueScript('app-v2', 'registration-print', 'js/registration-print.js')
                 
             </div>
         </div>
+        <?php $this->applyTemplateHook('section', 'end') ?>
     </section>
 </main>

--- a/src/modules/OpportunityWorkplan/Controllers/Workplan.php
+++ b/src/modules/OpportunityWorkplan/Controllers/Workplan.php
@@ -1,0 +1,112 @@
+<?php
+
+namespace OpportunityWorkplan\Controllers;
+
+use MapasCulturais\App;
+use MapasCulturais\Entities\Registration;
+use OpportunityWorkplan\Entities\Delivery;
+use OpportunityWorkplan\Entities\Workplan as EntitiesWorkplan;
+use OpportunityWorkplan\Entities\Goal;
+use OpportunityWorkplan\Services\WorkplanService;
+
+class Workplan extends \MapasCulturais\Controller
+{
+    public function GET_index()
+    {
+        $this->requireAuthentication();
+
+        $app = App::i();
+
+        if (!$this->data['id']) {
+            $app->pass();
+        }
+
+        $registration = $app->repo(Registration::class)->find($this->data['id']);
+        $workplan = $app->repo(EntitiesWorkplan::class)->findOneBy(['registration' => $registration->id]);
+
+        $data = [
+            'workplan' => null
+        ];
+
+        if ($workplan) {
+            $data = [
+                'workplan' => $workplan->jsonSerialize(),
+            ];
+        }
+
+
+        $this->json($data);
+    }
+
+    public function POST_save()
+    {
+        $this->requireAuthentication();
+
+        $app = App::i();
+
+        $app->disableAccessControl();
+
+        if (!$this->data['registrationId']) {
+            $app->pass();
+        }
+
+        $registration = $app->repo(Registration::class)->find($this->data['registrationId']);
+        $workplan = $app->repo(EntitiesWorkplan::class)->findOneBy(['registration' => $registration->id]);
+        $app->em->beginTransaction();
+        try {
+            $workplanService = new WorkplanService();
+            $workplan = $workplanService->save($registration, $workplan, $this->data);
+            $app->em->commit();
+        } catch (\Exception $e) {
+            $app->em->rollback();
+            $this->json(['error' => $e->getMessage()], 400);
+        }
+
+        $app->enableAccessControl();
+
+        $this->json([
+            'workplan' => $workplan->jsonSerialize(),
+        ]);
+    }
+
+
+    public function DELETE_goal()
+    {
+        $this->requireAuthentication();
+
+        $app = App::i();
+
+        if (!$this->data['id']) {
+            $app->pass();
+        }
+
+        $goal = $app->repo(Goal::class)->find($this->data['id']);
+
+        if ($goal) {
+            $app->em->remove($goal);
+            $app->em->flush();
+
+            $this->json(true);
+        }
+    }
+
+    public function DELETE_delivery()
+    {
+        $this->requireAuthentication();
+
+        $app = App::i();
+
+        if (!$this->data['id']) {
+            $app->pass();
+        }
+
+        $delivery = $app->repo(Delivery::class)->find($this->data['id']);
+
+        if ($delivery) {
+            $app->em->remove($delivery);
+            $app->em->flush();
+
+            $this->json(true);
+        }
+    }
+}

--- a/src/modules/OpportunityWorkplan/Entities/Delivery.php
+++ b/src/modules/OpportunityWorkplan/Entities/Delivery.php
@@ -1,0 +1,75 @@
+<?php
+namespace OpportunityWorkplan\Entities;
+
+use Doctrine\ORM\Mapping as ORM;
+
+use MapasCulturais\Traits\EntityMetadata;
+use MapasCulturais\Traits\EntityOwnerAgent;
+
+/**
+ * 
+ * @ORM\Table(name="registration_workplan_goal_delivery")
+ * @ORM\Entity
+ * @ORM\entity(repositoryClass="MapasCulturais\Repository")
+ */
+class Delivery extends \MapasCulturais\Entity {
+
+    use EntityMetadata,
+        EntityOwnerAgent;
+
+    /**
+     *
+     * @ORM\Id
+     * @ORM\Column(type="integer")
+     * @ORM\GeneratedValue(strategy="IDENTITY")
+     */
+    protected $id;
+
+    /**
+     * @var \MapasCulturais\Entities\Agent
+     *
+     * @ORM\ManyToOne(targetEntity="MapasCulturais\Entities\Agent", fetch="LAZY")
+     * @ORM\JoinColumns({
+     *   @ORM\JoinColumn(name="agent_id", referencedColumnName="id", onDelete="CASCADE")
+     * })
+     */
+    protected $owner;
+
+    /**
+     *
+     * @ORM\ManyToOne(targetEntity=\OpportunityWorkplan\Entities\Goal::class, inversedBy="deliveries"))
+     * @ORM\JoinColumns({
+     *   @ORM\JoinColumn(name="goal_id", referencedColumnName="id", nullable=false, onDelete="CASCADE")
+     * })
+     */
+    protected $goal;
+
+    /**
+    * @ORM\OneToMany(targetEntity=\OpportunityWorkplan\Entities\DeliveryMeta::class, mappedBy="owner", cascade={"remove","persist"}, orphanRemoval=true)
+    */
+    protected $__metadata;
+
+    /**
+     * @var \DateTime
+     *
+     * @ORM\Column(name="create_timestamp", type="datetime", nullable=false)
+     */
+    protected $createTimestamp;
+
+        /**
+     * @var \DateTime
+     *
+     * @ORM\Column(name="update_timestamp", type="datetime", nullable=true)
+     */
+    protected $updateTimestamp;
+
+    public function jsonSerialize(): array
+    {
+        $metadatas = $this->getMetadata();
+
+        return [
+            'id' => $this->id,
+            ...$metadatas
+        ];
+    }
+}

--- a/src/modules/OpportunityWorkplan/Entities/DeliveryMeta.php
+++ b/src/modules/OpportunityWorkplan/Entities/DeliveryMeta.php
@@ -1,0 +1,95 @@
+<?php
+
+namespace OpportunityWorkplan\Entities;
+
+use Doctrine\ORM\Mapping as ORM;
+
+use MapasCulturais\App;
+
+/**
+ * Delivery
+ *
+ * @ORM\Table(name="registration_workplan_goal_delivery_meta")
+ * @ORM\Entity
+ * @ORM\entity(repositoryClass="MapasCulturais\Repository")
+ */
+class DeliveryMeta extends \MapasCulturais\Entity {
+    /**
+     * @ORM\Id
+     * @ORM\Column(type="integer")
+     * @ORM\GeneratedValue(strategy="IDENTITY")
+     */
+    public $id;
+
+    /**
+     * @var string
+     *
+     * @ORM\Column(name="key", type="string", nullable=false)
+     */
+    public $key;
+
+    /**
+     * @var string
+     *
+     * @ORM\Column(name="value", type="text", nullable=true)
+     */
+    protected $value;
+
+    /**
+     * @var \OpportunityWorkplan\Entities\Delivery
+     *
+     * @ORM\ManyToOne(targetEntity=\OpportunityWorkplan\Entities\Delivery::class)
+     * @ORM\JoinColumns({
+     *   @ORM\JoinColumn(name="object_id", referencedColumnName="id", nullable=false, onDelete="CASCADE")
+     * })
+     */
+    protected $owner;
+
+
+    /** @ORM\PrePersist */
+    public function _prePersist($args = null){
+        App::i()->applyHookBoundTo($this, 'entity(Delivery).meta(' . $this->key . ').insert:before');
+    }
+    /** @ORM\PostPersist */
+    public function _postPersist($args = null){
+        App::i()->applyHookBoundTo($this, 'entity(Delivery).meta(' . $this->key . ').insert:after');
+    }
+
+    /** @ORM\PreRemove */
+    public function _preRemove($args = null){
+        App::i()->applyHookBoundTo($this, 'entity(Delivery).meta(' . $this->key . ').remove:before');
+    }
+    /** @ORM\PostRemove */
+    public function _postRemove($args = null){
+        App::i()->applyHookBoundTo($this, 'entity(Delivery).meta(' . $this->key . ').remove:after');
+    }
+
+    /** @ORM\PreUpdate */
+    public function _preUpdate($args = null){
+        App::i()->applyHookBoundTo($this, 'entity(Delivery).meta(' . $this->key . ').update:before');
+    }
+    /** @ORM\PostUpdate */
+    public function _postUpdate($args = null){
+        App::i()->applyHookBoundTo($this, 'entity(Delivery).meta(' . $this->key . ').update:after');
+    }
+
+    //============================================================= //
+    // The following lines ara used by MapasCulturais hook system.
+    // Please do not change them.
+    // ============================================================ //
+
+    /** @ORM\PrePersist */
+    public function prePersist($args = null){ parent::prePersist($args); }
+    /** @ORM\PostPersist */
+    public function postPersist($args = null){ parent::postPersist($args); }
+
+    /** @ORM\PreRemove */
+    public function preRemove($args = null){ parent::preRemove($args); }
+    /** @ORM\PostRemove */
+    public function postRemove($args = null){ parent::postRemove($args); }
+
+    /** @ORM\PreUpdate */
+    public function preUpdate($args = null){ parent::preUpdate($args); }
+    /** @ORM\PostUpdate */
+    public function postUpdate($args = null){ parent::postUpdate($args); }
+}

--- a/src/modules/OpportunityWorkplan/Entities/Goal.php
+++ b/src/modules/OpportunityWorkplan/Entities/Goal.php
@@ -1,0 +1,100 @@
+<?php
+namespace OpportunityWorkplan\Entities;
+
+use Doctrine\ORM\Mapping as ORM;
+use Doctrine\Common\Collections\ArrayCollection;
+use Doctrine\Common\Collections\Collection;
+
+use MapasCulturais\Traits\EntityMetadata;
+use MapasCulturais\Traits\EntityOwnerAgent;
+
+/**
+ * 
+ * @ORM\Table(name="registration_workplan_goal")
+ * @ORM\Entity
+ * @ORM\entity(repositoryClass="MapasCulturais\Repository")
+ */
+class Goal extends \MapasCulturais\Entity {
+
+
+    use EntityMetadata,
+        EntityOwnerAgent;
+
+    /**
+     *
+     * @ORM\Id
+     * @ORM\Column(type="integer")
+     * @ORM\GeneratedValue(strategy="IDENTITY")
+     */
+    protected $id;
+
+    /**
+     * @var \MapasCulturais\Entities\Agent
+     *
+     * @ORM\ManyToOne(targetEntity="MapasCulturais\Entities\Agent", fetch="LAZY")
+     * @ORM\JoinColumns({
+     *   @ORM\JoinColumn(name="agent_id", referencedColumnName="id", onDelete="CASCADE")
+     * })
+     */
+    protected $owner;
+
+    /**
+     *
+     * @ORM\ManyToOne(targetEntity=\OpportunityWorkplan\Entities\Workplan::class, inversedBy="goals"))
+     * @ORM\JoinColumns({
+     *   @ORM\JoinColumn(name="workplan_id", referencedColumnName="id", nullable=false, onDelete="CASCADE")
+     * })
+     */
+    protected $workplan;
+
+    /**
+    * @ORM\OneToMany(targetEntity=\OpportunityWorkplan\Entities\Delivery::class, mappedBy="goal", cascade={"persist", "remove"}, orphanRemoval=true)
+    */
+    protected $deliveries;
+
+    /**
+    * @ORM\OneToMany(targetEntity=\OpportunityWorkplan\Entities\GoalMeta::class, mappedBy="owner", cascade={"remove","persist"}, orphanRemoval=true)
+    */
+    protected $__metadata;
+
+       /**
+     * @var \DateTime
+     *
+     * @ORM\Column(name="create_timestamp", type="datetime", nullable=false)
+     */
+    protected $createTimestamp;
+
+        /**
+     * @var \DateTime
+     *
+     * @ORM\Column(name="update_timestamp", type="datetime", nullable=true)
+     */
+    protected $updateTimestamp;
+
+    public function getDeliveries(): Collection
+    {
+        return $this->deliveries;
+    }
+
+    public function __construct() {
+        $this->deliveries = new ArrayCollection();
+        parent::__construct();
+    }
+
+    public function jsonSerialize(): array
+    {
+        $sortedDeliveries = $this->deliveries->toArray();
+
+        usort($sortedDeliveries, function ($a, $b) {
+            return $a->id <=> $b->id;
+        });
+
+        $metadatas = $this->getMetadata();
+
+        return [
+            'id' => $this->id,
+            'deliveries' => $sortedDeliveries,
+            ...$metadatas
+        ];
+    }
+}

--- a/src/modules/OpportunityWorkplan/Entities/GoalMeta.php
+++ b/src/modules/OpportunityWorkplan/Entities/GoalMeta.php
@@ -1,0 +1,95 @@
+<?php
+
+namespace OpportunityWorkplan\Entities;
+
+use Doctrine\ORM\Mapping as ORM;
+
+use MapasCulturais\App;
+
+/**
+ * GoalMeta
+ *
+ * @ORM\Table(name="registration_workplan_goal_meta")
+ * @ORM\Entity
+ * @ORM\entity(repositoryClass="MapasCulturais\Repository")
+ */
+class GoalMeta extends \MapasCulturais\Entity {
+    /**
+     * @ORM\Id
+     * @ORM\Column(type="integer")
+     * @ORM\GeneratedValue(strategy="IDENTITY")
+     */
+    public $id;
+
+    /**
+     * @var string
+     *
+     * @ORM\Column(name="key", type="string", nullable=false)
+     */
+    public $key;
+
+    /**
+     * @var string
+     *
+     * @ORM\Column(name="value", type="text", nullable=true)
+     */
+    protected $value;
+
+    /**
+     * @var \OpportunityWorkplan\Entities\Goal
+     *
+     * @ORM\ManyToOne(targetEntity=\OpportunityWorkplan\Entities\Goal::class)
+     * @ORM\JoinColumns({
+     *   @ORM\JoinColumn(name="object_id", referencedColumnName="id", nullable=false, onDelete="CASCADE")
+     * })
+     */
+    protected $owner;
+
+
+    /** @ORM\PrePersist */
+    public function _prePersist($args = null){
+        App::i()->applyHookBoundTo($this, 'entity(goal).meta(' . $this->key . ').insert:before');
+    }
+    /** @ORM\PostPersist */
+    public function _postPersist($args = null){
+        App::i()->applyHookBoundTo($this, 'entity(goal).meta(' . $this->key . ').insert:after');
+    }
+
+    /** @ORM\PreRemove */
+    public function _preRemove($args = null){
+        App::i()->applyHookBoundTo($this, 'entity(goal).meta(' . $this->key . ').remove:before');
+    }
+    /** @ORM\PostRemove */
+    public function _postRemove($args = null){
+        App::i()->applyHookBoundTo($this, 'entity(goal).meta(' . $this->key . ').remove:after');
+    }
+
+    /** @ORM\PreUpdate */
+    public function _preUpdate($args = null){
+        App::i()->applyHookBoundTo($this, 'entity(goal).meta(' . $this->key . ').update:before');
+    }
+    /** @ORM\PostUpdate */
+    public function _postUpdate($args = null){
+        App::i()->applyHookBoundTo($this, 'entity(goal).meta(' . $this->key . ').update:after');
+    }
+
+    //============================================================= //
+    // The following lines ara used by MapasCulturais hook system.
+    // Please do not change them.
+    // ============================================================ //
+
+    /** @ORM\PrePersist */
+    public function prePersist($args = null){ parent::prePersist($args); }
+    /** @ORM\PostPersist */
+    public function postPersist($args = null){ parent::postPersist($args); }
+
+    /** @ORM\PreRemove */
+    public function preRemove($args = null){ parent::preRemove($args); }
+    /** @ORM\PostRemove */
+    public function postRemove($args = null){ parent::postRemove($args); }
+
+    /** @ORM\PreUpdate */
+    public function preUpdate($args = null){ parent::preUpdate($args); }
+    /** @ORM\PostUpdate */
+    public function postUpdate($args = null){ parent::postUpdate($args); }
+}

--- a/src/modules/OpportunityWorkplan/Entities/Workplan.php
+++ b/src/modules/OpportunityWorkplan/Entities/Workplan.php
@@ -1,0 +1,105 @@
+<?php
+namespace OpportunityWorkplan\Entities;
+
+use Doctrine\ORM\Mapping as ORM;
+use Doctrine\Common\Collections\ArrayCollection;
+use Doctrine\Common\Collections\Collection;
+use MapasCulturais\Traits\EntityMetadata;
+use MapasCulturais\Traits\EntityOwnerAgent;
+
+/**
+ * 
+ * @ORM\Table(name="registration_workplan")
+ * @ORM\Entity
+ * @ORM\entity(repositoryClass="MapasCulturais\Repository")
+ */
+class Workplan extends \MapasCulturais\Entity {
+
+    use EntityMetadata,
+        EntityOwnerAgent;
+    
+
+    /**
+     *
+     * @ORM\Id
+     * @ORM\Column(type="integer")
+     * @ORM\GeneratedValue(strategy="IDENTITY")
+     */
+    protected $id;
+
+    /**
+     * @var \MapasCulturais\Entities\Agent
+     *
+     * @ORM\ManyToOne(targetEntity="MapasCulturais\Entities\Agent", fetch="LAZY")
+     * @ORM\JoinColumns({
+     *   @ORM\JoinColumn(name="agent_id", referencedColumnName="id", onDelete="CASCADE")
+     * })
+     */
+    protected $owner;
+    
+    /**
+     * @var \MapasCulturais\Entities\Registration
+     *
+     * @ORM\ManyToOne(targetEntity="MapasCulturais\Entities\Registration")
+     * @ORM\JoinColumns({
+     *   @ORM\JoinColumn(name="registration_id", referencedColumnName="id", nullable=false, onDelete="CASCADE")
+     * })
+     */
+    protected $registration;
+
+    /**
+    * @ORM\OneToMany(targetEntity=\OpportunityWorkplan\Entities\Goal::class, mappedBy="workplan", cascade={"persist", "remove"}, orphanRemoval=true)
+    */
+    protected $goals;
+
+    /**
+    * @ORM\OneToMany(targetEntity=\OpportunityWorkplan\Entities\WorkplanMeta::class, mappedBy="owner", cascade={"remove","persist"}, orphanRemoval=true)
+    */
+    protected $__metadata;
+
+    /**
+     * @var \DateTime
+     *
+     * @ORM\Column(name="create_timestamp", type="datetime", nullable=false)
+     */
+    protected $createTimestamp;
+
+        /**
+     * @var \DateTime
+     *
+     * @ORM\Column(name="update_timestamp", type="datetime", nullable=true)
+     */
+    protected $updateTimestamp;
+    
+
+    public function getGoals(): Collection
+    {
+        return $this->goals;
+    }
+
+    public function __construct() {
+        $this->goals = new ArrayCollection();
+        parent::__construct();
+    }
+
+    public function jsonSerialize(): array
+    {
+        $metadatas = $this->getMetadata();
+
+        $sortedGoals = $this->goals->toArray();
+
+        usort($sortedGoals, function ($a, $b) {
+            return $a->id <=> $b->id;
+        });
+
+        return [
+            'id' => $this->id,
+            'registrationId' => $this->registration->id,
+            'registration' => $this->registration,
+            'goals' => $sortedGoals,
+            ...$metadatas
+        ];
+    }
+
+
+}

--- a/src/modules/OpportunityWorkplan/Entities/WorkplanMeta.php
+++ b/src/modules/OpportunityWorkplan/Entities/WorkplanMeta.php
@@ -1,0 +1,95 @@
+<?php
+
+namespace OpportunityWorkplan\Entities;
+
+use Doctrine\ORM\Mapping as ORM;
+
+use MapasCulturais\App;
+
+/**
+ * WorkplanMeta
+ *
+ * @ORM\Table(name="registration_workplan_meta")
+ * @ORM\Entity
+ * @ORM\entity(repositoryClass="MapasCulturais\Repository")
+ */
+class WorkplanMeta extends \MapasCulturais\Entity {
+    /**
+     * @ORM\Id
+     * @ORM\Column(type="integer")
+     * @ORM\GeneratedValue(strategy="IDENTITY")
+     */
+    public $id;
+
+    /**
+     * @var string
+     *
+     * @ORM\Column(name="key", type="string", nullable=false)
+     */
+    public $key;
+
+    /**
+     * @var string
+     *
+     * @ORM\Column(name="value", type="text", nullable=true)
+     */
+    protected $value;
+
+    /**
+     * @var \OpportunityWorkplan\Entities\Workplan
+     *
+     * @ORM\ManyToOne(targetEntity=\OpportunityWorkplan\Entities\Workplan::class)
+     * @ORM\JoinColumns({
+     *   @ORM\JoinColumn(name="object_id", referencedColumnName="id", nullable=false, onDelete="CASCADE")
+     * })
+     */
+    protected $owner;
+
+
+    /** @ORM\PrePersist */
+    public function _prePersist($args = null){
+        App::i()->applyHookBoundTo($this, 'entity(workplan).meta(' . $this->key . ').insert:before');
+    }
+    /** @ORM\PostPersist */
+    public function _postPersist($args = null){
+        App::i()->applyHookBoundTo($this, 'entity(workplan).meta(' . $this->key . ').insert:after');
+    }
+
+    /** @ORM\PreRemove */
+    public function _preRemove($args = null){
+        App::i()->applyHookBoundTo($this, 'entity(workplan).meta(' . $this->key . ').remove:before');
+    }
+    /** @ORM\PostRemove */
+    public function _postRemove($args = null){
+        App::i()->applyHookBoundTo($this, 'entity(workplan).meta(' . $this->key . ').remove:after');
+    }
+
+    /** @ORM\PreUpdate */
+    public function _preUpdate($args = null){
+        App::i()->applyHookBoundTo($this, 'entity(workplan).meta(' . $this->key . ').update:before');
+    }
+    /** @ORM\PostUpdate */
+    public function _postUpdate($args = null){
+        App::i()->applyHookBoundTo($this, 'entity(workplan).meta(' . $this->key . ').update:after');
+    }
+
+    //============================================================= //
+    // The following lines ara used by MapasCulturais hook system.
+    // Please do not change them.
+    // ============================================================ //
+
+    /** @ORM\PrePersist */
+    public function prePersist($args = null){ parent::prePersist($args); }
+    /** @ORM\PostPersist */
+    public function postPersist($args = null){ parent::postPersist($args); }
+
+    /** @ORM\PreRemove */
+    public function preRemove($args = null){ parent::preRemove($args); }
+    /** @ORM\PostRemove */
+    public function postRemove($args = null){ parent::postRemove($args); }
+
+    /** @ORM\PreUpdate */
+    public function preUpdate($args = null){ parent::preUpdate($args); }
+    /** @ORM\PostUpdate */
+    public function postUpdate($args = null){ parent::postUpdate($args); }
+}

--- a/src/modules/OpportunityWorkplan/Module.php
+++ b/src/modules/OpportunityWorkplan/Module.php
@@ -1,0 +1,521 @@
+<?php
+namespace OpportunityWorkplan;
+
+use MapasCulturais\App,
+    MapasCulturais\i;
+use OpportunityWorkplan\Controllers\Workplan as ControllersWorkplan;
+use OpportunityWorkplan\Entities\Workplan;
+use OpportunityWorkplan\Entities\Goal;
+use MapasCulturais\Definitions\Metadata;
+use OpportunityWorkplan\Entities\Delivery;
+
+class Module extends \MapasCulturais\Module{
+    function _init(){
+        $app = App::i();
+
+        $app->hook('app.init:after', function () use($app) {
+            $app->hook("template(opportunity.edit.opportunity-data-collection-config-form):after", function(){
+                $this->part('opportunity-workplan-config');
+            });
+
+            $app->hook("component(registration-form):after", function(){
+                $this->part('registration-workplan');
+            });
+
+            $app->hook("template(registration.view.registration-form-view):after", function(){
+                $this->part('registration-details-workplan');
+            });
+
+            $app->hook("entity(Registration).sendValidationErrors", function (&$errorsResult) use($app) {
+                $registration = $this;
+
+                if ($registration->opportunity->enableWorkplan) {
+                    $workplan = $app->repo(Workplan::class)->findOneBy(['registration' => $registration->id]);
+
+                    $errors = [];
+
+                    if (!$workplan) {
+                        $errors['workplan'] = [i::__('Plano de metas obrigatório.')];
+                    }
+
+                    if (!$workplan?->projectDuration) {
+                        $errors['projectDuration'] = [i::__('Plano de metas - Duração do projeto (meses) obrigatório.')];
+                    }
+
+                    if (!$workplan?->culturalArtisticSegment) {
+                        $errors['culturalArtisticSegment'] = [i::__('Plano de metas - Segmento artistico-cultural obrigatório.')];
+                    }
+                   
+                    if ($workplan?->goals->isEmpty()) {
+                        $errors['goal'] = [i::__('Meta do plano de metas obrigatório.')];
+                    }
+
+                    if ($registration->opportunity->workplan_deliveryReportTheDeliveriesLinkedToTheGoals) {
+                        if (is_iterable($workplan?->goals)) {
+                            foreach ($workplan?->goals as $goal) {
+                                if ($goal?->deliveries->isEmpty()) {
+                                    $errors['delivery'] = [i::__('Entrega da meta do plano de metas obrigatório.')];
+                                }
+                            }
+                        }
+                    }                   
+
+                    $errorsResult = [...$errors];
+                }               
+            });
+
+            $app->hook("template(registration.registrationPrint.section):end", function(){
+                $this->part('registration-details-workplan-print');
+            });
+        });
+    }
+
+    function register()
+    {
+        $app = App::i();
+
+        $app->registerController('workplan', ControllersWorkplan::class);
+       
+        $this->registerOpportunityMetadata('workplanLabelDefault', [
+            'label' => i::__('Plano de metas label'),
+            'default_value' => 'Plano de metas'
+        ]);
+
+        $this->registerOpportunityMetadata('goalLabelDefault', [
+            'label' => i::__('Meta label'),
+            'default_value' => 'Metas'
+        ]);
+
+        $this->registerOpportunityMetadata('deliveryLabelDefault', [
+            'label' => i::__('Entrega label'),
+            'default_value' => 'Entregas '
+        ]);
+
+        // metadados opportunity
+        $this->registerOpportunityMetadata('enableWorkplan', [
+            'label' => i::__('Habilitar plano de metas'),
+            'type' => 'boolean',
+            'default_value' => false
+        ]);
+
+         
+        $this->registerOpportunityMetadata('workplan_dataProjectlimitMaximumDurationOfProjects', [
+            'label' => i::__('Limitar duração máxima dos projetos'),
+            'type' => 'boolean',
+            'default_value' => false
+        ]);
+
+        
+        $this->registerOpportunityMetadata('workplan_dataProjectmaximumDurationInMonths', [
+            'label' => i::__('Duração máxima em meses'),
+            'type' => 'integer',
+            'default' => 1
+        ]);
+
+        
+        $this->registerOpportunityMetadata('workplan_metaInformTheStageOfCulturalMaking', [
+            'label' => i::__('Informar a etapa do fazer cultural'),
+            'type' => 'boolean',
+            'default_value' => false
+        ]);        
+        
+        $this->registerOpportunityMetadata('workplan_metaLimitNumberOfGoals', [
+            'label' => i::__('Limitar número de metas'),
+            'type' => 'boolean',
+            'default_value' => false
+        ]);
+
+         
+        $this->registerOpportunityMetadata('workplan_metaMaximumNumberOfGoals', [
+            'label' => i::__('Número máximo de metas'),
+            'type' => 'integer',
+            'default' => 1
+        ]);
+
+         
+        $this->registerOpportunityMetadata('workplan_deliveryReportTheDeliveriesLinkedToTheGoals', [
+            'label' => i::__('Informar as entregas vinculadas à meta'),
+            'type' => 'boolean',
+            'default_value' => false
+        ]);
+
+         
+        $this->registerOpportunityMetadata('workplan_deliveryLimitNumberOfDeliveries', [
+            'label' => i::__('Limitar número de entregas'),
+            'type' => 'boolean',
+            'default_value' => false
+        ]);
+
+         
+        $this->registerOpportunityMetadata('workplan_deliveryMaximumNumberOfDeliveries', [
+            'label' => i::__('Número máximo de entregas'),
+            'type' => 'integer',
+            'default' => 1
+        ]);
+         
+        $this->registerOpportunityMetadata('workplan_registrationReportTheNumberOfParticipants', [
+            'label' => i::__('Informar a quantidade estimada de público'),
+            'type' => 'boolean',
+            'default_value' => false
+        ]);
+
+        $this->registerOpportunityMetadata('workplan_registrationInformCulturalArtisticSegment', [
+            'label' => i::__('Informar segmento artístico-cultural'),
+            'type' => 'boolean',
+            'default_value' => false
+        ]);
+         
+        $this->registerOpportunityMetadata('workplan_registrationReportExpectedRenevue', [
+            'label' => i::__('Informar receita prevista'),
+            'type' => 'boolean',
+            'default_value' => false
+        ]);
+
+        $this->registerOpportunityMetadata('workplan_monitoringInformTheFormOfAvailability', [
+            'label' => i::__('Informar forma de disponibilização'),
+            'type' => 'boolean',
+            'default_value' => false
+        ]);
+
+        $this->registerOpportunityMetadata('workplan_monitoringEnterDeliverySubtype', [
+            'label' => i::__('Informar subtipo de entrega'),
+            'type' => 'boolean',
+            'default_value' => false
+        ]);
+
+        $this->registerOpportunityMetadata('workplan_monitoringInformAccessibilityMeasures', [
+            'label' => i::__('Informar as medidas de acessibilidade'),
+            'type' => 'boolean',
+            'default_value' => false
+        ]);
+        
+        $this->registerOpportunityMetadata('workplan_monitoringInformThePriorityTerritories', [
+            'label' => i::__('Informar os territórios prioritários'),
+            'type' => 'boolean',
+            'default_value' => false
+        ]);
+        
+        $this->registerOpportunityMetadata('workplan_monitoringProvideTheProfileOfParticipants', [
+            'label' => i::__('Informar o perfil do público'),
+            'type' => 'boolean',
+            'default_value' => false
+        ]);
+
+        $this->registerOpportunityMetadata('workplan_monitoringInformThePriorityAudience', [
+            'label' => i::__('Informar o público prioritário'),
+            'type' => 'boolean',
+            'default_value' => false
+        ]);
+
+        $this->registerOpportunityMetadata('workplan_monitoringReportExecutedRevenue', [
+            'label' => i::__('Informar receita executada'),
+            'type' => 'boolean',
+            'default_value' => false
+        ]);
+
+        // metadados workplan
+        $projectDuration = new Metadata('projectDuration', ['label' => \MapasCulturais\i::__('Duração do projeto (meses)')]);
+        $app->registerMetadata($projectDuration, Workplan::class);
+
+        $culturalArtisticSegment = new Metadata('culturalArtisticSegment', [
+            'label' => \MapasCulturais\i::__('Segmento artistico-cultural'),
+            'type' => 'select',
+            'options' => array(
+                \MapasCulturais\i::__('Artes Visuais'),
+                \MapasCulturais\i::__('Artesanato'),
+                \MapasCulturais\i::__('Audiovisual e Mídias Interativas'),
+                \MapasCulturais\i::__('Circo'),
+                \MapasCulturais\i::__('Culturas dos Povos Originários'),
+                \MapasCulturais\i::__('Culturas Tradicionais e Populares'),
+                \MapasCulturais\i::__('Dança'),
+                \MapasCulturais\i::__('Design e Serviços Criativos'),
+                \MapasCulturais\i::__('Economia, Produção e Áreas Técnicas da Cultura'),
+                \MapasCulturais\i::__('Festas Populares'),
+                \MapasCulturais\i::__('Humanidades'),
+                \MapasCulturais\i::__('Livro, Leitura e Literatura'),
+                \MapasCulturais\i::__('Música'),
+                \MapasCulturais\i::__('Patrimônio Cultural Imaterial'),
+                \MapasCulturais\i::__('Patrimônio Cultural Material'),
+                \MapasCulturais\i::__('Performance'),
+                \MapasCulturais\i::__('Teatro'),
+                \MapasCulturais\i::__('Transversalidades'),
+            ),
+        ]);
+        $app->registerMetadata($culturalArtisticSegment, Workplan::class);
+
+        // metadados goal
+        $monthInitial = new Metadata('monthInitial', ['label' => \MapasCulturais\i::__('Mês inicial')]);
+        $app->registerMetadata($monthInitial, Goal::class);
+
+        $monthEnd = new Metadata('monthEnd', ['label' => \MapasCulturais\i::__('Mês final')]);
+        $app->registerMetadata($monthEnd, Goal::class);
+
+        $title = new Metadata('title', ['label' => \MapasCulturais\i::__('Título da meta')]);
+        $app->registerMetadata($title, Goal::class);
+
+        $description = new Metadata('description', ['label' => \MapasCulturais\i::__('Descrição')]);
+        $app->registerMetadata($description, Goal::class);
+
+
+        $culturalMakingStage = new Metadata('culturalMakingStage', [
+            'label' => \MapasCulturais\i::__('Etapa do fazer cultural'),
+            'type' => 'select',
+            'options' => array(
+                \MapasCulturais\i::__('Criação, invenção e inovação'),
+                \MapasCulturais\i::__('Difusão, divulgação'),
+                \MapasCulturais\i::__('Formação e transmissão'),
+                \MapasCulturais\i::__('Intercâmbios, trocas e cooperação'),
+                \MapasCulturais\i::__('Análise, crítica, estudo, investigação, pesquisa e reflexão'),
+                \MapasCulturais\i::__('Fruição, consumo e circulação'),
+                \MapasCulturais\i::__('Conservação, memória e preservação'),
+                \MapasCulturais\i::__('Organização, legislação, gestão, produção da cultura'),
+            ),
+        ]);
+        $app->registerMetadata($culturalMakingStage, Goal::class);
+    
+        // metadados delivery
+        $name = new Metadata('name', ['label' => \MapasCulturais\i::__('Nome da entrega')]);
+        $app->registerMetadata($name, Delivery::class);
+
+        $description = new Metadata('description', ['label' => \MapasCulturais\i::__('Descrição')]);
+        $app->registerMetadata($description, Delivery::class);
+
+        $type = new Metadata('type', ['label' => \MapasCulturais\i::__('Tipo de entrega')]);
+        $app->registerMetadata($type, Delivery::class);
+
+        
+        $typeDelivery = new Metadata('typeDelivery', [
+            'label' => \MapasCulturais\i::__('Tipo entrega'),
+            'type' => 'select',
+            'options' => array(
+                \MapasCulturais\i::__("Acervo cultural adquirido"),
+                \MapasCulturais\i::__("Acervo cultural criado"),
+                \MapasCulturais\i::__("Acervo cultural mantido"),
+                \MapasCulturais\i::__("Ação de formação realizada"),
+                \MapasCulturais\i::__("Adereço criado"),
+                \MapasCulturais\i::__("Agente cultural fomentado"),
+                \MapasCulturais\i::__("Album musical criado"),
+                \MapasCulturais\i::__("Aplicativo criado"),
+                \MapasCulturais\i::__("Apresentação realizada"),
+                \MapasCulturais\i::__("Arte Gráfica criada"),
+                \MapasCulturais\i::__("Arte Visual comercializada"),
+                \MapasCulturais\i::__("Arte Visual criada"),
+                \MapasCulturais\i::__("Artesanato comercializado"),
+                \MapasCulturais\i::__("Artesanato criado"),
+                \MapasCulturais\i::__("Assemblage criada"),
+                \MapasCulturais\i::__("Aula realizada"),
+                \MapasCulturais\i::__("Áudio gravado"),
+                \MapasCulturais\i::__("Audiodescrição criada"),
+                \MapasCulturais\i::__("Audiolivro criado"),
+                \MapasCulturais\i::__("Audiolivro reproduzido"),
+                \MapasCulturais\i::__("Bem cultural adquirido"),
+                \MapasCulturais\i::__("Bem cultural conservado"),
+                \MapasCulturais\i::__("Bem cultural registrado"),
+                \MapasCulturais\i::__("Bem cultural restaurado"),
+                \MapasCulturais\i::__("Bem cultural tombado"),
+                \MapasCulturais\i::__("Biblioteca construída"),
+                \MapasCulturais\i::__("Biblioteca mantida"),
+                \MapasCulturais\i::__("Blog criado"),
+                \MapasCulturais\i::__("Bolsa concedida"),
+                \MapasCulturais\i::__("Capacitação realizada"),
+                \MapasCulturais\i::__("Caricatura criada"),
+                \MapasCulturais\i::__("Cartilha distribuída"),
+                \MapasCulturais\i::__("Cartum criado"),
+                \MapasCulturais\i::__("Catálogo distribuído"),
+                \MapasCulturais\i::__("Cerâmica criada"),
+                \MapasCulturais\i::__("Circulação realizada"),
+                \MapasCulturais\i::__("Concertado realizado"),
+                \MapasCulturais\i::__("Concurso cultural realizado"),
+                \MapasCulturais\i::__("Conferência realizada"),
+                \MapasCulturais\i::__("Congresso realizado"),
+                \MapasCulturais\i::__("Conteúdo cultural digital criado"),
+                \MapasCulturais\i::__("Coreografia criada"),
+                \MapasCulturais\i::__("Curta-metragem criado"),
+                \MapasCulturais\i::__("Curso realizado"),
+                \MapasCulturais\i::__("Desenho criado"),
+                \MapasCulturais\i::__("Design criado"),
+                \MapasCulturais\i::__("Design Gráfico criado"),
+                \MapasCulturais\i::__("Desfile realizado"),
+                \MapasCulturais\i::__("Direito autoral remunerado"),
+                \MapasCulturais\i::__("Disco criado"),
+                \MapasCulturais\i::__("Disco distribuído"),
+                \MapasCulturais\i::__("Documentário criado"),
+                \MapasCulturais\i::__("Dramaturgia criada"),
+                \MapasCulturais\i::__("E-Book criado"),
+                \MapasCulturais\i::__("E-Book disponibilizado"),
+                \MapasCulturais\i::__("Encontro cultural realizado"),
+                \MapasCulturais\i::__("Ensaio aberto realizado"),
+                \MapasCulturais\i::__("Equipamento cultural construído"),
+                \MapasCulturais\i::__("Equipamento cultural mantido"),
+                \MapasCulturais\i::__("Equipamento cultural modernizado"),
+                \MapasCulturais\i::__("Escultura comercializada"),
+                \MapasCulturais\i::__("Escultura criada"),
+                \MapasCulturais\i::__("Espaço cultural construído"),
+                \MapasCulturais\i::__("Espaço cultural mantido"),
+                \MapasCulturais\i::__("Espaço e/ou equipamento cultural construído"),
+                \MapasCulturais\i::__("Espaço e/ou equipamento cultural mantido"),
+                \MapasCulturais\i::__("Espaço e/ou equipamento cultural reformado"),
+                \MapasCulturais\i::__("Espetáculo realizado"),
+                \MapasCulturais\i::__("Evento Cultural realizado"),
+                \MapasCulturais\i::__("Exibição realizada"),
+                \MapasCulturais\i::__("Exposição realizada"),
+                \MapasCulturais\i::__("Fanzine criado"),
+                \MapasCulturais\i::__("Festa popular realizada"),
+                \MapasCulturais\i::__("Feira realizada"),
+                \MapasCulturais\i::__("Ficção criada"),
+                \MapasCulturais\i::__("Figurino criado"),
+                \MapasCulturais\i::__("Filme distribuído"),
+                \MapasCulturais\i::__("Fomento cultural concedido"),
+                \MapasCulturais\i::__("Fotografia criada"),
+                \MapasCulturais\i::__("Game criado"),
+                \MapasCulturais\i::__("Grafitti criado"),
+                \MapasCulturais\i::__("Gravura criada"),
+                \MapasCulturais\i::__("Grupo artístico-cultural fomentado"),
+                \MapasCulturais\i::__("Grupo artístico-cultural mantido"),
+                \MapasCulturais\i::__("História em Quadrinhos criada"),
+                \MapasCulturais\i::__("Ilustração criada"),
+                \MapasCulturais\i::__("Imóvel cultural adquirido"),
+                \MapasCulturais\i::__("Imóvel cultural conservado"),
+                \MapasCulturais\i::__("Imóvel cultural tombado"),
+                \MapasCulturais\i::__("Ingresso comercializado"),
+                \MapasCulturais\i::__("Instalação criada"),
+                \MapasCulturais\i::__("Intercâmbio realizado"),
+                \MapasCulturais\i::__("Inventário cultural criado"),
+                \MapasCulturais\i::__("Inventário cultural mantido"),
+                \MapasCulturais\i::__("Investigações realizada"),
+                \MapasCulturais\i::__("Joia de valor cultural comercializada"),
+                \MapasCulturais\i::__("Joia de valor cultural criada"),
+                \MapasCulturais\i::__("Jornal criado"),
+                \MapasCulturais\i::__("Jornal distribuído"),
+                \MapasCulturais\i::__("Livro criado"),
+                \MapasCulturais\i::__("Livro distribuído"),
+                \MapasCulturais\i::__("Longa-metragem criado"),
+                \MapasCulturais\i::__("Mentoria realizada"),
+                \MapasCulturais\i::__("Mostra realizada"),
+                \MapasCulturais\i::__("Movcéu adquirido"),
+                \MapasCulturais\i::__("Mural criado"),
+                \MapasCulturais\i::__("Música criada"),
+                \MapasCulturais\i::__("Objeto cultural criado"),
+                \MapasCulturais\i::__("Obra audiovisual criada"),
+                \MapasCulturais\i::__("Obra circense criada"),
+                \MapasCulturais\i::__("Obra de dança criada"),
+                \MapasCulturais\i::__("Obra e/ou conteúdo cultural distribuído"),
+                \MapasCulturais\i::__("Obra e/ou conteúdo cultural reproduzido"),
+                \MapasCulturais\i::__("Obra e/ou produto cultural comercializado"),
+                \MapasCulturais\i::__("Obra literária criada"),
+                \MapasCulturais\i::__("Obra musical criada"),
+                \MapasCulturais\i::__("Obra teatral criada"),
+                \MapasCulturais\i::__("Ocupação Criativa realizada"),
+                \MapasCulturais\i::__("Oficina realizada"),
+                \MapasCulturais\i::__("Outra Obra e/ou Conteúdo Cultural Criado"),
+                \MapasCulturais\i::__("Outra Performance e/ou Apresentação Realizada"),
+                \MapasCulturais\i::__("Outra ação de investigação e/ou pesquisa realizada"),
+                \MapasCulturais\i::__("Outra ação de salvaguarda do patrimônio cultural realizada"),
+                \MapasCulturais\i::__("Outra Obra e/ou Conteúdo Cultural Distribuído e/ou Reproduzido"),
+                \MapasCulturais\i::__("Outro Espaço e Equipamento Cultural Criado e/ou Mantido"),
+                \MapasCulturais\i::__("Outro Evento, Festa e/ou Exibição Realizada"),
+                \MapasCulturais\i::__("Outro Programa Educativo e/ou de Formação Realizado"),
+                \MapasCulturais\i::__("Outro fomento e/ou incentivo cultural concedido"),
+                \MapasCulturais\i::__("Parada realizada"),
+                \MapasCulturais\i::__("Patrimônio cultural conservado"),
+                \MapasCulturais\i::__("Patrimônio cultural registrado"),
+                \MapasCulturais\i::__("Patrimônio cultural restaurado"),
+                \MapasCulturais\i::__("Patrimônio cultural tombado"),
+                \MapasCulturais\i::__("Performance realizada"),
+                \MapasCulturais\i::__("Periódico criado"),
+                \MapasCulturais\i::__("Periódico distribuído"),
+                \MapasCulturais\i::__("Pesquisa realizada"),
+                \MapasCulturais\i::__("Pintura criada"),
+                \MapasCulturais\i::__("Plataforma digital criada"),
+                \MapasCulturais\i::__("Podcast criado"),
+                \MapasCulturais\i::__("Podcast reproduzido"),
+                \MapasCulturais\i::__("Poesia criada"),
+                \MapasCulturais\i::__("Premiação cultural concedida"),
+                \MapasCulturais\i::__("Projeto de salvaguarda do patrimônio cultural criado"),
+                \MapasCulturais\i::__("Projeto elaborado"),
+                \MapasCulturais\i::__("Programa de Rádio criado"),
+                \MapasCulturais\i::__("Programa de Rádio reproduzido"),
+                \MapasCulturais\i::__("Programa de TV criado"),
+                \MapasCulturais\i::__("Programa de TV reproduzido"),
+                \MapasCulturais\i::__("Programa educativo realizado"),
+                \MapasCulturais\i::__("Recital realizado"),
+                \MapasCulturais\i::__("Residência artístico-cultural realizada"),
+                \MapasCulturais\i::__("Revista criada"),
+                \MapasCulturais\i::__("Roda de Leitura realizados"),
+                \MapasCulturais\i::__("Romance criado"),
+                \MapasCulturais\i::__("Roteiro criado"),
+                \MapasCulturais\i::__("Sarau realizado"),
+                \MapasCulturais\i::__("Seminário realizado"),
+                \MapasCulturais\i::__("Série criada"),
+                \MapasCulturais\i::__("Show realizado"),
+                \MapasCulturais\i::__("Simpósio realizado"),
+                \MapasCulturais\i::__("Single criado"),
+                \MapasCulturais\i::__("Sítio histórico preservado"),
+                \MapasCulturais\i::__("Site criado"),
+                \MapasCulturais\i::__("Slam realizado"),
+                \MapasCulturais\i::__("Software criado"),
+                \MapasCulturais\i::__("Texto acadêmico elaborado"),
+                \MapasCulturais\i::__("Texto acadêmico publicado"),
+                \MapasCulturais\i::__("Texto cultural criado"),
+                \MapasCulturais\i::__("Trilha Sonora criada"),
+                \MapasCulturais\i::__("Vestuário criado"),
+                \MapasCulturais\i::__("Vídeo criado"),
+                \MapasCulturais\i::__("Videoarte criada"),
+                \MapasCulturais\i::__("Visita Guiada realizada"),
+                \MapasCulturais\i::__("Websérie criada"),
+                \MapasCulturais\i::__("Websérie reproduzida"),
+                \MapasCulturais\i::__("Workshop realizado"),
+            ),
+        ]);
+        $app->registerMetadata($typeDelivery, Delivery::class);
+
+        $segmentDelivery = new Metadata('segmentDelivery', [
+            'label' => \MapasCulturais\i::__('Segmento artístico cultural da entrega'),
+            'type' => 'select',
+            'options' => array(
+                \MapasCulturais\i::__('Artes Visuais'),  
+                \MapasCulturais\i::__('Artesanato'),  
+                \MapasCulturais\i::__('Audiovisual e Mídias Interativas'),  
+                \MapasCulturais\i::__('Circo'),  
+                \MapasCulturais\i::__('Culturas Tradicionais e Populares'),  
+                \MapasCulturais\i::__('Culturas dos Povos Originários'),  
+                \MapasCulturais\i::__('Dança'),  
+                \MapasCulturais\i::__('Design e Serviços Criativos'),  
+                \MapasCulturais\i::__('Economia, Produção e Áreas Técnicas da Cultura'),  
+                \MapasCulturais\i::__('Festas Populares'),  
+                \MapasCulturais\i::__('Humanidades'),  
+                \MapasCulturais\i::__('Livro, Leitura e Literatura'),  
+                \MapasCulturais\i::__('Música'),  
+                \MapasCulturais\i::__('Patrimônio Cultural Imaterial'),  
+                \MapasCulturais\i::__('Patrimônio Cultural Material'),  
+                \MapasCulturais\i::__('Performance'),  
+                \MapasCulturais\i::__('Produção e Áreas Técnicas da Cultura'),  
+                \MapasCulturais\i::__('Teatro'),  
+                \MapasCulturais\i::__('Transversalidades')
+            ),
+        ]);
+        $app->registerMetadata($segmentDelivery, Delivery::class);
+
+        $expectedNumberPeople = new Metadata('expectedNumberPeople', ['label' => \MapasCulturais\i::__('Número previsto de pessoas')]);
+        $app->registerMetadata($expectedNumberPeople, Delivery::class);
+
+        $generaterRevenue = new Metadata('generaterRevenue', [
+            'label' => \MapasCulturais\i::__('A entrega irá gerar receita?'),
+            'type' => 'select',
+            'options' => array(
+                'true' => \MapasCulturais\i::__('Sim'),
+                'false' => \MapasCulturais\i::__('Não'),
+            ),
+        ]);
+        $app->registerMetadata($generaterRevenue, Delivery::class);
+
+        $renevueQtd = new Metadata('renevueQtd', ['label' => \MapasCulturais\i::__('Quantidade')]);
+        $app->registerMetadata($renevueQtd, Delivery::class);
+
+        $unitValueForecast = new Metadata('unitValueForecast', ['label' => \MapasCulturais\i::__('Previsão de valor unitário')]);
+        $app->registerMetadata($unitValueForecast, Delivery::class);
+
+        $totalValueForecast = new Metadata('totalValueForecast', ['label' => \MapasCulturais\i::__('Previsão de valor total')]);
+        $app->registerMetadata($totalValueForecast, Delivery::class);
+    }
+}

--- a/src/modules/OpportunityWorkplan/Services/WorkplanService.php
+++ b/src/modules/OpportunityWorkplan/Services/WorkplanService.php
@@ -1,0 +1,76 @@
+<?php
+
+namespace OpportunityWorkplan\Services;
+
+use MapasCulturais\App;
+use OpportunityWorkplan\Entities\Delivery;
+use OpportunityWorkplan\Entities\Goal;
+use OpportunityWorkplan\Entities\Workplan;
+
+class WorkplanService 
+{
+    public function save($registration, $workplan, $data)
+    {
+        $app = App::i();
+
+        if (!$workplan) {
+            $workplan = new Workplan();
+        }
+        $dataWorkplan = $data['workplan'];
+
+        if (array_key_exists('projectDuration', $dataWorkplan)) {
+            $workplan->projectDuration = $dataWorkplan['projectDuration'];
+        }
+
+        if (array_key_exists('culturalArtisticSegment', $dataWorkplan)) {
+            $workplan->culturalArtisticSegment = $dataWorkplan['culturalArtisticSegment'];
+        }
+    
+        $workplan->registration = $registration;
+        $workplan->save(true);
+
+        if (array_key_exists('goals', $dataWorkplan)) {
+            foreach ($dataWorkplan['goals'] as $g) {
+                if (!empty($g['id'])) {
+                    $goal = $app->repo(Goal::class)->find($g['id']);
+                } else {
+                    $goal = new Goal();
+                }
+
+                $goal->monthInitial = $g['monthInitial'] ?? null;
+                $goal->monthEnd = $g['monthEnd'] ?? null;
+                $goal->title = $g['title'] ?? null;
+                $goal->description = $g['description'] ?? null;
+                $goal->culturalMakingStage = $g['culturalMakingStage'] ?? null;
+                $goal->amount = $g['amount'] ?? null;
+                $goal->workplan = $workplan;
+                $goal->save(true);
+
+
+                foreach ($g['deliveries'] as $d) {
+                    if (!empty($d['id']) > 0) {
+                        $delivery = $app->repo(Delivery::class)->find($d['id']);
+                    } else {
+                        $delivery = new Delivery();
+                    }
+    
+                    $delivery->name = $d['name'] ?? null;
+                    $delivery->description = $d['description'] ?? null;
+                    $delivery->typeDelivery = $d['typeDelivery'] ?? null;
+                    $delivery->segmentDelivery = $d['segmentDelivery'] ?? null;
+                    $delivery->expectedNumberPeople = $d['expectedNumberPeople'] ?? null;
+                    $delivery->generaterRevenue = $d['generaterRevenue'] ?? null;
+                    $delivery->renevueQtd = $d['renevueQtd'] ?? null;
+                    $delivery->unitValueForecast = $d['unitValueForecast'] ?? null;
+                    $delivery->totalValueForecast = $d['totalValueForecast'] ?? null;
+                    $delivery->goal = $goal;
+                    $delivery->save(true);
+                }  
+            }      
+        } 
+
+        $workplan = $app->repo(Workplan::class)->find($workplan->id);
+
+        return $workplan;        
+    }
+}

--- a/src/modules/OpportunityWorkplan/components/opportunity-enable-workplan/script.js
+++ b/src/modules/OpportunityWorkplan/components/opportunity-enable-workplan/script.js
@@ -1,0 +1,154 @@
+app.component('opportunity-enable-workplan', {
+    template: $TEMPLATES['opportunity-enable-workplan'],
+
+    setup() {
+        const text = Utils.getTexts('opportunity-enable-workplan');
+        return { text };
+    },
+    props: {
+        entity: {
+            type: Entity,
+            required: true
+        }
+    },
+    data() {
+        return {
+            entity: this.entity,
+            timeOut: null
+        }
+    },
+    watch: {
+        'entity.enableWorkplan'(_new) {
+            if (!_new) {
+                this.disabledWorkPlan();
+            }
+        },
+        'entity.workplan_dataProjectlimitMaximumDurationOfProjects'(_new) {
+            if (!_new) {
+                this.entity.workplan_dataProjectmaximumDurationInMonths = 0;
+            } else {
+                this.entity.workplan_dataProjectmaximumDurationInMonths = 1;
+            }
+            this.autoSave();
+        },
+        'entity.workplan_metaLimitNumberOfGoals'(_new) {
+            if (!_new) {
+                this.entity.workplan_metaMaximumNumberOfGoals = 0;
+            } else {
+                this.entity.workplan_metaMaximumNumberOfGoals = 1;
+            }
+            this.autoSave();
+        },
+        'entity.workplan_deliveryLimitNumberOfDeliveries'(_new) {
+            if (!_new) {
+                this.entity.workplan_deliveryMaximumNumberOfDeliveries = 0;
+            } else {
+                this.entity.workplan_deliveryMaximumNumberOfDeliveries = 1;
+            }
+            this.autoSave();
+        },
+        'entity.workplan_deliveryReportTheDeliveriesLinkedToTheGoals'(_new) {
+            if (!_new) {
+                this.disabledDeliveries();
+            }
+        },
+    },
+    computed: {
+        getWorkplanLabelDefault() {
+            return this.entity.workplanLabelDefault ? this.entity.workplanLabelDefault : $MAPAS.EntitiesDescription.opportunity.workplanLabelDefault.default_value;
+        },
+        getGoalLabelDefault() {
+            return this.entity.goalLabelDefault ? this.entity.goalLabelDefault : $MAPAS.EntitiesDescription.opportunity.goalLabelDefault.default_value;
+        },
+        getDeliveryLabelDefault() {
+            return this.entity.deliveryLabelDefault ? this.entity.deliveryLabelDefault : $MAPAS.EntitiesDescription.opportunity.deliveryLabelDefault.default_value;
+        },
+    },
+    methods: {
+        changeLabels(modal) {
+            this.autoSave();
+            modal.close();            
+        },
+        actionEnabledWorkplan() {
+            this.entity.enableWorkplan = true;
+            this.entity.save();
+        },
+        actionDisabledWorkplan() {
+            this.entity.enableWorkplan = false;
+            this.entity.save();
+        },
+        autoSave() {
+            this.entity.save(3000);
+        },
+        disabledWorkPlan() {
+            this.entity.workplan_dataProjectlimitMaximumDurationOfProjects = false;
+            this.entity.workplan_dataProjectmaximumDurationInMonths = 0;
+
+            this.entity.workplan_metaInformTheStageOfCulturalMaking = false;
+            this.entity.workplan_metaLimitNumberOfGoals = false;
+            this.entity.workplan_metaMaximumNumberOfGoals = 0;
+
+            this.entity.workplan_deliveryReportTheDeliveriesLinkedToTheGoals = false;
+
+            this.disabledDeliveries();
+        },
+        disabledDeliveries() {
+            this.entity.workplan_deliveryLimitNumberOfDeliveries = false;
+            this.entity.workplan_deliveryMaximumNumberOfDeliveries = 0;
+            this.entity.workplan_registrationReportTheNumberOfParticipants = false;
+            this.entity.workplan_registrationReportExpectedRenevue = false;
+            this.entity.workplan_registrationInformCulturalArtisticSegment = false;
+
+            this.entity.workplan_monitoringInformTheFormOfAvailability = false;
+            this.entity.workplan_monitoringEnterDeliverySubtype = false;
+            this.entity.workplan_monitoringInformAccessibilityMeasures = false;
+            this.entity.workplan_monitoringInformThePriorityTerritories = false;
+            this.entity.workplan_monitoringProvideTheProfileOfParticipants = false;
+            this.entity.workplan_monitoringInformThePriorityAudience = false;
+            this.entity.workplan_monitoringReportExecutedRevenue = false;
+        },
+        pluralParaSingular(texto) {
+            const palavras = texto.split(' ');
+        
+            const palavrasNoSingular = palavras.map(palavra => {
+                if (palavra.endsWith('s')) {
+                    palavra = palavra.slice(0, -1);
+        
+                    if (palavra.endsWith('e')) {
+                        palavra = palavra.slice(0, -1);
+                    }
+        
+                    if (palavra.endsWith('ã')) {
+                        palavra = palavra.slice(0, -1) + 'ão';
+                    } else if (palavra.endsWith('õ')) {
+                        palavra = palavra.slice(0, -1) + 'ão';
+                    } else if (palavra.endsWith('is')) {
+                        palavra = palavra.slice(0, -2) + 'il';
+                    } else if (palavra.endsWith('ns')) {
+                        palavra = palavra.slice(0, -2) + 'm';
+                    } else if (palavra.endsWith('ões')) {
+                        palavra = palavra.slice(0, -3) + 'ão';
+                    } else if (palavra.endsWith('ães')) {
+                        palavra = palavra.slice(0, -3) + 'ão';
+                    } else if (palavra.endsWith('ais')) {
+                        palavra = palavra.slice(0, -2) + 'al';
+                    } else if (palavra.endsWith('éis')) {
+                        palavra = palavra.slice(0, -2) + 'el';
+                    } else if (palavra.endsWith('óis')) {
+                        palavra = palavra.slice(0, -2) + 'ol';
+                    } else if (palavra.endsWith('uis')) {
+                        palavra = palavra.slice(0, -2) + 'ul';
+                    } else if (palavra.endsWith('ões')) {
+                        palavra = palavra.slice(0, -3) + 'ão';
+                    } else if (palavra.endsWith('ães')) {
+                        palavra = palavra.slice(0, -3) + 'ão';
+                    }
+                }
+        
+                return palavra;
+            });
+        
+            return palavrasNoSingular.join(' ');
+        }
+    },
+})

--- a/src/modules/OpportunityWorkplan/components/opportunity-enable-workplan/template.php
+++ b/src/modules/OpportunityWorkplan/components/opportunity-enable-workplan/template.php
@@ -1,0 +1,255 @@
+<?php
+
+/**
+ * @var MapasCulturais\App $app
+ * @var MapasCulturais\Themes\BaseV2\Theme $this
+ */
+
+use MapasCulturais\i;
+
+$this->import('
+    mc-tag-list
+    mc-icon
+    mc-modal
+');
+?>
+<div class="col-12 opportunity-enable-workplan" v-if="entity.isFirstPhase">
+    <div class="col-12 disabled-workplan" v-if="entity.enableWorkplan">
+        <mc-confirm-button @confirm="actionDisabledWorkplan()">
+            <template #button="{open}">
+                <button class="button button--delete button--icon button--sm" @click="open()">
+                    <mc-icon class="icon-workplandisabled" name="trash"></mc-icon> 
+                </button>
+            </template>
+            <template #message="message">
+                <h3>{{ `Você deseja desativar o ${getWorkplanLabelDefault}?` }}</h3><br>
+                <p>
+                    {{ `Todas as configurações e alterações realizadas serão perdidas definitivamente.` }}
+                </p>
+            </template>
+        </mc-confirm-button>
+    </div>
+    <h4 class="bold opportunity-enable-workplan__title">
+        {{ getWorkplanLabelDefault }}
+   
+        <mc-modal title="Editar rótulo" v-if="entity.enableWorkplan">
+            <h4>Rótulo: plano de metas</h4>
+            <div class="field col-12">
+                <div class="field__group">
+                    <label class="field__group">
+                        {{ `Escreva um rótulo personalizado para "${getWorkplanLabelDefault}"` }}
+                    </label>
+                    <input type="text" v-model="entity.workplanLabelDefault">
+                </div>
+            </div>
+
+            <template #actions="modal">
+                <button class="button" @click="modal.close()">Cancelar</button>
+                <button class="button button--primary" @click="changeLabels(modal)">Alterar</button>
+            </template>
+
+            <template #button="modal">
+                <a  href="#"  @click="modal.open()"><mc-icon class="edit" name="edit"></mc-icon></a>
+            </template>
+        </mc-modal>
+        
+    </h4>
+    <h6>{{ `Configurar parâmetros do ${getWorkplanLabelDefault}` }}</h6>
+    <div class="opportunity-enable-workplan__content">
+        <div class="col-12" v-if="!entity.enableWorkplan">
+            <button class="button button--primary button--icon" @click="actionEnabledWorkplan()">
+                <mc-icon name="add"></mc-icon><label>{{ `Configurar ${getWorkplanLabelDefault}` }}</label>
+            </button>
+        </div>
+
+        <div v-if="entity.enableWorkplan">
+            <div id="data-project" class="opportunity-enable-workplan__block col-12">
+                <h4 class="bold opportunity-enable-workplan__title"><?= i::__('Duração do projeto') ?></h4>
+                <div class="field col-12">
+                    <div class="field__group">
+                        <label class="field__checkbox">
+                            <input type="checkbox" v-model="entity.workplan_dataProjectlimitMaximumDurationOfProjects" @click="autoSave()" /><?= i::__("Limitar a duração máxima dos projetos") ?>
+                        </label>
+                    </div>
+
+                    <div class="field__group">
+                        <label class="field__group">
+                            <?php i::_e('Duração máxima (meses):') ?>
+                        </label>
+                        <input type="number" class="field__limits" min="1" :disabled="!entity.workplan_dataProjectlimitMaximumDurationOfProjects" v-model="entity.workplan_dataProjectmaximumDurationInMonths" @change="autoSave()">
+                    </div>
+                </div>
+            </div>
+            <div id="data-metas" class="opportunity-enable-workplan__block col-12">
+                <h4 class="bold opportunity-enable-workplan__title">
+                    {{ getGoalLabelDefault }}  
+                    <mc-modal title="Editar rótulo">
+                        <h4>Rótulo: Meta</h4>
+                        <div class="field col-12">
+                            <div class="field__group">
+                                <label class="field__group">
+                                    {{ `Escreva um rótulo personalizado para "${getGoalLabelDefault}"` }}
+                                </label>
+                                <input type="text" v-model="entity.goalLabelDefault">
+                            </div>
+                        </div>
+
+                        <template #actions="modal">
+                            <button class="button" @click="modal.close()">Cancelar</button>
+                            <button class="button button--primary" @click="changeLabels(modal)">Alterar</button>
+                        </template>
+
+                        <template #button="modal">
+                            <a href="#" @click="modal.open()"><mc-icon class="edit" name="edit"></mc-icon></a>
+                        </template>
+                    </mc-modal>  
+                </h4>
+                <h6>
+                    {{ `As ${getGoalLabelDefault} são constituídas por uma ou mais ${getDeliveryLabelDefault}` }}
+                </h6>
+                <div class="field col-12">
+                    <div class="field__group">
+                        <label class="field__checkbox">
+                            <input type="checkbox" v-model="entity.workplan_metaInformTheStageOfCulturalMaking" @click="autoSave()" /><?= i::__("Informar a etapa do fazer cultural") ?>
+                        </label>
+                    </div>
+
+                    <div class="field__group">
+                        <label class="field__checkbox">
+                            <input type="checkbox" v-model="entity.workplan_metaLimitNumberOfGoals" @click="autoSave()" />
+                            {{ `Limitar número de ${getGoalLabelDefault}` }}
+                        </label>
+                    </div>
+
+                    <div class="field__group">
+                        <label>
+                            {{ `Limitar número de ${getGoalLabelDefault}:` }}
+                        </label>
+                        <input type="number" class="field__limits" min="1" :disabled="!entity.workplan_metaLimitNumberOfGoals" v-model="entity.workplan_metaMaximumNumberOfGoals" @change="autoSave()">
+                    </div>
+                </div>
+            </div>
+            <div id="data-delivery" class="opportunity-enable-workplan__block  col-12">
+                <h4 class="bold opportunity-enable-workplan__title">
+                    {{ `${getDeliveryLabelDefault}` }}
+                    <mc-modal title="Editar rótulo">
+                        <h4>Rótulo: Entrega</h4>
+                        <div class="field col-12">
+                            <div class="field__group">
+                                <label class="field__group">
+                                    {{ `Escreva um rótulo personalizado para "${getDeliveryLabelDefault}"` }}
+                                </label>
+                                <input type="text" v-model="entity.deliveryLabelDefault">
+                            </div>
+                        </div>
+
+                        <template #actions="modal">
+                            <button class="button" @click="modal.close()">Cancelar</button>
+                            <button class="button button--primary" @click="changeLabels(modal)">Alterar</button>
+                        </template>
+
+                        <template #button="modal">
+                            <a href="#" @click="modal.open()"><mc-icon class="edit" name="edit"></mc-icon></a>
+                        </template>
+                    </mc-modal>  
+                </h4>
+                <h6>
+                    {{ `Entregas são os produtos, serviços ou atividades culturais resultantes do projeto fomentado.` }}
+                </h6>
+                <div class="field col-12">
+                    <div class="field__group">
+                        <label class="field__checkbox">
+                            <input type="checkbox" v-model="entity.workplan_deliveryReportTheDeliveriesLinkedToTheGoals" @click="autoSave()" />
+                            {{ `Informar as ${getDeliveryLabelDefault} vinculadas as ${getGoalLabelDefault}` }}
+                        </label>
+                    </div>
+
+                    <div v-if="entity.workplan_deliveryReportTheDeliveriesLinkedToTheGoals">                    
+                        <div class="field__group">
+                            <label class="field__checkbox">
+                                <input type="checkbox" v-model="entity.workplan_deliveryLimitNumberOfDeliveries" @click="autoSave()" />
+                                {{ `Limitar número de ${getDeliveryLabelDefault}` }}
+                            </label>
+                        </div>
+
+                        <div class="field__group mt">
+                            <label class="field__group">
+                                {{ `Número máximo de ${getDeliveryLabelDefault}` }}
+                            </label>
+                            <input type="number" class="field__limits" min="1" :disabled="!entity.workplan_deliveryLimitNumberOfDeliveries" v-model="entity.workplan_deliveryMaximumNumberOfDeliveries" @change="autoSave()">
+                        </div>
+                    </div>
+                </div>
+
+                <div v-if="entity.workplan_deliveryReportTheDeliveriesLinkedToTheGoals" id="data-registration" class="opportunity-enable-workplan__block  col-12">
+                    <h4 class="bold opportunity-enable-workplan__title"><?= i::__('Inscrição') ?></h4>
+                    <h6><?= $this->text('header-description', i::__('As informações que forem marcadas abaixo serão exigidas dos agentes no momento de inscrição na oportunidade.')) ?></h6>
+                    <div class="field col-12">
+                        <div class="field__group">
+                            <label class="field__checkbox">
+                                <input type="checkbox" v-model="entity.workplan_registrationReportTheNumberOfParticipants" @click="autoSave()" /><?= i::__("Informar a quantidade estimada de público") ?>
+                            </label>
+                        </div>
+                        <div class="field__group">
+                            <label class="field__checkbox">
+                                <input type="checkbox" v-model="entity.workplan_registrationInformCulturalArtisticSegment" @click="autoSave()" /><?= i::__("Informar segmento artístico-cultural") ?>
+                            </label>
+                        </div>
+                        <div class="field__group">
+                            <label class="field__checkbox">
+                                <input type="checkbox" v-model="entity.workplan_registrationReportExpectedRenevue" @click="autoSave()" /><?= i::__("Informar receita prevista") ?>
+                            </label>
+                        </div>
+                    </div>
+                </div>
+                <div v-if="entity.workplan_deliveryReportTheDeliveriesLinkedToTheGoals" id="data-monitoring" class="opportunity-enable-workplan__block  col-12">
+                    <h4 class="bold opportunity-enable-workplan__title"><?= i::__('Monitoramento') ?></h4>
+                    <h6><?= $this->text('header-description', i::__('As informações marcadas abaixo serão obrigatórias no monitoramento da oportunidade.')) ?></h6>
+                    <div class="field col-12">
+                        <div class="field__group">
+                            <label class="field__checkbox">
+                                <input type="checkbox" v-model="entity.workplan_monitoringInformTheFormOfAvailability" @click="autoSave()" /><?= i::__("Informar forma de disponibilização") ?>
+                            </label>
+                        </div>
+                        <div class="field__group">
+                            <label class="field__checkbox">
+                                <input type="checkbox" v-model="entity.workplan_monitoringEnterDeliverySubtype" @click="autoSave()" />
+                                {{ `Informar subtipo de ${getDeliveryLabelDefault}` }}
+                            </label>
+                        </div>
+                        <div class="field__group">
+                            <label class="field__checkbox">
+                                <input type="checkbox" v-model="entity.workplan_monitoringInformAccessibilityMeasures" @click="autoSave()" /><?= i::__("Informar as medidas de acessibilidade") ?>
+                            </label>
+                        </div>
+                        <div class="field__group">
+                            <label class="field__checkbox">
+                                <input type="checkbox" v-model="entity.workplan_monitoringInformThePriorityTerritories" @click="autoSave()" /><?= i::__("Informar os territórios prioritários") ?>
+                            </label>
+                        </div>
+
+                        <div class="field__group">
+                            <label class="field__checkbox">
+                                <input type="checkbox" v-model="entity.workplan_monitoringProvideTheProfileOfParticipants" @click="autoSave()" /><?= i::__("Informar o perfil do público") ?>
+                            </label>
+                        </div>
+
+                        <div class="field__group">
+                            <label class="field__checkbox">
+                                <input type="checkbox" v-model="entity.workplan_monitoringInformThePriorityAudience" @click="autoSave()" /><?= i::__("Informar o público prioritário") ?>
+                            </label>
+                        </div>
+
+                        <div class="field__group">
+                            <label class="field__checkbox">
+                                <input type="checkbox" v-model="entity.workplan_monitoringReportExecutedRevenue" @click="autoSave()" /><?= i::__("Informar receita executada") ?>
+                            </label>
+                        </div>
+                    </div>
+                </div>
+            </div>
+
+        </div>
+    </div>
+</div>
+<div class="config-phase__line col-12"></div>

--- a/src/modules/OpportunityWorkplan/components/registration-details-workplan/script.js
+++ b/src/modules/OpportunityWorkplan/components/registration-details-workplan/script.js
@@ -1,0 +1,97 @@
+app.component('registration-details-workplan', {
+    template: $TEMPLATES['registration-details-workplan'],
+    setup() {
+        const text = Utils.getTexts('registration-details-workplan');
+        return { text };
+    },
+    props: {
+        registration: {
+            type: Entity,
+            required: true
+        },
+    },
+    data() {
+        this.getWorkplan();
+
+        const entityWorkplan = new Entity('workplan');
+
+        return {
+            opportunity: this.registration.opportunity,
+            workplan: entityWorkplan,
+        };
+    },
+    computed: {
+        getWorkplanLabelDefault() {
+            return this.opportunity.workplanLabelDefault ? this.opportunity.workplanLabelDefault : $MAPAS.EntitiesDescription.opportunity.workplanLabelDefault.default_value;
+        },
+        getGoalLabelDefault() {
+            const label = this.opportunity.goalLabelDefault ? this.opportunity.goalLabelDefault : $MAPAS.EntitiesDescription.opportunity.goalLabelDefault.default_value;
+            return this.pluralParaSingular(label);
+        },
+        getDeliveryLabelDefault() {
+            const label = this.opportunity.deliveryLabelDefault ? this.opportunity.deliveryLabelDefault : $MAPAS.EntitiesDescription.opportunity.deliveryLabelDefault.default_value;
+            return this.pluralParaSingular(label);
+        },
+    },
+    methods: {
+        getWorkplan() {
+            const api = new API('workplan');
+            
+            const response = api.GET(`${this.registration.id}`);
+            response.then((res) => res.json().then((data) => {
+                if (data.workplan != null) {
+                    this.workplan = data.workplan;
+                }
+            }));
+        },
+        convertToCurrency(field) {
+            return new Intl.NumberFormat("pt-BR", {
+                style: "currency",
+                currency: "BRL"
+              }).format(field);
+        },
+        pluralParaSingular(texto) {
+            const palavras = texto.split(' ');
+        
+            const palavrasNoSingular = palavras.map(palavra => {
+                if (palavra.endsWith('s')) {
+                    palavra = palavra.slice(0, -1);
+        
+                    if (palavra.endsWith('e')) {
+                        palavra = palavra.slice(0, -1);
+                    }
+    
+                    if (palavra.endsWith('ã')) {
+                        palavra = palavra.slice(0, -1) + 'ão';
+                    } else if (palavra.endsWith('õ')) {
+                        palavra = palavra.slice(0, -1) + 'ão';
+                    } else if (palavra.endsWith('is')) {
+                        palavra = palavra.slice(0, -2) + 'il';
+                    } else if (palavra.endsWith('ns')) {
+                        palavra = palavra.slice(0, -2) + 'm';
+                    } else if (palavra.endsWith('ões')) {
+                        palavra = palavra.slice(0, -3) + 'ão';
+                    } else if (palavra.endsWith('ães')) {
+                        palavra = palavra.slice(0, -3) + 'ão';
+                    } else if (palavra.endsWith('ais')) {
+                        palavra = palavra.slice(0, -2) + 'al';
+                    } else if (palavra.endsWith('éis')) {
+                        palavra = palavra.slice(0, -2) + 'el';
+                    } else if (palavra.endsWith('óis')) {
+                        palavra = palavra.slice(0, -2) + 'ol';
+                    } else if (palavra.endsWith('uis')) {
+                        palavra = palavra.slice(0, -2) + 'ul';
+                    } else if (palavra.endsWith('ões')) {
+                        palavra = palavra.slice(0, -3) + 'ão';
+                    } else if (palavra.endsWith('ães')) {
+                        palavra = palavra.slice(0, -3) + 'ão';
+                    }
+                }
+        
+                return palavra.toLowerCase();
+            });
+    
+            return palavrasNoSingular.join(' ');
+        }
+    },
+})

--- a/src/modules/OpportunityWorkplan/components/registration-details-workplan/template.php
+++ b/src/modules/OpportunityWorkplan/components/registration-details-workplan/template.php
@@ -1,0 +1,118 @@
+<?php
+
+/**
+ * @var MapasCulturais\App $app
+ * @var MapasCulturais\Themes\BaseV2\Theme $this
+ */
+
+use MapasCulturais\i;
+
+$this->import('
+    entity-field
+    mc-card
+    mc-icon
+    mc-currency-input
+');
+?>
+<mc-card class="registration-details-workplan" v-if="registration.opportunity.enableWorkplan">
+    <template #title>
+        <h3 class="card__title">{{ getWorkplanLabelDefault }}</h3>
+        <p><?= i::esc_attr__('Dados da ação cultural.') ?></p>
+    </template>
+    <template #content>
+        <div v-if="workplan.projectDuration" class="field">
+            <label><?= i::esc_attr__('Duração do projeto (meses)') ?></label>
+            {{ workplan.projectDuration }}
+        </div>
+
+        <div v-if="workplan.culturalArtisticSegment" class="field">
+            <label><?= i::esc_attr__('Segmento artistico-cultural') ?></label>
+            {{ workplan.culturalArtisticSegment }}
+        </div>
+
+        <div v-for="(goal, index) in workplan.goals" :key="index" class="registration-details-workplan__goals">
+            <div class="registration-details-workplan__header-goals">
+                <h4 class="registration-details-workplan__goals-title">
+                    {{ getGoalLabelDefault }} - {{ goal.title }}</h4>
+            </div>
+
+            <div v-if="goal.monthInitial" class="field">
+                <label><?= i::esc_attr__('Mês inicial') ?></label>
+                {{ goal.monthInitial }}
+            </div>
+            <div v-if="goal.monthEnd" class="field">
+                <label for="mes-final"><?= i::esc_attr__('Mês final') ?></label>
+                {{ goal.monthEnd }}
+            </div>
+            <div v-if="goal.title" class="field">
+                <label>{{ `Titulo da ${getGoalLabelDefault}` }}</label>
+                {{ goal.title }}
+            </div>
+
+            <div v-if="goal.description" class="field">
+                <label><?= i::esc_attr__('Descrição') ?></label>
+                {{ goal.description }}
+            </div>
+
+            <!-- Etapa do fazer cultural -->
+            <div v-if="goal.culturalMakingStage" class="field">
+                <label><?= i::esc_attr__('Etapa do fazer cultural') ?></label>
+                {{ goal.culturalMakingStage }}
+            </div>
+
+            <div v-for="(delivery, index_) in goal.deliveries" :key="delivery.id" class="registration-details-workplan__goals__deliveries">
+                <div class="registration-details-workplan__header-deliveries">
+                    <h4 class="registration-details-workplan__goals-title">
+                        {{ getDeliveryLabelDefault }} - {{ delivery.name }}</h4>
+                </div>
+                <div v-if="delivery.name" class="field">
+                    <label><?= i::esc_attr__('Nome') ?></label>
+                    {{ delivery.name }}
+                </div>
+
+                <div v-if="delivery.description" class="field">
+                    <label><?= i::esc_attr__('Descrição') ?></label>
+                    {{ delivery.description }}
+                </div>
+
+                <div v-if="delivery.typeDelivery" class="field">
+                    <label><?= i::esc_attr__('Tipo') ?></label>
+                    {{ delivery.typeDelivery }}
+                </div>
+
+                <div v-if="delivery.segmentDelivery" class="field">
+                    <label><?= i::esc_attr__('Segmento artístico cultural') ?></label>
+                    {{ delivery.segmentDelivery }}
+                </div>
+
+                <div v-if="delivery.expectedNumberPeople" class="field">
+                    <label><?= i::esc_attr__('Número previsto de pessoas') ?></label>
+                    {{ delivery.expectedNumberPeople }}
+                </div>
+
+
+                <div v-if="delivery.generaterRevenu" class="field">
+                    <label><?= i::esc_attr__('Irá gerar receita?') ?></label>
+                    {{ delivery.generaterRevenue }}
+                </div>
+
+                <div v-if="delivery.renevueQtd" class="field">
+                    <label><?= i::esc_attr__('Quantidade') ?></label>
+                    {{ delivery.renevueQtd }}
+                </div>
+
+                <div v-if="delivery.unitValueForecast" class="field">
+                    <label><?= i::esc_attr__('Previsão de valor unitário') ?></label>
+                    {{ convertToCurrency(delivery.unitValueForecast) }}
+                </div>
+
+                <div v-if="delivery.totalValueForecast" class="field">
+                    <label><?= i::esc_attr__(text: 'Previsão de valor total') ?></label>
+                    {{ convertToCurrency(delivery.totalValueForecast) }}
+                </div>
+            </div>
+
+        </div>
+
+    </template>
+</mc-card>

--- a/src/modules/OpportunityWorkplan/components/registration-workplan/init.php
+++ b/src/modules/OpportunityWorkplan/components/registration-workplan/init.php
@@ -1,0 +1,9 @@
+<?php
+
+use OpportunityWorkplan\Entities\Delivery;
+use OpportunityWorkplan\Entities\Goal;
+use OpportunityWorkplan\Entities\Workplan;
+
+$this->jsObject['EntitiesDescription']['workplan'] = Workplan::getPropertiesMetadata();
+$this->jsObject['EntitiesDescription']['workplan']['goal'] = Goal::getPropertiesMetadata();
+$this->jsObject['EntitiesDescription']['workplan']['goal']['delivery'] = Delivery::getPropertiesMetadata();

--- a/src/modules/OpportunityWorkplan/components/registration-workplan/init.php
+++ b/src/modules/OpportunityWorkplan/components/registration-workplan/init.php
@@ -4,6 +4,8 @@ use OpportunityWorkplan\Entities\Delivery;
 use OpportunityWorkplan\Entities\Goal;
 use OpportunityWorkplan\Entities\Workplan;
 
+$this->jsObject['workplan'] = $app->_config['workplan'] ?? [];
+
 $this->jsObject['EntitiesDescription']['workplan'] = Workplan::getPropertiesMetadata();
 $this->jsObject['EntitiesDescription']['workplan']['goal'] = Goal::getPropertiesMetadata();
 $this->jsObject['EntitiesDescription']['workplan']['goal']['delivery'] = Delivery::getPropertiesMetadata();

--- a/src/modules/OpportunityWorkplan/components/registration-workplan/script.js
+++ b/src/modules/OpportunityWorkplan/components/registration-workplan/script.js
@@ -564,7 +564,7 @@ app.component('registration-workplan', {
             this.tour.start();
         },
         isTutorialDisabled() {
-            return localStorage.getItem('tutorialDisabled') === 'true';
+            return ($MAPAS.workplan?.enable_workplan_tutorial !== true) || (localStorage.getItem('tutorialDisabled') === 'true');
         },
         disableTutorial() {
             localStorage.setItem('tutorialDisabled', 'true');

--- a/src/modules/OpportunityWorkplan/components/registration-workplan/script.js
+++ b/src/modules/OpportunityWorkplan/components/registration-workplan/script.js
@@ -1,0 +1,576 @@
+app.component('registration-workplan', {
+    template: $TEMPLATES['registration-workplan'],
+    setup() {
+        const text = Utils.getTexts('registration-workplan');
+        return { text };
+    },
+    props: {
+        registration: {
+            type: Entity,
+            required: true
+        },
+    },
+    data() {
+        this.getWorkplan();
+
+        const entityWorkplan = new Entity('workplan');
+        entityWorkplan.id = null;
+        entityWorkplan.registrationId = this.registration.id;
+        entityWorkplan.projectDuration = null;
+        entityWorkplan.culturalArtisticSegment = null;
+        entityWorkplan.goals = [];
+
+        const enableWorkplanInStep = this.registration.opportunity.registrationSteps.length > 1 ? false : true;
+
+
+        return {
+            enableWorkplanInStep: enableWorkplanInStep,
+            opportunity: this.registration.opportunity,
+            workplan: entityWorkplan,
+            workplanFields: $MAPAS.EntitiesDescription.workplan,
+            expandedGoals: [],
+            enableButtonNewGoal: false
+        };
+    },
+    mounted() {
+        this.handleHashChange();
+        window.addEventListener('hashchange', this.handleHashChange);
+    },
+    computed: {
+        getWorkplanLabelDefault() {
+            return this.opportunity.workplanLabelDefault ? this.opportunity.workplanLabelDefault : $MAPAS.EntitiesDescription.opportunity.workplanLabelDefault.default_value;
+        },
+        getGoalLabelDefault() {
+            const label = this.opportunity.goalLabelDefault ? this.opportunity.goalLabelDefault : $MAPAS.EntitiesDescription.opportunity.goalLabelDefault.default_value;
+            return this.pluralParaSingular(label);
+        },
+        getDeliveryLabelDefault() {
+            const label = this.opportunity.deliveryLabelDefault ? this.opportunity.deliveryLabelDefault : $MAPAS.EntitiesDescription.opportunity.deliveryLabelDefault.default_value;
+            return this.pluralParaSingular(label);
+        },
+        
+    },
+    methods: {
+        handleHashChange() {
+            const hash = window.location.hash;
+            const stepMatch = hash.match(/#etapa_(\d+)/);
+
+            if (this.registration.opportunity.registrationSteps.length > 1) {
+                if (stepMatch && stepMatch[1]) {
+                    const stepNumber = parseInt(stepMatch[1], 10); 
+                    this.enableWorkplanInStep = stepNumber === this.registration.opportunity.registrationSteps.length;
+    
+                } else {
+                    this.enableWorkplanInStep = false;
+                }
+            } else {
+                this.enableWorkplanInStep = true;
+            }
+
+            if (this.enableWorkplanInStep) {
+                this.startTutorialWorkplan();
+            }
+        },
+        getWorkplan() {
+            const api = new API('workplan');
+            
+            const response = api.GET(`${this.registration.id}`);
+            response.then((res) => res.json().then((data) => {
+                if (data.workplan != null) {
+                    this.workplan = data.workplan;
+                    this.updateEnableButtonNewGoal();
+                }
+            }));
+        },
+        
+        async newGoal() {
+            if (!this.validateGoal()) {
+                return false;
+            }
+
+            this.startTutorialGoal();
+
+            const entityGoal = new Entity('goal');
+            entityGoal.id = null;
+            entityGoal.monthInitial = null;
+            entityGoal.monthEnd = null;
+            entityGoal.title = null;
+            entityGoal.description = null;
+            entityGoal.culturalMakingStage = null;
+            entityGoal.deliveries = [];
+
+        
+            this.workplan.goals.push(entityGoal);
+            this.expandedGoals.push(this.workplan.goals.length - 1);
+        },
+        async deleteGoal(goal) {
+            const api = new API('workplan');
+            
+            if (goal.id) {
+                const response = api.DELETE('goal', {id: goal.id});
+                response.then((res) => res.json().then((data) => {
+                    this.workplan.goals = this.workplan.goals.filter(g => g.id !== goal.id);
+                    this.updateEnableButtonNewGoal();
+                }));
+            } else {
+                const index = this.workplan.goals.indexOf(goal);
+                if (index !== -1) {
+                    this.workplan.goals.splice(index, 1);Zs
+                    this.expandedGoals = this.expandedGoals
+                        .filter(i => i !== index)
+                        .map(i => i > index ? i - 1 : i);
+                    
+                        this.updateEnableButtonNewGoal();
+                }
+            }
+        },
+        async newDelivery(goal) {
+            if (!this.validateDelivery(goal)) {
+                return false;
+            }
+
+            this.startTutorialDelivery();
+
+            const entityDelivery = new Entity('delivery');
+            entityDelivery.id = null;
+            entityDelivery.name = null;
+            entityDelivery.description = null;
+            entityDelivery.typeDelivery = null
+            entityDelivery.segmentDelivery = null;
+            entityDelivery.expectedNumberPeople = null
+            entityDelivery.generaterRevenue = null;
+            entityDelivery.renevueQtd = null;
+            entityDelivery.unitValueForecast = null;
+            entityDelivery.totalValueForecast = null;
+
+            goal.deliveries.push(entityDelivery);
+        },
+        async deleteDelivery(delivery) {
+            const api = new API('workplan');
+
+            if (delivery.id) {
+                const response = api.DELETE('delivery', {id: delivery.id});
+                response.then((res) => res.json().then((data) => {
+                    this.workplan.goals = this.workplan.goals.map(goal => {
+                        if (goal.deliveries) {
+                            goal.deliveries = goal.deliveries.filter(delivery_ => delivery_.id !== delivery.id);
+                        }
+                        this.updateEnableButtonNewGoal();
+                        return goal;
+                    });
+                }));
+            } else {
+                this.workplan.goals = this.workplan.goals.map(goal => {
+                    if (goal.deliveries) {
+                        goal.deliveries = goal.deliveries.filter(d => d !== delivery);
+                    }
+                    this.updateEnableButtonNewGoal();
+                    return goal;
+                });
+            }
+           
+        },
+        validateGoal() {
+            const messages = useMessages();
+
+            let validationMessages = [];
+
+            this.workplan.goals.forEach((goal, index) => {
+                let emptyFields = [];
+                let position = index+1;
+
+                // Verificar cada campo do objeto `goal`
+                if (!goal.monthInitial) emptyFields.push("Mês inicial");
+                if (!goal.monthEnd) emptyFields.push("Mês final");
+                if (!goal.title) emptyFields.push(`Título da ${this.getGoalLabelDefault}`);
+                if (!goal.description) emptyFields.push("Descrição");
+                if (this.opportunity.workplan_metaInformTheStageOfCulturalMaking && !goal.culturalMakingStage) emptyFields.push("Etapa do fazer cultural");
+                if (this.opportunity.workplan_deliveryReportTheDeliveriesLinkedToTheGoals && goal.deliveries.length === 0) emptyFields.push(`${this.getDeliveryLabelDefault}`);
+
+                const validateDelivery = this.validateDelivery(goal);
+                if (validateDelivery.length > 0) {
+                    emptyFields.push(`${this.getDeliveryLabelDefault}`);
+                    emptyFields.push(validateDelivery);
+                }
+        
+                // Adicionar mensagem ao array se houver campos vazios
+                if (emptyFields.length > 0) {
+
+                    const emptyFieldsList = `<ul>${emptyFields.map(item => `<li>${item}</li>`).join('')}</ul>`;
+
+                    validationMessages.push(
+                        `<br>A ${this.getGoalLabelDefault} ${position} possui os seguintes campos vazios:<br> ${emptyFieldsList}`
+                    );
+                }
+            });
+        
+            if (validationMessages.length > 0) {
+                messages.error(validationMessages);
+                return false;
+            }
+            
+            return true;
+        },
+        validateDelivery(goal) {
+            const messages = useMessages();
+
+            let validationMessages = [];
+
+            goal.deliveries.forEach((delivery, index) => {
+                let emptyFields = [];
+                let position = index+1;
+        
+                if ('name' in delivery && !delivery.name) emptyFields.push(`Nome da ${this.getDeliveryLabelDefault}`);
+                if ('description' in delivery && !delivery.description) emptyFields.push("Descrição");
+                if ('typeDelivery' in delivery && !delivery.typeDelivery) emptyFields.push(`Tipo de ${this.getDeliveryLabelDefault}`);
+                if (this.opportunity.workplan_registrationInformCulturalArtisticSegment && 'segmentDelivery' in delivery && !delivery.segmentDelivery) emptyFields.push(`Segmento artístico-cultural da ${this.getDeliveryLabelDefault}`);
+                if (this.opportunity.workplan_registrationReportTheNumberOfParticipants && 'expectedNumberPeople' in delivery && !delivery.expectedNumberPeople) emptyFields.push("Número previsto de pessoas");
+                if (this.opportunity.workplan_registrationReportExpectedRenevue && 'generaterRevenue' in delivery && !delivery.generaterRevenue) emptyFields.push(`A ${this.getDeliveryLabelDefault} irá gerar receita?`);
+                if (delivery.generaterRevenue == 'true' && 'renevueQtd' in delivery && !delivery.renevueQtd) emptyFields.push("Quantidade");
+                if (delivery.generaterRevenue == 'true' && 'unitValueForecast' in delivery && !delivery.unitValueForecast) emptyFields.push("Previsão de valor unitário");
+                if (delivery.generaterRevenue == 'true' && 'totalValueForecast' in delivery && !delivery.totalValueForecast) emptyFields.push("Previsão de valor total");
+                
+                if (emptyFields.length > 0) {
+                    const emptyFieldsList = `<ul>${emptyFields.map(item => `<li>${item}</li>`).join('')}</ul>`;
+
+                    validationMessages.push(
+                        `A ${this.getDeliveryLabelDefault} ${position} possui os seguintes campos vazios:<br> ${emptyFieldsList}<br>`
+                    );
+                }
+            });
+        
+            return validationMessages;
+        },
+        async save_(enableValidations = true) {    
+            if (enableValidations && !this.validateGoal()) {
+                return false;
+            }
+            const messages = useMessages();        
+            const api = new API('workplan');
+
+            let data = {
+                registrationId: this.registration.id,
+                workplan: this.workplan,
+            };
+
+            const response = api.POST(`save`, data);
+            response.then((res) => res.json().then((data) => {                
+                this.getWorkplan();
+                this.updateEnableButtonNewGoal();
+                messages.success(this.text('Modificações salvas'));
+            }));    
+        },
+        range(start, end) {
+            return Array.from({ length: end - start + 1 }, (_, i) => start + i);
+        },
+        updateEnableButtonNewGoal() {
+            this.enableButtonNewGoal = this.enableNewGoal(this.workplan);
+        },
+        enableNewGoal(workplan) {
+            if (workplan.projectDuration == null || workplan.culturalArtisticSegment == null) {
+                return false;
+            }
+
+            if (!this.opportunity.workplan_metaLimitNumberOfGoals) {
+                return true;
+            }
+            
+            return this.opportunity.workplan_metaMaximumNumberOfGoals > workplan.goals.length;
+        },
+        enableNewDelivery(goal) {
+            if (this.opportunity.workplan_deliveryReportTheDeliveriesLinkedToTheGoals) {
+                if (this.opportunity.workplan_deliveryLimitNumberOfDeliveries) {
+                    return this.opportunity.workplan_deliveryMaximumNumberOfDeliveries > goal.deliveries.length;
+                }
+                return true;
+            }
+            return false;
+        },
+        totalValueForecastToCurrency(delivery, renevueQtd, unitValueForecast) {
+            let value = renevueQtd * unitValueForecast;
+            delivery.totalValueForecast = value;
+            return new Intl.NumberFormat("pt-BR", {
+                style: "currency",
+                currency: "BRL"
+              }).format(value);
+        },
+        optionsProjectDurationData() {
+            if (this.opportunity.workplan_dataProjectlimitMaximumDurationOfProjects) {
+                return this.opportunity.workplan_dataProjectmaximumDurationInMonths;
+            } else {
+                return 60;
+            }
+        },
+        toggle(index) {
+            if (this.expandedGoals.includes(index)) {
+              this.expandedGoals = this.expandedGoals.filter((i) => i !== index);
+            } else {
+              this.expandedGoals.push(index);
+            }
+        },
+        isExpanded(index) {
+            return this.expandedGoals.includes(index); 
+        },
+        pluralParaSingular(texto) {
+            const palavras = texto.split(' ');
+        
+            const palavrasNoSingular = palavras.map(palavra => {
+                if (palavra.endsWith('s')) {
+                    palavra = palavra.slice(0, -1);
+        
+                    if (palavra.endsWith('e')) {
+                        palavra = palavra.slice(0, -1);
+                    }
+    
+                    if (palavra.endsWith('ã')) {
+                        palavra = palavra.slice(0, -1) + 'ão';
+                    } else if (palavra.endsWith('õ')) {
+                        palavra = palavra.slice(0, -1) + 'ão';
+                    } else if (palavra.endsWith('is')) {
+                        palavra = palavra.slice(0, -2) + 'il';
+                    } else if (palavra.endsWith('ns')) {
+                        palavra = palavra.slice(0, -2) + 'm';
+                    } else if (palavra.endsWith('ões')) {
+                        palavra = palavra.slice(0, -3) + 'ão';
+                    } else if (palavra.endsWith('ães')) {
+                        palavra = palavra.slice(0, -3) + 'ão';
+                    } else if (palavra.endsWith('ais')) {
+                        palavra = palavra.slice(0, -2) + 'al';
+                    } else if (palavra.endsWith('éis')) {
+                        palavra = palavra.slice(0, -2) + 'el';
+                    } else if (palavra.endsWith('óis')) {
+                        palavra = palavra.slice(0, -2) + 'ol';
+                    } else if (palavra.endsWith('uis')) {
+                        palavra = palavra.slice(0, -2) + 'ul';
+                    } else if (palavra.endsWith('ões')) {
+                        palavra = palavra.slice(0, -3) + 'ão';
+                    } else if (palavra.endsWith('ães')) {
+                        palavra = palavra.slice(0, -3) + 'ão';
+                    }
+                }
+        
+                return palavra.toLowerCase();
+            });
+    
+            return palavrasNoSingular.join(' ');
+        },
+        tutorialButtonsDisabled() {
+            return [
+                {
+                    text: 'Desativar assistente de configuração',
+                    action: () => {
+                        this.disableTutorial();
+                        this.tour.complete(); // Fecha o tutorial imediatamente
+                    },
+                    classes: 'button button--secondary button--sm'
+                },
+                {
+                    text: 'Avançar',
+                    action: this.tour.next,
+                    classes: 'button button--primary button--sm'
+                }
+          ];
+        },
+        tutorialButtonsDefault() {
+            return [
+                {
+                  text: 'Voltar',
+                  action: this.tour.back,
+                  classes: 'button button--solid-dark button--sm'
+                },
+                {
+                  text: 'Avançar',
+                  action: this.tour.next,
+                  classes: 'button button--primary button--sm'
+                }
+              ];
+        },
+        titleTutorial() {
+            return "Assistente de Configuração - Plano de metas";
+        },
+        startTutorialWorkplan() {
+            if (this.isTutorialDisabled()) {
+                return;
+            }
+
+            if (this.tour) {
+                this.tour.complete(); 
+                this.tour = null;
+            }
+
+            this.tour = new Shepherd.Tour({
+              useModalOverlay: true, // Escurece a tela
+              defaultStepOptions: {
+                cancelIcon: {
+                    enabled: true
+                },
+                classes: 'shadow-md bg-white p-4 rounded-lg', // Estilização
+                scrollTo: true
+              }
+            });
+      
+            this.tour.addStep({
+              id: 'registration-workplan',
+              title: this.titleTutorial(),
+              text: 'Bem-vindo ao tutorial do Plano de Metas! Aqui você aprenderá a usá-lo de forma fácil e eficiente.',
+              attachTo: {
+                element: '#registration-workplan',
+                on: 'bottom'
+              },
+              buttons: this.tutorialButtonsDisabled()
+            });
+      
+            this.tour.addStep({
+              id: 'projectDuration',
+              title: this.titleTutorial(),
+              text: 'Este campo exibe a duração do projeto em meses.',
+              attachTo: {
+                element: '#projectDuration',
+                on: 'bottom'
+              },
+              buttons: this.tutorialButtonsDefault()
+            });
+
+            this.tour.addStep({
+                id: 'culturalArtisticSegment',
+                title: this.titleTutorial(),
+                text: 'Este campo exibe o segmento artístico-cultural. Após o preenchimento, um botão para cadastro de metas será habilitado.',
+                attachTo: {
+                  element: '#culturalArtisticSegment',
+                  on: 'bottom'
+                },
+                buttons: this.tutorialButtonsDefault()
+            });
+      
+            this.tour.start();
+        },
+        startTutorialGoal() {
+            if (this.isTutorialDisabled()) {
+                return;
+            }
+
+            if (this.tour) {
+                this.tour.complete(); 
+                this.tour = null;
+            }
+
+            this.tour = new Shepherd.Tour({
+              useModalOverlay: true, // Escurece a tela
+              defaultStepOptions: {
+                classes: 'shadow-md bg-white p-4 rounded-lg', // Estilização
+                scrollTo: true
+              }
+            });
+      
+            this.tour.addStep({
+              id: 'container_goals',
+              title: this.titleTutorial(),
+              text: 'Preencha as metas do projeto.',
+              attachTo: {
+                element: '#container_goals',
+                on: 'bottom'
+              },
+              buttons: this.tutorialButtonsDisabled()
+            });
+      
+            this.tour.addStep({
+              id: 'registration-workplan__delete-goal',
+              title: this.titleTutorial(),
+              text: 'O botão "Excluir meta" permite remover uma meta cadastrada ou em processo de cadastro.',
+              attachTo: {
+                element: '#registration-workplan__delete-goal',
+                on: 'bottom'
+              },
+              buttons: this.tutorialButtonsDefault()
+            });
+
+            this.tour.addStep({
+                id: 'button-registration-workplan__new-delivery',
+                title: this.titleTutorial(),
+                text: 'O botão "+ Entrega" permite adicionar uma nova entrega à sua meta.',
+                attachTo: {
+                  element: '#button-registration-workplan__new-delivery',
+                  on: 'bottom'
+                },
+                buttons: this.tutorialButtonsDefault()
+            });
+
+            this.tour.addStep({
+                id: 'button-registration-workplan__save-goal',
+                title: this.titleTutorial(),
+                text: 'Última etapa! Clique no botão "Salvar metas" para garantir que suas metas e entregas sejam salvas.',
+                attachTo: {
+                  element: '#button-registration-workplan__save-goal',
+                  on: 'bottom'
+                },
+                buttons: this.tutorialButtonsDefault()
+            });
+            
+            this.tour.start();
+        },
+        startTutorialDelivery() {
+            if (this.isTutorialDisabled()) {
+                return;
+            }
+
+            if (this.tour) {
+                this.tour.complete(); 
+                this.tour = null;
+            }
+
+            this.tour = new Shepherd.Tour({
+              useModalOverlay: true, // Escurece a tela
+              defaultStepOptions: {
+                classes: 'shadow-md bg-white p-4 rounded-lg', // Estilização
+                scrollTo: true
+              }
+            });
+      
+            this.tour.addStep({
+              id: 'container_deliveries',
+              title: this.titleTutorial(),
+              text: 'Preencha as informações das suas entregas.',
+              attachTo: {
+                element: '#container_deliveries',
+                on: 'bottom'
+              },
+              buttons: this.tutorialButtonsDisabled()
+            });
+      
+            this.tour.addStep({
+              id: 'registration-workplan__delete-delivery',
+              title: this.titleTutorial(),
+              text: 'Botão "Excluir entrega" para remover a entrega cadastrada ou em processo de cadastro.',
+              attachTo: {
+                element: '#registration-workplan__delete-delivery',
+                on: 'bottom'
+              },
+              buttons: this.tutorialButtonsDefault()
+            });
+
+            this.tour.addStep({
+                id: 'button-registration-workplan__save-goal',
+                title: this.titleTutorial(),
+                text: 'Última etapa! Para garantir que suas metas e entregas sejam salvas, clique no botão "Salvar metas".',
+                attachTo: {
+                  element: '#button-registration-workplan__save-goal',
+                  on: 'bottom'
+                },
+                buttons: this.tutorialButtonsDefault()
+            });
+
+            this.disableTutorial();
+            
+            this.tour.start();
+        },
+        isTutorialDisabled() {
+            return localStorage.getItem('tutorialDisabled') === 'true';
+        },
+        disableTutorial() {
+            localStorage.setItem('tutorialDisabled', 'true');
+        },
+        enableTutorial() {
+            localStorage.setItem('tutorialDisabled', 'false');
+        },
+    },
+})

--- a/src/modules/OpportunityWorkplan/components/registration-workplan/template.php
+++ b/src/modules/OpportunityWorkplan/components/registration-workplan/template.php
@@ -1,0 +1,251 @@
+<?php
+
+/**
+ * @var MapasCulturais\App $app
+ * @var MapasCulturais\Themes\BaseV2\Theme $this
+ */
+
+use MapasCulturais\i;
+
+$this->import('
+    entity-field
+    mc-card
+    mc-icon
+    mc-confirm-button
+    mc-currency-input
+');
+?>
+
+<div id="registration-workplan">
+<mc-card  class="registration-workplan" v-if="registration.opportunity.enableWorkplan && enableWorkplanInStep">
+    <template #title>
+        <h3 class="card__title">
+            {{ getWorkplanLabelDefault }}
+            <?php $this->info('inscricao -> preenchimento -> plano-de-metas') ?>
+        </h3>
+        <p>
+            {{ `Descrição do ${getWorkplanLabelDefault}` }}
+        </p>
+        <br>
+        <div class="registration-actions__alert">
+            <div class="registration-actions__alert-header">
+                <mc-icon name="exclamation"></mc-icon>
+                <span class="bold"><?= i::__('Atenção - Preenchimento do plano de metas') ?></span>
+            </div>
+            <div class="registration-actions__alert-content">
+                <span><?= i::__('Para registrar as metas e entregas do plano de metas, preencha os campos obrigatórios e clique no botão "Salvar Meta"') ?></span>
+            </div>
+        </div>
+        <br>
+        <!-- Botão para ativar tutorial -->
+        <div v-if="isTutorialDisabled()" >
+            <button class="button button--primary button--primary-outline button--sm" @click="enableTutorial(); startTutorialWorkplan()">
+                <mc-icon name="help"></mc-icon>
+                <?= i::__('Reativar assistente de configuração') ?>
+            </button>
+        </div>
+    </template>
+    <template #content>
+        <div class="field" id="projectDuration">
+            <label><?= i::esc_attr__('Duração do projeto (meses)') ?><span class="required">obrigatório*</span></label>
+            <select class="field__limits" v-model="workplan.projectDuration" @change="save_(false)">
+                <option value=""><?= i::esc_attr__('Selecione') ?></option>
+                <option v-for="n in optionsProjectDurationData()" :key="n" :value="n">{{ n }}</option>
+            </select>
+        </div>
+
+        <div class="field" id="culturalArtisticSegment">
+            <label><?= i::esc_attr__('Segmento artistico-cultural') ?><span class="required">obrigatório*</span></label>
+            <select v-model="workplan.culturalArtisticSegment" @change="save_(false)">
+                <option value=""><?= i::esc_attr__('Selecione') ?></option>
+                <option v-for="n in workplanFields.culturalArtisticSegment.options" :key="n" :value="n">{{ n }}</option>
+            </select>
+        </div>
+
+        <!-- Metas -->
+        <div id="container_goals">
+            <div v-for="(goal, index) in workplan.goals" :key="index" class="registration-workplan__goals">
+                <div class="registration-workplan__header-goals">
+                    <h4 class="registration-workplan__goals-title" @click="toggle(index)">
+                        {{ goal.title }}
+                        <mc-icon v-if="isExpanded(index)" name="arrowPoint-up"></mc-icon>
+                        <mc-icon v-if="!isExpanded(index)" name="arrowPoint-down"></mc-icon>
+                    </h4>
+
+                    <div id="registration-workplan__delete-goal" class="registration-workplan__delete-goal">
+                        <mc-confirm-button @confirm="deleteGoal(goal)">
+                            <template #button="{open}">
+                                <button class="button button--delete button--icon button--sm" @click="open()">
+                                    <mc-icon name="trash"></mc-icon>
+                                    {{ `Excluir ${getGoalLabelDefault}`  }}
+                                </button>
+                            </template>
+                            <template #message="message">
+                                <h3>{{ `Excluir ${getGoalLabelDefault}` }}</h3><br>
+                                <p>
+                                    {{ `Deseja excluir a ${getGoalLabelDefault} selecionada, todas as suas configurações e as respectivas ${getDeliveryLabelDefault} associadas a ela?` }}
+                                </p>
+                            </template>
+                        </mc-confirm-button>
+                    </div>
+                </div>
+                <h6> {{ getGoalLabelDefault }} {{ index + 1 }}</h6>
+                <div v-if="isExpanded(index)" class="collapse-content">
+                    <div class="registration-workplan__goals-period">
+                        <p>
+                            {{ `Especificação da ${getGoalLabelDefault}` }}
+                        </p>
+                        <div class="registration-workplan__goals-months">
+                            <div class="field">
+                                <label><?= i::esc_attr__('Mês inicial') ?><span class="required">obrigatório*</span></label>
+                                <select v-model="goal.monthInitial" id="mes-inicial">
+                                    <option value=""><?= i::esc_attr__('Selecione') ?></option>
+                                    <option v-for="n in parseInt(workplan.projectDuration)" :key="n" :value="n">{{ n }}</option>
+                                </select>
+                            </div>
+                            <div class="field">
+                                <label for="mes-final"><?= i::esc_attr__('Mês final') ?><span class="required">obrigatório*</span></label>
+                                <select v-model="goal.monthEnd" id="mes-final">
+                                    <option value=""><?= i::esc_attr__('Selecione') ?></option>
+                                    <option v-for="n in range(parseInt(goal.monthInitial), parseInt(workplan.projectDuration)) " :key="n" :value="n">{{ n }}</option>
+                                </select>
+                            </div>
+                        </div>
+                    </div>
+                    
+                    <!-- Título da meta -->
+                    <div class="field">
+                        <label>
+                            {{ `Título da ${getGoalLabelDefault}` }}<span class="required">obrigatório*</span></label>
+                        <input v-model="goal.title" type="text">
+                    </div>
+
+                    <!-- Descrição -->
+                    <div class="field">
+                        <label><?= i::esc_attr__('Descrição') ?><span class="required">obrigatório*</span></label>
+                        <textarea v-model="goal.description"></textarea>
+                    </div>
+
+                    <!-- Etapa do fazer cultural -->
+                    <div v-if="opportunity.workplan_metaInformTheStageOfCulturalMaking" class="field">
+                        <label><?= i::esc_attr__('Etapa do fazer cultural') ?><span class="required">obrigatório*</span></label>
+                        <select v-model="goal.culturalMakingStage">
+                            <option value=""><?= i::esc_attr__('Selecione') ?></option>
+                            <option v-for="n in workplanFields.goal.culturalMakingStage.options" :key="n" :value="n">{{ n }}</option>
+                        </select>
+                    </div>
+
+                    <!-- Valor da meta -->
+                    <div id="container_deliveries">
+                        <div v-for="(delivery, index_) in goal.deliveries" :key="delivery.id" class="registration-workplan__goals__deliveries">
+                            <div class="registration-workplan__header-deliveries">
+                                <h4 class="registration-workplan__goals-title">{{ delivery.name }}</h4>
+                                <div id="registration-workplan__delete-delivery"  class="registration-workplan__delete-delivery">
+                                    <mc-confirm-button @confirm="deleteDelivery(delivery)">
+                                        <template #button="{open}">
+                                            <button class="button button--delete button--icon button--sm" @click="open()">
+                                                <mc-icon name="trash"></mc-icon> 
+                                                {{ `Excluir ${getDeliveryLabelDefault}` }}
+                                            </button>
+                                        </template>
+                                        <template #message="message">
+                                            <h3>{{ `Excluir ${getDeliveryLabelDefault}` }}</h3><br>
+                                            <p>
+                                                {{ `Deseja excluir a ${getDeliveryLabelDefault} selecionada e todas as suas respectivas configurações?` }}
+                                            </p>
+                                        </template>
+                                    </mc-confirm-button>
+                                </div>
+                            </div>
+                            <h6>{{ getDeliveryLabelDefault }} {{ index_ + 1 }}</h6>
+                            <div class="field">
+                                <label>{{ `Nome da ${getDeliveryLabelDefault}` }}<span class="required">obrigatório*</span></label>
+                                <input v-model="delivery.name" type="text">
+                            </div>
+
+                            <div class="field">
+                                <label><?= i::esc_attr__('Descrição') ?><span class="required">obrigatório*</span></label>
+                                <textarea v-model="delivery.description"></textarea>
+                            </div>
+
+                            <div class="field">
+                                <label>
+                                    {{ `Tipo de ${getDeliveryLabelDefault}` }}<span class="required">obrigatório*</span></label>
+                                <select v-model="delivery.typeDelivery">
+                                    <option value=""><?= i::esc_attr__('Selecione') ?></option>
+                                    <option v-for="n in workplanFields.goal.delivery.typeDelivery.options" :key="n" :value="n">{{ n }}</option>
+                                </select>
+                            </div>
+
+                            <div v-if="opportunity.workplan_registrationInformCulturalArtisticSegment" class="field">
+                                <label>
+                                    {{ `Segmento artístico-cultural da entrega` }}
+                                    <span class="required">obrigatório*</span></label>
+                                <select v-model="delivery.segmentDelivery">
+                                    <option value=""><?= i::esc_attr__('Selecione') ?></option>
+                                    <option v-for="n in workplanFields.goal.delivery.segmentDelivery.options" :key="n" :value="n">{{ n }}</option>
+                                </select>
+                            </div>
+
+                            <div v-if="opportunity.workplan_registrationReportTheNumberOfParticipants" class="field">
+                                <label><?= i::esc_attr__('Número previsto de pessoas') ?><span class="required">obrigatório*</span></label>
+                                <input class="field__limits" v-model="delivery.expectedNumberPeople" min="0" type="number">
+                            </div>
+
+                            <div v-if="opportunity.workplan_registrationReportExpectedRenevue">
+                                <div class="field">
+                                    <label>
+                                        {{ `A ${getDeliveryLabelDefault} irá gerar receita?` }}
+                                        <span class="required">obrigatório*</span></label>
+                                    <select class="field__limits" v-model="delivery.generaterRevenue">
+                                        <option value=""><?= i::esc_attr__('Selecione') ?></option>
+                                        <option v-for="(n, i) in workplanFields.goal.delivery.generaterRevenue.options" :key="i" :value="i">{{ n }}</option>
+                                    </select>
+                                </div>
+
+                                <div v-if="delivery.generaterRevenue == 'true'" class="grid-12">
+                                    <div class="field col-4 sm:col-12">
+                                        <label><?= i::esc_attr__('Previsão Quantidade') ?><span class="required">obrigatório*</span></label>
+                                        <input v-model="delivery.renevueQtd" type="number" min="0">
+                                    </div>
+
+                                    <div class="field col-4 sm:col-12">
+                                        <label><?= i::esc_attr__('Previsão de valor unitário') ?><span class="required">obrigatório*</span></label>
+                                        <mc-currency-input v-model="delivery.unitValueForecast"></mc-currency-input>
+                                    </div>
+
+                                    <div class="field col-4 sm:col-12">
+                                        <label><?= i::esc_attr__(text: 'Previsão de valor total') ?><span class="required">obrigatório*</span></label>
+                                        <input readonly :model="delivery.totalValueForecast" :value="totalValueForecastToCurrency(delivery, delivery.renevueQtd, delivery.unitValueForecast)">
+                                    </div>
+                                </div>
+                            </div>
+
+
+                        </div>
+                    </div>
+
+                    <div v-if="enableNewDelivery(goal)"  class="registration-workplan__new-delivery">
+                        <button class="button button--primary-outline" id="button-registration-workplan__new-delivery" @click="newDelivery(goal)">
+                            + {{ getDeliveryLabelDefault }}
+                        </button>
+                    </div>
+
+                    <div class="registration-workplan__save-goal" id="registration-workplan__save-goal">
+                        <button class="button button--primary" id="button-registration-workplan__save-goal" @click="save_">
+                            {{ `Salvar ${getGoalLabelDefault}` }}
+                        </button>
+                    </div>
+
+                </div>
+            </div>
+        </div>
+
+        <div v-if="enableButtonNewGoal && enableNewGoal(workplan)" id="registration-workplan__new-goal" class="registration-workplan__new-goal">
+            <button class="button button--primary-outline" @click="newGoal">
+                + {{ getGoalLabelDefault }}
+            </button>
+        </div>
+    </template>
+</mc-card>
+</div>

--- a/src/modules/OpportunityWorkplan/components/registration-workplan/texts.php
+++ b/src/modules/OpportunityWorkplan/components/registration-workplan/texts.php
@@ -1,0 +1,6 @@
+<?php
+use MapasCulturais\i;
+
+return [
+    'Modificações salvas' => i::__('Modificações salvas')
+];

--- a/src/modules/OpportunityWorkplan/layouts/parts/opportunity-workplan-config.php
+++ b/src/modules/OpportunityWorkplan/layouts/parts/opportunity-workplan-config.php
@@ -1,0 +1,5 @@
+<?php 
+  $this->import('opportunity-enable-workplan');
+?>
+
+<opportunity-enable-workplan :entity="phase"></opportunity-enable-workplan>

--- a/src/modules/OpportunityWorkplan/layouts/parts/registration-details-workplan-print.php
+++ b/src/modules/OpportunityWorkplan/layouts/parts/registration-details-workplan-print.php
@@ -1,0 +1,5 @@
+<?php 
+  $this->import('registration-details-workplan');
+?>
+
+<registration-details-workplan :registration="entity"></registration-workplan>

--- a/src/modules/OpportunityWorkplan/layouts/parts/registration-details-workplan.php
+++ b/src/modules/OpportunityWorkplan/layouts/parts/registration-details-workplan.php
@@ -1,0 +1,5 @@
+<?php 
+  $this->import('registration-details-workplan');
+?>
+
+<registration-details-workplan :registration="entity"></registration-workplan>

--- a/src/modules/OpportunityWorkplan/layouts/parts/registration-workplan.php
+++ b/src/modules/OpportunityWorkplan/layouts/parts/registration-workplan.php
@@ -1,0 +1,5 @@
+<?php 
+  $this->import('registration-workplan');
+?>
+
+<registration-workplan :registration="registration"></registration-workplan>

--- a/src/themes/BaseV2/assets-src/sass/2.components/_opportunity-enable-workplan.scss
+++ b/src/themes/BaseV2/assets-src/sass/2.components/_opportunity-enable-workplan.scss
@@ -1,0 +1,63 @@
+@use '../0.settings/mixins' as *;
+
+.opportunity-enable-workplan {
+    display: flex;
+    flex-direction: column;
+    gap: size(8);
+
+    border-radius: 4px 4px 4px 4px;
+    -webkit-border-radius: 4px 4px 4px 4px;
+    -moz-border-radius: 4px 4px 4px 4px;
+    border: 1px solid #bbbbbb;
+    margin-top: size(16);
+    padding: size(20);
+    width: 100%;
+
+    &__block {
+        border-radius: 4px 4px 4px 4px;
+        -webkit-border-radius: 4px 4px 4px 4px;
+        -moz-border-radius: 4px 4px 4px 4px;
+        border: 1px solid #bbbbbb;
+        margin-top: size(16);
+        padding: size(20);
+        width: 100%;
+    }
+
+    h4 {
+        margin-bottom: size(5);
+    }
+
+    h6 {
+        margin-bottom: size(16);
+    }
+
+    .field-delivery-type {
+        border-radius: 4px 4px 4px 4px;
+        -webkit-border-radius: 4px 4px 4px 4px;
+        -moz-border-radius: 4px 4px 4px 4px;
+        border: 1px solid #bbbbbb;
+        margin-top: size(16);
+        padding: size(20);
+        width: 100%;
+    }    
+
+    .field__limits {
+        max-width: 6.25rem;
+        padding: .5rem;
+        z-index: 2;
+    }
+
+    .disabled-workplan {
+        display:flex;
+        align-items:right;
+        justify-content: flex-end;
+    }
+
+    .icon-workplandisabled {
+        color: #117C83;
+    }
+
+    .mt {
+        margin-top: size(8);
+    }
+}

--- a/src/themes/BaseV2/assets-src/sass/2.components/_registration-details-workplan.scss
+++ b/src/themes/BaseV2/assets-src/sass/2.components/_registration-details-workplan.scss
@@ -1,0 +1,49 @@
+@use '../0.settings/mixins' as *;
+
+.registration-details-workplan {
+    &__goals {
+        padding: size(12);
+        margin-top: size(12);
+        background-color: #f7f7f7;
+        border-radius: 4px 4px 4px 4px;
+        -webkit-border-radius: 4px 4px 4px 4px;
+        -moz-border-radius: 4px 4px 4px 4px;
+        border: 1px solid #ccc;
+        width: 100%;
+    }
+
+    &__header-goals {
+        // cursor: pointer;
+        display: flex;
+        justify-content: space-between;
+        color: var(--mc-primary-500);
+    }
+
+    &__header-deliveries {
+        // cursor: pointer;
+        display: flex;
+        justify-content: space-between;
+        color: var(--mc-primary-500);
+    }
+
+    &__goals-title {
+        color: var(--mc-primary-500);
+    }
+
+    &__goals__deliveries {
+        border-radius: 4px 4px 4px 4px;
+        -webkit-border-radius: 4px 4px 4px 4px;
+        -moz-border-radius: 4px 4px 4px 4px;
+        border: 1px solid #ccc;
+        padding: size(24);
+        margin-top: size(12);
+        background-color: #f3f3f3;
+    }
+
+    .field {
+        margin-top: size(12);
+        background-color: #E8E8E8;
+        padding: size(8);
+        border-radius: 4px;
+    }
+}

--- a/src/themes/BaseV2/assets-src/sass/2.components/_registration-workplan.scss
+++ b/src/themes/BaseV2/assets-src/sass/2.components/_registration-workplan.scss
@@ -1,0 +1,91 @@
+@use '../0.settings/mixins' as *;
+
+.registration-workplan {
+    &__goals {
+        padding: size(12);
+        margin-top: size(12);
+        background-color: #f7f7f7;
+        border-radius: 4px 4px 4px 4px;
+        -webkit-border-radius: 4px 4px 4px 4px;
+        -moz-border-radius: 4px 4px 4px 4px;
+        border: 1px solid #ccc;
+    }
+
+    &__header-goals {
+        cursor: pointer;
+        display: flex;
+        justify-content: space-between;
+        color: var(--mc-primary-500);
+    }
+
+    &__header-deliveries {
+        cursor: pointer;
+        display: flex;
+        justify-content: space-between;
+        color: var(--mc-primary-500);
+    }
+
+    &__goals-title {
+        color: var(--mc-primary-500);
+    }
+
+    &__goals-period {
+        margin-top: size(12);
+        border: 1px solid #ccc;
+        padding: size(12);
+        p {
+            font-weight: bold;
+        }
+    }
+
+    &__goals-months {
+        display: flex; 
+        gap: size(12); 
+    }
+
+    &__delete-goal, &__delete-delivery {
+        // margin-top: size(12);
+        display:flex;
+        align-items:right;
+        justify-content: flex-end;
+        
+    }
+
+    &__goals__deliveries {
+        border-radius: 4px 4px 4px 4px;
+        -webkit-border-radius: 4px 4px 4px 4px;
+        -moz-border-radius: 4px 4px 4px 4px;
+        border: 1px solid #ccc;
+        padding: size(24);
+        margin-top: size(12);
+        background-color: #f3f3f3;
+    }
+
+    &__new-delivery {
+        margin-top: size(12);
+    }
+
+    &__new-goal {
+        margin-top: size(12);
+    }
+
+    &__save-goal {
+        display: flex;
+        justify-content: flex-end;
+        margin-top: size(12);
+    }
+
+    .field {
+        margin-top: size(12);
+    }
+
+    .is-invalid {
+        border: 3px solid red;
+    }
+
+    .field__limits {
+        max-width: 6.25rem;
+        padding: .5rem;
+        z-index: 2;
+    }
+}

--- a/src/themes/BaseV2/assets-src/sass/theme-BaseV2.scss
+++ b/src/themes/BaseV2/assets-src/sass/theme-BaseV2.scss
@@ -142,6 +142,7 @@
 @import '2.components/opportunity-phases-timeline';
 @import '2.components/opportunity-proponent-types';
 @import '2.components/opportunity-ranges-config';
+@import '2.components/opportunity-enable-workplan';
 @import '2.components/opportunity-registrations';
 @import '2.components/opportunity-registration-filter-configuration';
 @import '2.components/opportunity-rules';
@@ -178,6 +179,8 @@
 @import '2.components/registration-related-entity';
 @import '2.components/registration-results';
 @import '2.components/registration-status';
+@import '2.components/registration-workplan';
+@import '2.components/registration-details-workplan';
 @import '2.components/opportunity-header';
 @import '2.components/opportunity-registration-table';
 @import '2.components/occurrence-card';


### PR DESCRIPTION

## Integração da funcionalidade de Plano de Trabalho

Este PR faz parte das entregas de evoluções implementadas no Mapa da Cultura do MinC, realizadas por meio do Termo de Execução Descentralizada - TED GSE, celebrado entre a Secretaria Executiva do Ministério da Cultura e a Universidade Federal do Paraná, contemplando as funcionalidades mínimas necessárias para atender à demanda por ferramentas digitais de mapeamento, monitoramento, prestação de contas, avaliação, cadastro e inscrição de propostas da Política Nacional de Fomento à Cultura Aldir Blanc.

### Contexto e Objetivo

Este PR realiza o repasse da funcionalidade de **Plano de Trabalho**, originalmente desenvolvida no PR [#40](https://github.com/culturagovbr/mapadacultura/pull/40) e [#45](https://github.com/culturagovbr/mapadacultura/pull/45) do [RedeMapas](https://github.com/RedeMapas/mapas) e atualizada no [#73](https://github.com/culturagovbr/mapadacultura/pull/73).  O objetivo é incorporar ao repositório original a funcionalidade completa e corrigida, garantindo aderência à arquitetura atual do sistema.

### Funcionalidade: Plano de Trabalho  (PR [#40](https://github.com/culturagovbr/mapadacultura/pull/40)  e [#45](https://github.com/culturagovbr/mapadacultura/pull/45)) 

Permite ao gestor da oportunidade configurar uma fase com detalhes e características do plano de trabalho que será preenchido no momento da inscrição, caso habilitado.

#### Visão do Gestor de Oportunidade

- Habilitação do plano de trabalho e duração  
  ![Plano de trabalho - duração](https://github.com/user-attachments/assets/08047ad9-de79-4dd3-ae6c-2eaaf9d309d5)

- Configurações das metas  
  ![Metas](https://github.com/user-attachments/assets/fb1ffa55-b55d-4e57-996f-6f5f9d7a29e3)

- Configurações das entregas e monitoramento  
  ![Entregas](https://github.com/user-attachments/assets/f57f58e8-8a19-4b72-9ff8-866508e2c286)

#### Visão do Proponente

- Preenchimento do plano de trabalho na inscrição  
  ![Preenchimento plano](https://github.com/user-attachments/assets/7241f017-3569-4f11-8562-4210d1c8d660)

- Preenchimento de metas  
  ![Preenchimento meta](https://github.com/user-attachments/assets/2ab1610d-41dd-4030-97c0-fbc5d4d6d7c5)

- Preenchimento de entregas da meta  
  ![Preenchimento entrega](https://github.com/user-attachments/assets/6dd161a0-f266-4b60-8111-29fac0780695)

- Visualização dos detalhes da inscrição  
  ![Detalhes inscrição](https://github.com/user-attachments/assets/c21c7d86-0975-4b58-956d-d184e38c5b76)

- Impressão da ficha de inscrição  
  ![Impressão ficha](https://github.com/user-attachments/assets/28c56563-63dd-4ea5-9093-1416b01af86e)

### Considerações Finais

Este repasse consolida de forma coesa a entrega realizada nos PR's [#40](https://github.com/culturagovbr/mapadacultura/pull/40) e [#45](https://github.com/culturagovbr/mapadacultura/pull/45). A melhoria implementada no PR [#73](https://github.com/culturagovbr/mapadacultura/pull/73) foi necessária para garantir flexibilidade aos temas, possibilitando a cada tema a escolha da exibição do tutorial.

Este trabalho concentra-se no repasse formal e estruturado das entregas validadas, sem reengenharia das soluções originais.