### PR TITLE
Corrige erro ao reordenar etapas do formulário

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ e este projeto adere ao [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 ### Correções
 - Aplica texto de internacionalização faltante no componente opportunity-registration-table
 - Corrige acento faltante no texto "Gênero" na listagem de pessoas do formulário de inscrição
+- Corrige erro ao reordenar etapas na configuração do formulário de oportunidades
 
 ## [7.7.20] - 2026-03-30
 ### Melhorias

--- a/src/modules/Opportunities/components/opportunity-form-builder/script.js
+++ b/src/modules/Opportunities/components/opportunity-form-builder/script.js
@@ -27,12 +27,19 @@ app.component('opportunity-form-builder' , {
     },
 
     computed: {
-        stepsWithSlugs: {
+        draggableSteps: {
             get () {
-                return this.steps.map((step) => ({ slug: `section-${step.id}`, step }));
+                return this.steps.map((step) => ({
+                    id: step.id,
+                    name: step.name ?? '',
+                    slug: `section-${step.id}`,
+                }));
             },
             set (value) {
-                this.steps = value.map((step) => step.step);
+                const stepsById = new Map(this.steps.map((step) => [step.id, step]));
+                this.steps = value
+                    .map((item) => stepsById.get(item.id))
+                    .filter(Boolean);
             },
         }
     },
@@ -41,8 +48,7 @@ app.component('opportunity-form-builder' , {
         steps () {
             this.steps.forEach(async (step, index) => {
                 if (index !== step.displayOrder) {
-                    const entity = new Entity('registrationstep');
-                    entity.populate(step);
+                    const entity = new Entity('registrationstep', step.id);
                     entity.displayOrder = index;
                     await entity.save();
                 }

--- a/src/modules/Opportunities/components/opportunity-form-builder/template.php
+++ b/src/modules/Opportunities/components/opportunity-form-builder/template.php
@@ -99,9 +99,9 @@ $this->import('
     </div>
 
     <div class="col-12">
-        <mc-tabs ref="tabs" v-model:draggable="stepsWithSlugs">
+        <mc-tabs ref="tabs" v-model:draggable="draggableSteps">
             <template #default>
-                <mc-tab v-for="({ step, slug }, index) of stepsWithSlugs" :label="`${index + 1}. ${step.name ?? ''}`" :key="step.id" :slug="slug" :cache="false">
+                <mc-tab v-for="(step, index) of steps" :label="`${index + 1}. ${step.name ?? ''}`" :key="step.id" :slug="`section-${step.id}`" :cache="false">
                     <div class="form-builder__step-config">
                         <div>
                             <entity-field :entity="step" prop="name" :autosave="1000" hide-required></entity-field>


### PR DESCRIPTION
# Correção da ordenação de etapas na configuração do formulário

## Problema

Ao alterar a ordem das etapas na configuração do formulário da oportunidade, a interface quebrava durante o drag and drop com erros como:

```text
Uncaught TypeError: Converting circular structure to JSON
Uncaught (in promise) RangeError: Maximum call stack size exceeded
```

O problema acontecia porque a lista usada pelo `draggable` carregava o objeto completo da etapa (`step`), incluindo a relação `opportunity`. Essa relação apontava novamente para `registrationSteps`, formando uma referência circular:

`registrationSteps -> step -> opportunity -> registrationSteps`

Quando a biblioteca do drag tentava serializar/clonar esses dados, o fluxo quebrava.

Além disso, ao salvar a nova ordem, o código fazia `entity.populate(step)` em uma entidade temporária, reaproveitando o mesmo objeto circular e ampliando o problema.

## Solução aplicada

- A lista enviada para o `draggable` passou a usar apenas dados simples da aba: `id`, `name` e `slug`.
- A renderização dos `mc-tab` continua baseada em `steps`, preservando o comportamento visual do componente.
- O salvamento da nova ordem agora instancia a entidade apenas com o tipo e o `id`, atualizando somente o `displayOrder`, sem repopular a entidade completa com relações circulares.

## Resultado

Com isso, a reordenação das etapas deixa de disparar serialização de estruturas circulares, evitando o erro em tempo de execução e permitindo salvar a nova ordem normalmente.
