### PR TITLE
evita erro ao hidratar datas inválidas em entidades

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ e este projeto adere ao [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 ### Correções
 - Aplica texto de internacionalização faltante no componente opportunity-registration-table
 - Corrige acento faltante no texto "Gênero" na listagem de pessoas do formulário de inscrição
+- Evita erro ao hidratar campos de data inválidos em entidades
 
 ## [7.7.19] - 2026-03-27
 ### Correções

--- a/src/modules/Components/assets/js/components-base/Entity.js
+++ b/src/modules/Components/assets/js/components-base/Entity.js
@@ -74,8 +74,10 @@ class Entity {
             if ((definition.type == 'datetime' || definition.type == 'date' ) && val && !(val instanceof McDate)) {
                 if (typeof val == 'string') {
                     val = new McDate(val);
-                } else {
+                } else if (typeof val?.date == 'string' && val.date) {
                     val = new McDate(val.date);
+                } else {
+                    val = null;
                 }
             }
 


### PR DESCRIPTION
## Resumo

Evita erro na hidratação de entidades quando campos `date`/`datetime` chegam da API sem uma string de data válida.
