### PR TITLE
Feature/duplicate registration fields

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ O formato é baseado no [Keep a Changelog](https://keepachangelog.com/pt-BR/1.0.
 e este projeto adere ao [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [UNRELEASED]
+### Novas Funcionalidades
+- Adiciona botão para duplicar campos do formulário de inscrição, criando a cópia logo abaixo do campo original
+- Adiciona botão para duplicar anexos do formulário de inscrição, incluindo a cópia do arquivo modelo e inserindo o novo anexo logo abaixo do original
+
 ### Melhorias
 - Adiciona um campo de busca para encontrar colunas por palavra-chave na listagem por tabela nas entidades. 
 - Implementa a funcionalidade que permite ao saasSuperAdmin ordenar globalmente as colunas das tabelas que utilizam o entity-table, por meio de drag and drop.

--- a/src/core/Controllers/RegistrationFileConfiguration.php
+++ b/src/core/Controllers/RegistrationFileConfiguration.php
@@ -22,7 +22,7 @@ use MapasCulturais\Traits;
 class RegistrationFileConfiguration extends EntityController {
     use Traits\ControllerUploads;
 
-    function POST_duplicate() {
+    public function POST_duplicate() {
         $this->requireAuthentication();
 
         $app = App::i();

--- a/src/core/Controllers/RegistrationFileConfiguration.php
+++ b/src/core/Controllers/RegistrationFileConfiguration.php
@@ -2,6 +2,8 @@
 namespace MapasCulturais\Controllers;
 
 use MapasCulturais\App;
+use MapasCulturais\Entities\RegistrationFileConfiguration as RegistrationFileConfigurationEntity;
+use MapasCulturais\Entities\RegistrationFileConfigurationFile;
 use MapasCulturais\Traits;
 
 /**
@@ -19,6 +21,65 @@ use MapasCulturais\Traits;
  */
 class RegistrationFileConfiguration extends EntityController {
     use Traits\ControllerUploads;
+
+    function POST_duplicate() {
+        $this->requireAuthentication();
+
+        $app = App::i();
+        /** @var RegistrationFileConfigurationEntity|null $entity */
+        $entity = $this->requestedEntity;
+
+        if (!$entity) {
+            $app->pass();
+        }
+
+        $entity->checkPermission('create');
+
+        $duplicated = new RegistrationFileConfigurationEntity();
+        $duplicated->owner = $entity->owner;
+        $duplicated->step = $entity->step;
+        $duplicated->title = $entity->title;
+        $duplicated->description = $entity->description;
+        $duplicated->required = $entity->required;
+        $duplicated->categories = $entity->categories ?: [];
+        $duplicated->displayOrder = $entity->displayOrder + 1;
+        $duplicated->conditional = $entity->conditional;
+        $duplicated->conditionalField = $entity->conditionalField;
+        $duplicated->conditionalValue = $entity->conditionalValue;
+        $duplicated->registrationRanges = $entity->registrationRanges ?: [];
+        $duplicated->proponentTypes = $entity->proponentTypes ?: [];
+        $duplicated->allowedFileTypes = $entity->allowedFileTypes ?: [];
+        $duplicated->save(true);
+
+        if ($template = $entity->getFile('registrationFileTemplate')) {
+            $originFile = $app->repo('RegistrationFileConfigurationFile')->find($template->id);
+
+            if ($originFile && file_exists($originFile->path)) {
+                $tmp_file = sys_get_temp_dir() . '/' . uniqid('rfc-template-', true) . '-' . $template->name;
+                copy($originFile->path, $tmp_file);
+
+                $newTemplateFile = [
+                    'name' => $template->name,
+                    'type' => $template->mimeType,
+                    'tmp_name' => $tmp_file,
+                    'error' => 0,
+                    'size' => filesize($tmp_file)
+                ];
+
+                $newTemplate = new RegistrationFileConfigurationFile($newTemplateFile);
+                $newTemplate->owner = $duplicated;
+                $newTemplate->description = $template->description;
+                $newTemplate->group = $template->group;
+                $newTemplate->save(true);
+
+                if (file_exists($tmp_file)) {
+                    unlink($tmp_file);
+                }
+            }
+        }
+
+        $this->json($duplicated->jsonSerialize());
+    }
 
     /**
      * Redireciona requisições GET para criação

--- a/src/themes/BaseV1/Theme.php
+++ b/src/themes/BaseV1/Theme.php
@@ -2099,6 +2099,7 @@ class Theme extends MapasCulturais\Theme {
             'fieldRemoved' =>  i::__('Campo removido.'),
             'changesSaved' =>  i::__('Alterações Salvas.'),
             'attachmentCreated' =>  i::__('Anexo criado.'),
+            'attachmentDuplicated' => i::__('Anexo duplicado.'),
             'attachmentRemoved' =>  i::__('Anexo removido.'),
             'confirmAttachmentRemoved' =>  i::__('Deseja remover este anexo?'),
             'confirmRemoveModel' =>  i::__('Deseja remover este modelo?'),

--- a/src/themes/BaseV1/Theme.php
+++ b/src/themes/BaseV1/Theme.php
@@ -2095,6 +2095,7 @@ class Theme extends MapasCulturais\Theme {
             'allCategories' => i::__('Todas as categorias'),
             'selectFieldType' =>  i::__('Selecione o tipo de campo'),
             'fieldCreated' =>  i::__('Campo criado.'),
+            'fieldDuplicated' => i::__('Campo duplicado.'),
             'fieldRemoved' =>  i::__('Campo removido.'),
             'changesSaved' =>  i::__('Alterações Salvas.'),
             'attachmentCreated' =>  i::__('Anexo criado.'),

--- a/src/themes/BaseV1/assets/js/ng.entity.module.opportunity.js
+++ b/src/themes/BaseV1/assets/js/ng.entity.module.opportunity.js
@@ -1010,6 +1010,38 @@ module.controller('RegistrationConfigurationsController', ['$scope', '$rootScope
             }
         };
 
+        $scope.duplicateFileConfiguration = function(file, index) {
+            $scope.data.uploadSpinner = true;
+
+            $http.post(fileService.getUrl('duplicate', file.id)).then(function(result) {
+                var response = result.data;
+                $scope.data.uploadSpinner = false;
+
+                if (response.error) {
+                    if (response.data && typeof response.data === 'object' && response.data.message) {
+                        MapasCulturais.Messages.error(response.data.message);
+                    } else {
+                        validationErrors(response);
+                    }
+                    return;
+                }
+
+                response = processFileConfiguration(response);
+                $scope.data.fields.push(response);
+
+                var newIndex = $scope.data.fields.length - 1;
+                var movedFile = $scope.data.fields.splice(newIndex, 1)[0];
+                $scope.data.fields.splice(index + 1, 0, movedFile);
+
+                persistFieldsOrder(false).then(function() {
+                    MapasCulturais.Messages.success(labels['attachmentDuplicated']);
+                });
+            }, function(response) {
+                $scope.data.uploadSpinner = false;
+                validationErrors(response);
+            });
+        };
+
         $scope.editFileConfiguration = function(attrs) {
             $scope.data.uploadSpinner = true;
             var model = $scope.data.fields[attrs.index];

--- a/src/themes/BaseV1/assets/js/ng.entity.module.opportunity.js
+++ b/src/themes/BaseV1/assets/js/ng.entity.module.opportunity.js
@@ -540,25 +540,29 @@ module.controller('RegistrationConfigurationsController', ['$scope', '$rootScope
 
             // ao reordenar, atualiza displayOrder dos campos e salva
             stop: function(e, ui) {
-
-                var ii = 1;
-
-                var _fields = [];
-
-                $.each(fields, function(i,f) {
-                    f.displayOrder = ii;
-                    _fields.push({id: f.id, displayOrder: ii, fieldType: f.fieldType});
-                    ii++;
-                });
-
-                var url = new UrlService('opportunity');
-                var saveOrderUrl = url.create('saveFieldsOrder', MapasCulturais.entity.id);
-                // requisição para salvar ordem
-                $http.post(saveOrderUrl, {fields: _fields}).success(function(){
-                    MapasCulturais.Messages.success(labels['changesSaved']);
-                });
+                persistFieldsOrder(true);
             }
         };
+
+        function persistFieldsOrder(showSuccessMessage) {
+            var ii = 1;
+            var reorderedFields = [];
+
+            $.each(fields, function(i, f) {
+                f.displayOrder = ii;
+                reorderedFields.push({id: f.id, displayOrder: ii, fieldType: f.fieldType});
+                ii++;
+            });
+
+            var url = new UrlService('opportunity');
+            var saveOrderUrl = url.create('saveFieldsOrder', MapasCulturais.entity.id);
+
+            return $http.post(saveOrderUrl, {fields: reorderedFields}).success(function(){
+                if (showSuccessMessage) {
+                    MapasCulturais.Messages.success(labels['changesSaved']);
+                }
+            });
+        }
 
         $scope.data = {
             fieldSpinner: false,
@@ -785,6 +789,48 @@ module.controller('RegistrationConfigurationsController', ['$scope', '$rootScope
                     }
                 });
             }
+        };
+
+        $scope.duplicateFieldConfiguration = function(field, index) {
+            var duplicatedField = angular.copy(field);
+
+            delete duplicatedField.id;
+            delete duplicatedField.fieldName;
+            delete duplicatedField.step;
+
+            duplicatedField.ownerId = MapasCulturais.entity.id;
+            duplicatedField.displayOrder = $scope.data.fields.length + 1;
+            duplicatedField.categories = duplicatedField.categories || [];
+            duplicatedField.registrationRanges = duplicatedField.registrationRanges || [];
+            duplicatedField.proponentTypes = duplicatedField.proponentTypes || [];
+            duplicatedField.config = duplicatedField.config || {};
+            duplicatedField.step = field.step?.id ?? null;
+
+            $scope.data.fieldSpinner = true;
+
+            fieldService.create(duplicatedField).then(function(response) {
+                $scope.data.fieldSpinner = false;
+
+                if (response.error) {
+                    if (response.data && typeof response.data === 'object' && response.data.message) {
+                        MapasCulturais.Messages.error(response.data.message);
+                    } else {
+                        validationErrors(response);
+                    }
+                    return;
+                }
+
+                response = processFieldConfiguration(response);
+                $scope.data.fields.push(response);
+
+                var newIndex = $scope.data.fields.length - 1;
+                var movedField = $scope.data.fields.splice(newIndex, 1)[0];
+                $scope.data.fields.splice(index + 1, 0, movedField);
+
+                persistFieldsOrder(false).then(function() {
+                    MapasCulturais.Messages.success(labels['fieldDuplicated']);
+                });
+            });
         };
 
         $scope.editFieldConfiguration = function(attrs) {

--- a/src/themes/BaseV1/layouts/parts/singles/opportunity-registrations--fields.php
+++ b/src/themes/BaseV1/layouts/parts/singles/opportunity-registrations--fields.php
@@ -226,6 +226,7 @@ $app->applyHookBoundTo($this, 'opportunity.blockedFields', [$entity]);
                     </edit-box>
                     <div ng-if="data.entity.canUserModifyRegistrationFields && !isBlockedFields(field.id)" class="btn-group">
                         <a ng-click="openFieldConfigurationEditBox(field.id, $index, $event);" class="btn btn-default edit hltip" title="<?php i::esc_attr_e("editar campo"); ?>"></a>
+                        <a ng-click="duplicateFieldConfiguration(field, $index)" class="btn btn-default add hltip" title="<?php i::esc_attr_e("duplicar campo"); ?>" aria-label="<?php i::esc_attr_e("duplicar campo"); ?>"></a>
                         <a ng-click="removeFieldConfiguration(field.id, $index)" data-href="{{field.deleteUrl}}" class="btn btn-default delete hltip" title="<?php i::esc_attr_e("excluir campo"); ?>"></a>
                     </div>
                     <div style="color: red;">

--- a/src/themes/BaseV1/layouts/parts/singles/opportunity-registrations--fields.php
+++ b/src/themes/BaseV1/layouts/parts/singles/opportunity-registrations--fields.php
@@ -375,6 +375,7 @@ $app->applyHookBoundTo($this, 'opportunity.blockedFields', [$entity]);
 
                     <div ng-if="data.entity.canUserModifyRegistrationFields && !isBlockedFields(field.id)" class="btn-group">
                         <a ng-click="openFileConfigurationEditBox(field.id, $index, $event);" class="btn btn-default edit hltip" title="<?php i::esc_attr_e("editar anexo"); ?>"></a>
+                        <a ng-click="duplicateFileConfiguration(field, $index)" class="btn btn-default add hltip" title="<?php i::esc_attr_e("duplicar anexo"); ?>" aria-label="<?php i::esc_attr_e("duplicar anexo"); ?>"></a>
                         <a ng-if="!field.template" ng-click="openFileConfigurationTemplateEditBox(field.id, $index, $event);" class="btn btn-default send hltip" title="<?php i::esc_attr_e("enviar modelo"); ?>"></a>
                         <a ng-click="removeFileConfiguration(field.id, $index)" data-href="{{field.deleteUrl}}" class="btn btn-default delete hltip" title="<?php i::esc_attr_e("excluir anexo"); ?>"></a>
                     </div>


### PR DESCRIPTION
## Resumo
Implementa a duplicação de campos e anexos na configuração do formulário de inscrição.

Agora o gestor pode:
- duplicar um campo do formulário e inserir a cópia logo abaixo do original
- duplicar um anexo do formulário e inserir a cópia logo abaixo do original
- duplicar anexos preservando também o arquivo modelo já enviado

### Anexos
Ao clicar em duplicar:
- o anexo é clonado com a mesma configuração
- a cópia aparece logo abaixo do anexo original
- o arquivo modelo também é copiado, quando existir
- a nova ordem é persistida

## Observações
- o botão de duplicação foi mantido com ícone de `+`, no mesmo padrão visual já usado na interface
- a duplicação de anexos foi implementada com cópia do modelo, conforme esperado para uso editorial
