### PR TITLE
Verificando a existência da propriedade antes de tentar acessar durante criação de oportunidade de fluxo contínuo 

### DIFF
--- a/src/core/Entities/Opportunity.php
+++ b/src/core/Entities/Opportunity.php
@@ -1659,7 +1659,7 @@ abstract class Opportunity extends \MapasCulturais\Entity
 
     protected function canUser_control($user) {
 
-        if ($this->ownerEntity->canUser('@control', $user)) {
+        if ($this->ownerEntity && $this->ownerEntity->canUser('@control', $user)) {
             return true;
         } else {
             return parent::canUser_control($user);


### PR DESCRIPTION
Essa correção faz parte da implementação presente na release [v7.6.0-minc40.5](https://github.com/culturagovbr/mapadacultura/releases/tag/v7.6.0-minc40.5) do culturagovbr/mapadacultura

