### PR TITLE
fix: Corrige lógica de exibição de acessibilidade em componentes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ e este projeto adere ao [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 ### Correções
  - Ajuste a estilização do campo pessoa com deficiência
  - Ajuste as labels na single do agente
+ - Ajuste da exibição de acessbilidade na lista de espaços
 
 ## [7.6.11] - 2025-10-07
 ### Correções

--- a/src/modules/Components/components/entity-card/template.php
+++ b/src/modules/Components/components/entity-card/template.php
@@ -71,12 +71,6 @@ $this->import('
 			</div>
 		</template>
 
-
-
-
-
-
-
 		<div v-if="entity.shortDescription" class="entity-card__content-shortDescription">
 			<small v-if="sliceDescription">{{slice(entity.shortDescription, 300)}}</small>
 			<small v-if="!sliceDescription">{{showShortDescription}}</small>
@@ -84,8 +78,9 @@ $this->import('
 
 		<div v-if="entity.__objectType=='space'" class="entity-card__content--description">
 			<label><?= i::_e('ACESSIBILIDADE:') ?>
-				<strong v-if="entity.acessibilidade"> <?= i::_e('Oferece') ?> </strong>
-				<strong v-if="!entity.acessibilidade"> <?= i::_e('Não') ?> </strong>
+				<strong v-if="entity.acessibilidade === 'Sim'"> <?= i::_e('Oferece') ?> </strong>
+				<strong v-else-if="entity.acessibilidade === 'Não'"> <?= i::_e('Não') ?> </strong>
+				<strong v-else> <?= i::_e('Não informado') ?> </strong>
 			</label>
 		</div>
 

--- a/src/modules/Components/components/mc-map-card/template.php
+++ b/src/modules/Components/components/mc-map-card/template.php
@@ -37,12 +37,15 @@ $this->import('
         <div v-if="areas" class="mc-map-card__content--info">
             <p v-if="entity.__objectType != 'agent'" class="info">
             <?= i::_e('ACESSIBILIDADE:') ?>
-                <strong v-if="entity.acessibilidade">
-                   <strong><?= i::_e('Oferece') ?></strong>
+                <strong v-if="entity.acessibilidade === 'Sim'">
+                   <?= i::_e('Oferece') ?>
                 </strong>
-                <strong v-else> <?= i::_e('Não') ?>
+                <strong v-else-if="entity.acessibilidade === 'Não'">
+                   <?= i::_e('Não') ?>
                 </strong>
-
+                <strong v-else>
+                   <?= i::_e('Não informado') ?>
+                </strong>
             </p>
         </div>
         <div v-if="areas" class="mc-map-card__content--info">


### PR DESCRIPTION
Quando marcava Não na acessibilidade, ele mostrava oferece na listagem

<img width="760" height="184" alt="image" src="https://github.com/user-attachments/assets/44162c67-13f4-4030-9983-6a45849058f0" />

<img width="740" height="332" alt="image" src="https://github.com/user-attachments/assets/d95ad7ed-b872-4791-8afc-2d03dc2f7493" />
