### PR TITLE
Feat/opportunity collective avatar required

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ e este projeto adere ao [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 - Ordena opções de tipos de campos da lista de campos @ em ordem alfabética
 - Ajusta exportação da planilha para organizar as colunas segundo a ordem definida pelo superSaasAdmin
 - Melhora a exibição do botão minha conta no header para exibir o nome do perfil do agente responsável logado
+- Adiciona configuração para exigir foto de perfil do agente coletivo vinculado na inscrição para proponentes do tipo coletivo e pessoa jurídica
 
 ### Correções
 - Aplica texto de internacionalização faltante no componente opportunity-registration-table

--- a/src/core/Entities/Registration.php
+++ b/src/core/Entities/Registration.php
@@ -1381,6 +1381,9 @@ class Registration extends \MapasCulturais\Entity
             $errorsResult['avatar'] = [sprintf(\MapasCulturais\i::__('A imagem avatar do agente "%s" é obrigatório.'),$this->owner->name)];
         }
 
+        $proponent_agent_relation = $this->opportunity->proponentAgentRelation ?? null;
+        $proponent_agent_relation_avatar = $this->opportunity->proponentAgentRelationAvatar ?? null;
+
         $definitionsWithAgents = $this->_getDefinitionsWithAgents();
         
         // validate agents
