### PR TITLE
Adiciona opção do fediverso como rede social nos metadados das entidades.

### DIFF
--- a/config/registrations.php
+++ b/config/registrations.php
@@ -2,7 +2,7 @@
 
 return [
     'registration.prefix' => env('REGISTRATION_PREFIX', 'on-'),
-    
+
    'registration.proponentTypes' => [
     	\MapasCulturais\i::__('Pessoa Física'),
     	\MapasCulturais\i::__('MEI'),
@@ -11,14 +11,14 @@ return [
     ],
 
     'registration.proponentTypesToAgentsMap' => [
-        'Pessoa Física' => 'owner', 
+        'Pessoa Física' => 'owner',
         'MEI' => 'owner',
         'Coletivo' => 'coletivo',
         'Pessoa Jurídica' => 'coletivo',
     ],
 
 
-    /* 
+    /*
     Timeout para o auto salvamento das inscrições (em milisegundos)
     */
     'registration.autosaveTimeout' => env('REGISTRATION_AUTOSAVE_INTERVAL', MINUTE_IN_SECONDS * 1000),
@@ -29,10 +29,10 @@ return [
         'optional' => \MapasCulturais\i::__('Opcional')
     ),
 
-    /* 
+    /*
     Array que define quais propriedades do reponsável serão exportados.
-    
-    ex: `["genero","raca"]` 
+
+    ex: `["genero","raca"]`
     */
     'registration.reportOwnerProperties' => json_decode(env('REGISTRATION_REPORT_OWNER_PROPERTIES', '["name","genero","raca","documento"]')),
 
@@ -61,7 +61,8 @@ return [
         'site',
         'googleplus',
         'facebook',
-        'twitter'
+        'twitter',
+        'fediverso'
     ),
     'registration.ownerDefinition' => array(
         'required' => true,
@@ -107,7 +108,8 @@ return [
         'site',
         'googleplus',
         'facebook',
-        'twitter'
+        'twitter',
+        'fediverso'
     ),
 
     'registrations.distribution.dateString' => 'H:00',

--- a/src/conf/agent-types.php
+++ b/src/conf/agent-types.php
@@ -116,7 +116,7 @@ return array(
                 MapasCulturais\i::__('Retireiros do Araguaia'),
                 MapasCulturais\i::__('Ribeirinhos'),
                 MapasCulturais\i::__('Vazanteiros'),
-                MapasCulturais\i::__('Veredeiros'),                                
+                MapasCulturais\i::__('Veredeiros'),
             ),
             'available_for_opportunities' => true
         ),
@@ -165,7 +165,7 @@ return array(
                 if (!$value && isset($entity->type) && $entity->type->id == 2) {
                     $value = $entity->documento;
                 }
-    
+
                 return Utils::formatCnpjCpf($value);
             },
             'validations' => array(
@@ -188,7 +188,7 @@ return array(
                 /**@var MapasCulturais\App $this */
                 if(!$this->rcache->contains("$entity:SET_cpf")){
                     $this->rcache->save("$entity:SET_cpf", true);
-                    
+
                     if($entity->type && $entity->type->id == 1 && !$this->rcache->contains("$entity:SET_documento")){
                         $entity->documento = $value;
                     }
@@ -330,7 +330,7 @@ return array(
                $this->hook("entity(<<*>>).save:before", function() use ($entity){
                     /** @var MapasCulturais\Entity $entity */
                     if($this->equals($entity)){
-                        $this->idoso = 1; 
+                        $this->idoso = 1;
                     }
                });
                return (new DateTime($value))->format("Y-m-d");
@@ -448,7 +448,7 @@ return array(
             'field_type' => 'email',
             'unserialize' => function($value, $agent = null){
                 $agent = (object) $agent;
-                $user = $agent->user ?? null;  
+                $user = $agent->user ?? null;
                 if(!$value && $user && $user->email){
                     return $user->email;
                 }
@@ -496,7 +496,7 @@ return array(
             'label' => \MapasCulturais\i::__('Endereço'),
             'type' => 'text'
         ),
-                    
+
         'En_CEP' => [
             'label' => \MapasCulturais\i::__('CEP'),
             'type' => 'cep',
@@ -722,6 +722,18 @@ return array(
             ),
             'placeholder' => \MapasCulturais\i::__('nomedousuario'),
             'available_for_opportunities' => true
+        ),
+        'fediverso' => array(
+            'type' => "socialMedia",
+            'label' => \MapasCulturais\i::__('Fediverso'),
+            'available_for_opportunities' => true,
+            'serialize' => function ($value) {
+                return $value;
+            },
+            'validations' => array(
+                "v::url()" => \MapasCulturais\i::__("A url informada é inválida.")
+            ),
+            'placeholder' => \MapasCulturais\i::__('https://nomedoservidor.com.br/@nomedousuario'),
         ),
     ),
     'items' => array(

--- a/src/conf/event-types.php
+++ b/src/conf/event-types.php
@@ -180,6 +180,18 @@ return array(
             'placeholder' => \MapasCulturais\i::__('nomedousuario'),
             'available_for_opportunities' => true
         ),
+        'fediverso' => array(
+            'type' => "socialMedia",
+            'label' => \MapasCulturais\i::__('Fediverso'),
+            'available_for_opportunities' => true,
+            'serialize' => function ($value) {
+                return $value;
+            },
+            'validations' => array(
+                "v::url()" => \MapasCulturais\i::__("A url informada é inválida.")
+            ),
+            'placeholder' => \MapasCulturais\i::__('https://nomedoservidor.com.br/@nomedousuario'),
+        ),
         'event_attendance' => array(
             'label' => \MapasCulturais\i::__('Público presente'),
             'type' => 'integer',

--- a/src/conf/opportunity-types.php
+++ b/src/conf/opportunity-types.php
@@ -212,6 +212,18 @@ return array(
             'placeholder' => \MapasCulturais\i::__('nomedousuario'),
             'available_for_opportunities' => true
         ),
+        'fediverso' => array(
+            'type' => "socialMedia",
+            'label' => \MapasCulturais\i::__('Fediverso'),
+            'available_for_opportunities' => true,
+            'serialize' => function ($value) {
+                return $value;
+            },
+            'validations' => array(
+                "v::url()" => \MapasCulturais\i::__("A url informada é inválida.")
+            ),
+            'placeholder' => \MapasCulturais\i::__('https://nomedoservidor.com.br/@nomedousuario'),
+        ),
         'registrationSeals' => array(
                 'label' => \MapasCulturais\i::__('Selos'),
                 'serialize' => function($value) { return json_encode($value); },
@@ -256,7 +268,7 @@ return array(
             'type' => 'integer',
             'label' => \MapasCulturais\i::__('É modelo público?'),
         ),
-        
+
         'requestAgentAvatar' => array(
             'label' => \MapasCulturais\i::__('Solicitar avatar'),
             'type' => 'radio',
@@ -275,15 +287,15 @@ return array(
             'label' => \MapasCulturais\i::__('É modelo?'),
             'default_value' => 0
         ),
-        
+
         'isModelPublic' => array(
             'type' => 'integer',
             'label' => \MapasCulturais\i::__('É modelo público?'),
         ),
-        
+
     ),
     'items' => $items,
-    
+
     /* EXEMPLOS DE METADADOS:
 
     'cnpj' => array(

--- a/src/conf/project-types.php
+++ b/src/conf/project-types.php
@@ -169,7 +169,18 @@ return array(
             'placeholder' => \MapasCulturais\i::__('nomedousuario'),
             'available_for_opportunities' => true
         ),
-
+        'fediverso' => array(
+            'type' => "socialMedia",
+            'label' => \MapasCulturais\i::__('Fediverso'),
+            'available_for_opportunities' => true,
+            'serialize' => function ($value) {
+                return $value;
+            },
+            'validations' => array(
+                "v::url()" => \MapasCulturais\i::__("A url informada é inválida.")
+            ),
+            'placeholder' => \MapasCulturais\i::__('https://nomedoservidor.com.br/@nomedousuario'),
+        ),
         'emailPublico' => array(
             'label' => \MapasCulturais\i::__('Email Público'),
             'validations' => array(
@@ -223,7 +234,7 @@ return array(
 
     ),
     'items' => $items,
-    
+
     /* EXEMPLOS DE METADADOS:
 
     'cnpj' => array(

--- a/src/conf/space-types.php
+++ b/src/conf/space-types.php
@@ -15,7 +15,7 @@ use MapasCulturais\Utils;
             13 => array( 'name' => \MapasCulturais\i::__('Espaço Público Para Projeção de Filmes') ),
             14 => array( 'name' => \MapasCulturais\i::__('Sala de cinema')),
         ),
-        
+
     ),
 
     \MapasCulturais\i::__('Bibliotecas') => array(
@@ -232,7 +232,7 @@ use MapasCulturais\Utils;
 
 function ordenaSubcategorias(&$array) {
     ksort($array);
-    
+
     foreach ($array as &$item) {
         if (isset($item['items'])) {
             uasort($item['items'], function($a, $b) {
@@ -548,7 +548,18 @@ return array(
             'placeholder' => \MapasCulturais\i::__('nomedousuario'),
             'available_for_opportunities' => true
         ),
-
+        'fediverso' => array(
+            'type' => "socialMedia",
+            'label' => \MapasCulturais\i::__('Fediverso'),
+            'available_for_opportunities' => true,
+            'serialize' => function ($value) {
+                return $value;
+            },
+            'validations' => array(
+                "v::url()" => \MapasCulturais\i::__("A url informada é inválida.")
+            ),
+            'placeholder' => \MapasCulturais\i::__('https://nomedoservidor.com.br/@nomedousuario'),
+        ),
     ),
 
 /**

--- a/src/modules/Components/components/mc-icon/init.php
+++ b/src/modules/Components/components/mc-icon/init.php
@@ -11,7 +11,7 @@ $iconset = [
     'agent' => 'fa-solid:user-friends',
     'agent-1' => 'fa-solid:user',
     'agent-2' => 'fa-solid:user-friends',
-  
+
     'space' => 'clarity:building-solid',
     'event' => 'bxs:calendar-event',
     'project' => 'ri:file-list-2-fill',
@@ -31,6 +31,7 @@ $iconset = [
     'whatsapp' => 'akar-icons:whatsapp-fill',
     'vimeo' => 'brandico:vimeo',
     'youtube' => 'akar-icons:youtube-fill',
+    'fediverso' => 'ri-fediverse-line',
 
 
     // IMPORTANTE: manter ordem alfabética
@@ -126,7 +127,7 @@ $iconset = [
     'sync' => 'material-symbols:sync',
     'table-view' => 'ic:outline-table-view',
     'text' => 'ic:sharp-text-fields',
-    'ticket' => 'mdi:ticket-confirmation-outline',  
+    'ticket' => 'mdi:ticket-confirmation-outline',
     'trash' => 'ooui:trash',
     'triangle-down' => 'entypo:triangle-down',
     'triangle-up' => 'entypo:triangle-up',

--- a/src/modules/Components/components/mc-summary-agent-info/template.php
+++ b/src/modules/Components/components/mc-summary-agent-info/template.php
@@ -7,7 +7,7 @@
 use MapasCulturais\i;
 
 $this->import('
-    mc-icon    
+    mc-icon
 ');
 ?>
 
@@ -39,6 +39,7 @@ $this->import('
         <h4 v-if="owner.site"> <span class="bold"><?= i::__("Site:") ?></span> {{owner.site}} </h4>
         <h4 v-if="owner.facebook"> <span class="bold"><?= i::__("Facebook:") ?></span> {{owner.facebook}} </h4>
         <h4 v-if="owner.twitter"> <span class="bold"><?= i::__("Twitter:") ?></span> {{owner.twitter}} </h4>
+        <h4 v-if="owner.fediverso"> <span class="bold"><?= i::__("Fediverso:") ?></span> {{owner.fediverso}} </h4>
     </div>
 
     <div v-if="opportunity.useAgentRelationColetivo && opportunity.useAgentRelationColetivo !== 'dontUse'" class="mc-summary-agent-info__section">

--- a/src/modules/Entities/components/entity-header/script.js
+++ b/src/modules/Entities/components/entity-header/script.js
@@ -1,7 +1,7 @@
 app.component('entity-header', {
     template: $TEMPLATES['entity-header'],
-    setup() { 
-        // os textos estão localizados no arquivo texts.php deste componente 
+    setup() {
+        // os textos estão localizados no arquivo texts.php deste componente
         const text = Utils.getTexts('entity-header')
         return { text }
     },
@@ -22,7 +22,7 @@ app.component('entity-header', {
     },
     created() {
         switch(this.entity.__objectType) {
-            case 'agent': 
+            case 'agent':
                 this.titleEdit = (this.entity.type?.id == 1) ?  __('title agent-1', 'entity-header') : __('title agent-2', 'entity-header');
                 break;
             case 'project':
@@ -56,6 +56,7 @@ app.component('entity-header', {
                 'pinterest',
                 'whatsapp',
                 'tiktok',
+                'fediverso',
             ]
 
             let itHas = false;

--- a/src/modules/Entities/components/entity-header/template.php
+++ b/src/modules/Entities/components/entity-header/template.php
@@ -55,6 +55,9 @@ $this->import('
                 <a v-if="entity.tiktok" class="button button--text button--icon" aria-label="tiktok" target="_blank" :href="buildSocialMediaLink('tiktok')">
                     <mc-icon name="tiktok"></mc-icon>
                 </a>
+                <a v-if="entity.fediverso" class="button button--text button--icon" aria-label="fediverso" target="_blank" :href="buildSocialMediaLink('fediverso')">
+                    <mc-icon name="fediverso"></mc-icon>
+                </a>
             </nav>
         </div>
         <div class="rightSide">
@@ -65,7 +68,7 @@ $this->import('
                         <dl v-if="entity.id && global.showIds[entity.__objectType]" class="metadata__id">
                             <dt class="metadata__id--id"><?= i::__('ID') ?></dt>
                             <dd><strong>{{entity.id}}</strong></dd>
-                        </dl> 
+                        </dl>
                         <dl v-if="entity.type">
                             <dt><?= i::__('Tipo')?></dt>
                             <dd :class="[entity.__objectType+'__color', 'type']">{{entity.type.name}} </dd>

--- a/src/modules/Entities/components/entity-social-media/script.js
+++ b/src/modules/Entities/components/entity-social-media/script.js
@@ -3,7 +3,7 @@ app.component('entity-social-media', {
 
     data() {
         return {
-            show: !!(this.entity.instagram || this.entity.twitter || this.entity.vimeo || this.entity.linkedin || this.entity.facebook || this.entity.youtube || this.entity.spotify || this.entity.pinterest || this.entity.tiktok),
+            show: !!(this.entity.instagram || this.entity.twitter || this.entity.vimeo || this.entity.linkedin || this.entity.facebook || this.entity.youtube || this.entity.spotify || this.entity.pinterest || this.entity.tiktok || this.entity.fediverso),
         }
     },
 

--- a/src/modules/Entities/components/entity-social-media/template.php
+++ b/src/modules/Entities/components/entity-social-media/template.php
@@ -1,4 +1,4 @@
-<?php 
+<?php
 /**
  * @var MapasCulturais\App $app
  * @var MapasCulturais\Themes\BaseV2\Theme $this
@@ -58,6 +58,10 @@ $this->import('
             <a target="_blank" :href="buildSocialMediaLink('tiktok')">{{entity.tiktok}}</a>
         </div>
 
+        <div v-if="entity.fediverso" class="entity-social-media__links--link">
+            <mc-icon name="fediverso"></mc-icon>
+            <a target="_blank" :href="buildSocialMediaLink('fediverso')">{{entity.fediverso}}</a>
+        </div>
     </div>
 
 
@@ -107,6 +111,10 @@ $this->import('
         <div class="entity-social-media__edit--link">
             <mc-icon name="tiktok"></mc-icon>
             <entity-field :entity="entity" prop="tiktok"></entity-field>
+        </div>
+        <div class="entity-social-media__edit--link">
+            <mc-icon name="fediverso"></mc-icon>
+            <entity-field :entity="entity" prop="fediverso"></entity-field>
         </div>
     </div>
 </div>


### PR DESCRIPTION
## Objetivo

Disseminar o fediverso enquanto opção de rede social no mapeamento cultural brasileiro.

## Contexto

O Thiago Skarnio provou sobre a necessidade da inclusão da opção de redes sociais decentralizadas e em pouco tempo tinha um commit com as alterações mínima. ficou faltando só a validação da url, sugestão dele para contemplar a maior quantidade de servidores possível.

## Abordagem Técnica

Foi replicado em as entidades: Agentes, oportunidades, espaços, eventos e projetos passam a ter um novo campo de redes sociais, agora incluindo as decentralizadas com a validação por url.

Contou com a ajuda do @vitfera para revisão e testes.