### PR TITLE
Corrige nome do agente coletivo em minhas inscrições

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ e este projeto adere ao [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 ### Correções
 - Aplica texto de internacionalização faltante no componente opportunity-registration-table
 - Corrige acento faltante no texto "Gênero" na listagem de pessoas do formulário de inscrição
+- Corrige a exibição do nome do agente coletivo nos cards da tela Minhas inscrições
 
 ## [7.7.19] - 2026-03-27
 ### Correções

--- a/src/modules/Opportunities/components/registration-card/script.js
+++ b/src/modules/Opportunities/components/registration-card/script.js
@@ -45,6 +45,11 @@ app.component('registration-card', {
             }
             return status;
         },
+        collectiveName() {
+            return this.entity.agentRelations?.coletivo?.[0]?.agent?.name
+                || this.entity.agentRelations?.coletivo?.[0]?.agent?.nomeCompleto
+                || '';
+        },
     },
     
     methods: { 

--- a/src/modules/Opportunities/components/registration-card/template.php
+++ b/src/modules/Opportunities/components/registration-card/template.php
@@ -82,9 +82,9 @@ $this->import('
                 <?php endif ?>
 
                 <?php if($app->config['app.registrationCardFields']['coletive']): ?>
-                    <div v-if="entity?.agentRelations?.coletivo" class="registerData">
+                    <div v-if="collectiveName" class="registerData">
                         <p class="title"> <?= $this->text('coletive-label',i::__('Nome coletivo')) ?></p>
-                        <p class="data"> {{entity?.agentRelations?.coletivo[0].agent.nomeCompleto}} </p>
+                        <p class="data"> {{collectiveName}} </p>
                     </div>
                 <?php endif ?>
             </div>


### PR DESCRIPTION
## Objetivo
Corrigir a exibição do nome do agente coletivo nos cards da tela **Minhas inscrições**.

## O que foi ajustado
- Ajusta o componente `registration-card` para exibir o nome do agente coletivo usando o campo padrão da aplicação.
- Mantém fallback defensivo para `nomeCompleto` quando necessário.
- Adiciona registro da correção no `CHANGELOG.md`.

## Comportamento antes
Nos cards da tela **Minhas inscrições**, o campo **Nome coletivo** não exibia corretamente o nome do agente coletivo em alguns casos.

## Comportamento agora
Quando a inscrição possui agente coletivo vinculado, o card passa a exibir corretamente o nome do coletivo.