@@ -1415,6 +1418,17 @@ class Registration extends \MapasCulturais\Entity
             }
 
             if($def->agent){
+                $requires_avatar = false;
+                if ($proponent_agent_relation && $proponent_agent_relation_avatar) {
+                    $requires_avatar = ($proponent_agent_relation->{$this->proponentType} ?? false)
+                        && ($proponent_agent_relation_avatar->{$this->proponentType} ?? false);
+                }
+
+                if ($group_name === 'coletivo' && $requires_avatar && !array_key_exists('avatar', $def->agent->files)) {
+                    $errorsResult[$agent_prefix . $def->agentRelationGroupName . '_avatar'] = [
+                        sprintf(i::__('A imagem avatar do agente "%s" é obrigatório.'), $def->agent->name)
+                    ];
+                }
 
                 if($def->relationStatus < 0){
                     $errors[] = sprintf(i::__('O agente %s ainda não confirmou sua participação neste projeto.'), $def->agent->name);

--- a/src/modules/Entities/components/entity-profile/template.php
+++ b/src/modules/Entities/components/entity-profile/template.php
@@ -12,7 +12,7 @@ $this->import('
 ');
 ?>
 
-<div class="entity-profile" :class="{error: entity.__validationErrors['file:avatar']}">
+<div class="entity-profile" :class="{error: entity.__validationErrors?.['file:avatar']}">
     <mc-image-uploader :entity="entity" group="avatar" :aspect-ratio="1" :circular="true">
         <template #default="modal">
             <div class="entity-profile__profile">
@@ -24,7 +24,7 @@ $this->import('
             </div>
         </template>
     </mc-image-uploader>
-    <div v-if="entity.__validationErrors['file:avatar']" class="field__error">
-        {{entity.__validationErrors['file:avatar'].join(', ')}}
+    <div v-if="entity.__validationErrors?.['file:avatar']" class="field__error">
+        {{entity.__validationErrors?.['file:avatar'].join(', ')}}
     </div>
 </div>

--- a/src/modules/Opportunities/Module.php
+++ b/src/modules/Opportunities/Module.php
@@ -1224,6 +1224,12 @@ class Module extends \MapasCulturais\Module{
             'description' => i::__('Armazena se a vinculação de agente coletivo está habilitada para Coletivo ou Pessoa Jurídica'),
         ]);
 
+        $this->registerOpportunityMetadata('proponentAgentRelationAvatar', [
+            'label' => i::__('Solicitação de avatar do Agente coletivo para tipos de proponente'),
+            'type' => 'object',
+            'description' => i::__('Armazena se o avatar do agente coletivo é obrigatório para Coletivo ou Pessoa Jurídica'),
+        ]);
+
         $this->registerEvauationMethodConfigurationMetadata('fetchFields', [
             'label' => i::__('Configuração filtro de inscrição para avaliadores/comissão'),
             'type' => 'object',

--- a/src/modules/Opportunities/components/opportunity-proponent-types/script.js
+++ b/src/modules/Opportunities/components/opportunity-proponent-types/script.js
@@ -26,6 +26,10 @@ app.component('opportunity-proponent-types', {
                 "Coletivo": false,
                 "Pessoa Jurídica": false
             },
+            proponentAgentRelationAvatar: this.entity.proponentAgentRelationAvatar || {
+                "Coletivo": false,
+                "Pessoa Jurídica": false
+            },
         };
     },
 
@@ -51,6 +55,7 @@ app.component('opportunity-proponent-types', {
     
                 if (optionValue === 'Coletivo' || optionValue === 'Pessoa Jurídica') {
                     this.proponentAgentRelation[optionValue] = false;
+                    this.proponentAgentRelationAvatar[optionValue] = false;
                 }
             }
 
@@ -60,6 +65,17 @@ app.component('opportunity-proponent-types', {
 
         toggleAgentRelation(event, type) {
             this.proponentAgentRelation[type] = event.target.checked;
+
+            if (!event.target.checked) {
+                this.proponentAgentRelationAvatar[type] = false;
+            }
+
+            this.updateProponentAgentRelation();
+            this.entity.save();
+        },
+
+        toggleAgentRelationAvatar(event, type) {
+            this.proponentAgentRelationAvatar[type] = event.target.checked;
             this.updateProponentAgentRelation();
             this.entity.save();
         },
@@ -68,6 +84,7 @@ app.component('opportunity-proponent-types', {
             const anyAgentRelationChecked = Object.values(this.proponentAgentRelation).includes(true);
             this.entity.useAgentRelationColetivo = anyAgentRelationChecked ? 'required' : 'dontUse';
             this.entity.proponentAgentRelation = this.proponentAgentRelation;
+            this.entity.proponentAgentRelationAvatar = this.proponentAgentRelationAvatar;
         }
     }
 });

--- a/src/modules/Opportunities/components/opportunity-proponent-types/template.php
+++ b/src/modules/Opportunities/components/opportunity-proponent-types/template.php
@@ -38,7 +38,7 @@ use MapasCulturais\i;
                             :checked="proponentAgentRelationAvatar['Coletivo']" 
                             @change="toggleAgentRelationAvatar($event, 'Coletivo')"
                         > 
-                        <?= i::__("Obrigar o upload da foto de perfil")?>
+                        <?= i::__("Habilitar solicitação de imagem de perfil")?>
                     </label>
                 </div>
 
@@ -57,7 +57,7 @@ use MapasCulturais\i;
                             :checked="proponentAgentRelationAvatar['Pessoa Jurídica']" 
                             @change="toggleAgentRelationAvatar($event, 'Pessoa Jurídica')"
                         > 
-                        <?= i::__("Obrigar o upload da foto de perfil")?>
+                        <?= i::__("Habilitar solicitação de imagem de perfil")?>
                     </label>
                 </div>
             </div>

--- a/src/modules/Opportunities/components/opportunity-proponent-types/template.php
+++ b/src/modules/Opportunities/components/opportunity-proponent-types/template.php
@@ -32,6 +32,14 @@ use MapasCulturais\i;
                         > 
                         <?= i::__("Habilitar a vinculação de agente coletivo")?>
                     </label>
+                    <label v-if="proponentAgentRelation['Coletivo']">
+                        <input 
+                            type="checkbox" 
+                            :checked="proponentAgentRelationAvatar['Coletivo']" 
+                            @change="toggleAgentRelationAvatar($event, 'Coletivo')"
+                        > 
+                        <?= i::__("Obrigar o upload da foto de perfil")?>
+                    </label>
                 </div>
 
                 <div class="opportunity-proponent-types__field field__legal" v-if="showJuridicaBinding && optionValue === '<?= i::__('Pessoa Jurídica') ?>'">
@@ -42,6 +50,14 @@ use MapasCulturais\i;
                             @change="toggleAgentRelation($event, 'Pessoa Jurídica')"
                         > 
                         <?= i::__("Habilitar a vinculação de agente coletivo")?>
+                    </label>
+                    <label v-if="proponentAgentRelation['Pessoa Jurídica']">
+                        <input 
+                            type="checkbox" 
+                            :checked="proponentAgentRelationAvatar['Pessoa Jurídica']" 
+                            @change="toggleAgentRelationAvatar($event, 'Pessoa Jurídica')"
+                        > 
+                        <?= i::__("Obrigar o upload da foto de perfil")?>
                     </label>
                 </div>
             </div>

--- a/src/modules/Opportunities/components/registration-edition/script.js
+++ b/src/modules/Opportunities/components/registration-edition/script.js
@@ -69,6 +69,12 @@ app.component('registration-edition', {
         step () {
             return this.steps[this.stepIndex];
         },
+
+        collectiveAvatarRequired() {
+            const avatarConfig = this.entity.opportunity.proponentAgentRelationAvatar ?? {};
+            const relationConfig = this.entity.opportunity.proponentAgentRelation ?? {};
+            return relationConfig[this.entity.proponentType] === true && avatarConfig[this.entity.proponentType] === true;
+        },
     },
 
     watch: {

--- a/src/modules/Opportunities/components/registration-edition/script.js
+++ b/src/modules/Opportunities/components/registration-edition/script.js
@@ -70,6 +70,28 @@ app.component('registration-edition', {
             return this.steps[this.stepIndex];
         },
 
+        collectiveRelations() {
+            const relations = this.entity.agentRelations.coletivo ?? [];
+
+            return relations.map((relation) => {
+                if (relation?.agent instanceof Entity) {
+                    return relation;
+                }
+
+                if (relation?.agent?.id) {
+                    const agent = new Entity('agent', relation.agent.id);
+                    agent.populate(relation.agent);
+
+                    return {
+                        ...relation,
+                        agent,
+                    };
+                }
+
+                return relation;
+            });
+        },
+
         collectiveAvatarRequired() {
             const avatarConfig = this.entity.opportunity.proponentAgentRelationAvatar ?? {};
             const relationConfig = this.entity.opportunity.proponentAgentRelation ?? {};

--- a/src/modules/Opportunities/components/registration-edition/template.php
+++ b/src/modules/Opportunities/components/registration-edition/template.php
@@ -59,8 +59,8 @@ $this->import('
                             </div>
                         </div>
                     </div>
-                    <div class="card collective" v-if="!preview && entity.agentRelations.coletivo?.length > 0">
-                        <div class="card__content" v-for="agentCollective in entity.agentRelations.coletivo">
+                    <div class="card collective" v-if="!preview && collectiveRelations.length > 0">
+                        <div class="card__content" v-for="agentCollective in collectiveRelations">
                             <div class="collective">
                                 <mc-avatar v-if="!collectiveAvatarRequired" :entity="agentCollective.agent" size="small"></mc-avatar>
                                 <request-agent-avatar

--- a/src/modules/Opportunities/components/registration-edition/template.php
+++ b/src/modules/Opportunities/components/registration-edition/template.php
@@ -62,7 +62,12 @@ $this->import('
                     <div class="card collective" v-if="!preview && entity.agentRelations.coletivo?.length > 0">
                         <div class="card__content" v-for="agentCollective in entity.agentRelations.coletivo">
                             <div class="collective">
-                                <mc-avatar :entity="agentCollective.agent" size="small"></mc-avatar>
+                                <mc-avatar v-if="!collectiveAvatarRequired" :entity="agentCollective.agent" size="small"></mc-avatar>
+                                <request-agent-avatar
+                                    v-if="collectiveAvatarRequired"
+                                    :entity="entity"
+                                    :agent="agentCollective.agent"
+                                    error-key="agent_coletivo_avatar"></request-agent-avatar>
                                 <div class="collective__content">
                                     <div class="collective__content--title">
                                         <h3 class="card__title">
@@ -71,6 +76,9 @@ $this->import('
                                         <div class="collective__name">
                                             {{agentCollective.agent.name}}
                                         </div>
+                                    </div>
+                                    <div v-if="collectiveAvatarRequired" class="card__mandatory">
+                                        <div class="obrigatory"> <?= i::__('*obrigatório') ?> </div>
                                     </div>
                                 </div>
                             </div>

--- a/src/modules/Opportunities/components/request-agent-avatar/script.js
+++ b/src/modules/Opportunities/components/request-agent-avatar/script.js
@@ -8,18 +8,39 @@ template: $TEMPLATES['request-agent-avatar'],
         return {}
     },
 
-    computed: {},
+    computed: {
+        targetEntity() {
+            return this.agent || this.entity.owner;
+        },
+
+        errorMessages() {
+            if (!this.errorKey) {
+                return [];
+            }
+
+            return this.entity.__validationErrors?.[this.errorKey] || [];
+        },
+    },
 
     props: {
         entity: {
             type: Entity,
             required: true
         },
+        agent: {
+            type: Entity,
+            required: false,
+            default: null
+        },
+        errorKey: {
+            type: String,
+            default: 'avatar'
+        }
     },
 
     methods: {
         hasErrors() {
-            let errors = this.entity.__validationErrors['avatar'] || [];
+            let errors = this.errorMessages;
             if(errors.length > 0){
                 return true;
             } else {

--- a/src/modules/Opportunities/components/request-agent-avatar/template.php
+++ b/src/modules/Opportunities/components/request-agent-avatar/template.php
@@ -13,5 +13,8 @@ $this->import('
 
 ?>
 <span class="icon">
-    <entity-profile :entity="entity.owner" size="small"></entity-profile>
+    <entity-profile :entity="targetEntity" size="small"></entity-profile>
 </span>
+<div v-if="errorMessages.length" class="field__error">
+    {{ errorMessages.join(', ') }}
+</div>

--- a/src/modules/OpportunityExporter/Exporter.php
+++ b/src/modules/OpportunityExporter/Exporter.php
@@ -188,6 +188,7 @@ class Exporter
             'registrationProponentTypes' => $this->opportunity->registrationProponentTypes ?: [],
             'useAgentRelationColetivo' => $this->opportunity->useAgentRelationColetivo,
             'proponentAgentRelation' => $this->opportunity->proponentAgentRelation,
+            'proponentAgentRelationAvatar' => $this->opportunity->proponentAgentRelationAvatar,
         ];
 
         return $result;

--- a/src/modules/OpportunityExporter/Importer.php
+++ b/src/modules/OpportunityExporter/Importer.php
@@ -178,6 +178,10 @@ class Importer
             $this->opportunity->proponentAgentRelation = $data['proponentAgentRelation'];
         }
 
+        if (array_key_exists('proponentAgentRelationAvatar', $data)) {
+            $this->opportunity->proponentAgentRelationAvatar = $data['proponentAgentRelationAvatar'];
+        }
+
         $this->opportunity->save(true);
     }
 


### PR DESCRIPTION
## Resumo
Este PR adiciona a possibilidade de exigir a imagem de perfil do agente coletivo vinculado na inscrição, seguindo a mesma lógica já existente para o agente individual responsável.

Além da configuração, o comportamento foi replicado no formulário de inscrição, incluindo exibição do campo de upload e validação quando a obrigatoriedade estiver habilitada.

## Observações
- a implementação preserva o comportamento atual da solicitação de imagem de perfil do agente individual
- a obrigatoriedade da imagem do agente coletivo só é aplicada quando houver vínculo habilitado para o tipo de proponente selecionado
