### PR TITLE
Corrige importacao de formatos aceitos em anexos

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ e este projeto adere ao [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 ### Correções
 - Aplica texto de internacionalização faltante no componente opportunity-registration-table
 - Corrige acento faltante no texto "Gênero" na listagem de pessoas do formulário de inscrição
+- Corrige a importação de formulários de inscrição para preservar os formatos aceitos configurados nos campos de anexo
 
 ##[7.7.22] - 2026-04-07
 ### Correções

--- a/src/core/Entities/Opportunity.php
+++ b/src/core/Entities/Opportunity.php
@@ -1268,6 +1268,7 @@ abstract class Opportunity extends \MapasCulturais\Entity
                 $newFile->displayOrder = $file->displayOrder;
                 $newFile->conditional = $file->conditional;
                 $newFile->conditionalValue = $file->conditionalValue;
+                $newFile->allowedFileTypes = $file->allowedFileTypes ?? [];
                 $newFile->step = $step->id;
                 $newFile->proponentTypes = $file->proponentTypes;
                 $newFile->registrationRanges = $file->registrationRanges;

--- a/src/modules/OpportunityExporter/Exporter.php
+++ b/src/modules/OpportunityExporter/Exporter.php
@@ -401,6 +401,7 @@ class Exporter
                 'categories' => $rfc->categories,
                 'registrationRanges' => $rfc->registrationRanges,
                 'proponentTypes' => $rfc->proponentTypes,
+                'allowedFileTypes' => $rfc->allowedFileTypes,
 
                 'conditional' => false,
             ];

--- a/src/modules/OpportunityExporter/Importer.php
+++ b/src/modules/OpportunityExporter/Importer.php
@@ -400,6 +400,7 @@ class Importer
             $rfc->categories = $rfc_data['categories'];
             $rfc->registrationRanges = $rfc_data['registrationRanges'];
             $rfc->proponentTypes = $rfc_data['proponentTypes'];
+            $rfc->allowedFileTypes = $rfc_data['allowedFileTypes'] ?? [];
             $rfc->conditional = $conditional;
 
             if ($rfc->conditional && $conditional_field) {


### PR DESCRIPTION
## Resumo

Corrige a importação de formulários de inscrição para preservar os formatos aceitos configurados nos campos de anexo.

## Problema

Ao exportar o formulário de inscrições em `.txt` e importar em outra oportunidade, os campos de anexo perdiam a configuração de formatos aceitos (`allowedFileTypes`).

Na prática, o anexo era recriado sem as restrições de tipo de arquivo, mesmo quando elas existiam no formulário original.

## Solução

Ajusta a importação legada de formulário para copiar `allowedFileTypes` ao recriar `RegistrationFileConfiguration`.

Também alinha o fluxo do módulo `OpportunityExporter` para exportar e importar esse mesmo atributo, evitando inconsistência entre os diferentes caminhos de migração de formulário.

## Impacto

Após a correção, os campos de anexo mantêm corretamente os formatos aceitos configurados quando o formulário é exportado e importado.
