### PR TITLE
Flexibilidade para configurar Headers específicos do proxy para obtenção do IP externo do Usuário [module.LGPD]

### DIFF
--- a/src/modules/LGPD/Module.php
+++ b/src/modules/LGPD/Module.php
@@ -86,7 +86,11 @@ class Module extends \MapasCulturais\Module
                     'timestamp' => (new DateTime())->getTimestamp(),
                     'md5' => Module::createHash($text),
                     'text' => $text,
-                    'ip' => $app->request->getIp(),
+                    'ip' => (function() use ($app) {
+                        $proxyHeader = env('PROXY_HEADER', null);
+
+                        return $_SERVER[$proxyHeader] ?? $app->request->getIp();
+                    })(),
                     'userAgent' => $app->request->getUserAgent(),
                 ];
             }


### PR DESCRIPTION
# Cenário

Em alguns ambientes com proxy, a aplicação pode se confundir e pegar o IP de algum container ao invés do IP externo do usuário, a exemplo da Cloudflare que passar o IP externo do usuário através do HEADER (HTTP_CF_CONNECTING_IP).

## Solução

Permite customizar o nome de um HEADER específico (a depender do proxy) para conseguir obter o IP real do usuário.

## Variável de Ambiente
```.env
PROXY_HEADER=HTTP_CF_CONNECTING_IP
```

