### PR TITLE
Corrige internacionalização de cotas na tabela de inscrições

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ e este projeto adere ao [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 ### Correções
 - Aplica texto de internacionalização faltante no componente opportunity-registration-table
 - Corrige acento faltante no texto "Gênero" na listagem de pessoas do formulário de inscrição
+- Corrige a chave de internacionalização do texto "Elegível para cotas" no componente de listagem de inscrições
 
 ## [7.7.19] - 2026-03-27
 ### Correções

--- a/src/modules/Opportunities/components/opportunity-registrations-table/script.js
+++ b/src/modules/Opportunities/components/opportunity-registrations-table/script.js
@@ -39,7 +39,7 @@ app.component('opportunity-registrations-table', {
             readonly: true,
             type: "array",
             length: 255,
-            label: text("Elegível para as cotas"),
+            label: text("Elegível para cotas"),
             isPK: false
         };
 

--- a/src/modules/Opportunities/components/opportunity-registrations-table/texts.php
+++ b/src/modules/Opportunities/components/opportunity-registrations-table/texts.php
@@ -36,5 +36,6 @@ return [
     'pontuação final' => i::__('pontuação final'),
     'Range' => i::__('Faixa/Linha'),
     'aguardando desempate' => i::__('Aguardando desempate'),
-    'Elegível para as cotas' => i::__('Elegível para as cotas'),
+    'Elegível para cotas' => i::__('Elegível para cotas'),
+    'Elegível para as cotas' => i::__('Elegível para cotas'),
 ];


### PR DESCRIPTION
## Resumo

Corrige a internacionalização do texto de cotas no componente de listagem de inscrições, mantendo a redação original da interface como `Elegível para cotas`.

## Problema

O componente `opportunity-registrations-table` estava usando uma chave de texto inconsistente, o que gerava aviso de tradução faltando no navegador.

## O que foi alterado

- padroniza o texto exibido no componente para `Elegível para cotas`
- adiciona compatibilidade no arquivo de traduções para a chave antiga `Elegível para as cotas`
- atualiza o `CHANGELOG.md` com a correção

## Arquivos alterados

- `src/modules/Opportunities/components/opportunity-registrations-table/script.js`
- `src/modules/Opportunities/components/opportunity-registrations-table/texts.php`

## Impacto

- remove o aviso de tradução faltando no componente
- mantém o texto da interface igual ao que já era usado anteriormente
- evita regressão caso ainda exista algum ponto usando a chave antiga
