### PR TITLE
Permite à infra/devops definir cabeçalho de IP do cliente atrás de proxy (ex. Cloudflare)

### DIFF
--- a/config/0.main.php
+++ b/config/0.main.php
@@ -114,4 +114,6 @@ return [
     /* Lista de MIME types bloqueados */
     'app.not_allowed_mime_types' => env('APP_NOT_ALLOWED_MIME_TYPES', "html|php|javascript|css|executable|msdownload|bat|cmd|installer|bash|diskimage|android|java|octet-stream"),
 
+    /* Define o header proxy para o IP */
+    'app.proxyHeader' => env('PROXY_HEADER', ''),
 ];

--- a/dev/config.d/0.main.php
+++ b/dev/config.d/0.main.php
@@ -28,4 +28,7 @@ return [
 
         'publishFolderCommand' => 'cp -R {IN} {PUBLISH_PATH}{FILENAME}'
     ],
+
+    /* Define o header proxy para o IP */
+    'app.proxyHeader' => env('PROXY_HEADER', ''),
 ];

--- a/src/core/Request.php
+++ b/src/core/Request.php
@@ -212,11 +212,24 @@ class Request {
     }
 
     /**
-     * Retorna o endereço IP do cliente
-     * 
+     * Retorna o endereço IP do cliente.
+     *
+     * O nome do cabeçalho HTTP vem de `app.proxyHeader` (variável de ambiente `PROXY_HEADER`).
+     * Se estiver definido como string não vazia, o valor retornado é o conteúdo desse cabeçalho
+     * na requisição — cabe ao ambiente (proxy reverso / load balancer) enviá-lo de forma correta
+     * e confiável.
+     *
+     * Se `app.proxyHeader` estiver vazio (padrão), não se lê cabeçalho de proxy; usa-se o
+     * atributo PSR-7 `ip_address`, normalmente preenchido pelo middleware de IP da aplicação.
+     *
      * @return string
      */
-    public function getIp() {
-        return $this->psr7request->getAttribute('ip_address');
+    public function getIp(): string {
+        $proxyHeader = App::i()->config['app.proxyHeader'] ?? '';
+        if (is_string($proxyHeader) && $proxyHeader !== '') {
+            return (string) ($this->psr7request->getHeaderLine($proxyHeader) ?? '');
+        }
+
+        return (string) ($this->psr7request->getAttribute('ip_address') ?? '');
     }
 }


### PR DESCRIPTION
# Proxy IP customizável

## Contexto

Em ambientes com reverse proxy (nginx, load balancer, Cloudflare, etc.), o IP “real” do cliente costuma vir em headers como `CF-Connecting-IP`, `X-Forwarded-For` ou `X-Real-IP`, enquanto o middleware que já usamos (RKA) continua expondo o IP em `ip_address` com base na cadeia de confiança da infra.

Para registrar IP em fluxos como aceite de termos (LGPD) de forma alinhada com o que o proxy manda, faz sentido poder **configurar qual header** a aplicação deve priorizar, sem espalhar `$_SERVER` no código.

## O que mudou

- Inclusão da chave **`app.proxyHeader`** na config principal (`config/0.main.php`), lendo a variável de ambiente **`PROXY_HEADER`** (string vazia = não usar header dedicado).
- Ajuste do **`Request::getIp()`**: se `PROXY_HEADER` estiver definido, o IP vem de `getHeaderLine()` com esse nome; caso contrário, mantém o comportamento anterior usando o atributo **`ip_address`** do request (como já era com o middleware RKA).

## PRINTS

<img width="513" height="293" alt="image" src="https://github.com/user-attachments/assets/949e5acc-3208-44c9-be0a-8d71509c83d5" />
<img width="662" height="365" alt="image" src="https://github.com/user-attachments/assets/01bf929c-1f52-49e4-b521-5d64a08fec99" />
<img width="499" height="313" alt="image" src="https://github.com/user-attachments/assets/857874af-46a5-4c0e-984a-0531dce36a6b" />


## Como testar

### Cenário genérico (nginx na frente)

1. Suba a aplicação como costuma (Docker ou local).
2. Configure o proxy para encaminhar o header desejado, por exemplo:

```nginx
location / {
    proxy_pass http://backend_que_serve_o_mapas;

    proxy_set_header Host $host;
    proxy_set_header CF-Connecting-IP 203.0.113.10;
    # ou, conforme o header configurado na aplicação:
    # proxy_set_header X-Forwarded-For 203.0.113.10;
    # proxy_set_header X-Real-IP 203.0.113.10;
}
```

3. No `.env` (ou ambiente equivalente), defina o mesmo nome de header que o proxy envia:

```env
PROXY_HEADER=CF-Connecting-IP
```

4. Dispare um fluxo que chame `getIp()` — por exemplo aceite de termos LGPD (grava `ip` no metadado do usuário) ou um log temporário de `App::i()->request->getIp()`.
5. Confira se o valor gravado ou logado corresponde ao IP injetado no proxy (ex.: `203.0.113.10`).

### Stack `dev/` (Docker Compose + `dev/nginx.conf`)

1. Suba os serviços a partir de `dev/` e acesse pela URL do **nginx** (ex.: `http://localhost`), não pelo backend exposto só na rede interna — assim os headers definidos em `dev/nginx.conf` chegam ao PHP.
2. **Fluxo LGPD**: com usuário autenticado que ainda não aceitou os termos de `config/lgpd.php`, complete o aceite (rota amigável `termos-e-condicoes` → `lgpd/accept`). O módulo LGPD grava `ip` via `Request::getIp()` no metadado (aceite por hash do texto).
3. Valide que o `ip` persistido bate com o valor do header configurado em `PROXY_HEADER` para o IP de teste que o nginx envia.
4. **Sem header dedicado**: deixe `PROXY_HEADER` vazio ou ausente e confira que o IP segue o atributo `ip_address` do request (middleware RKA), para comparar os dois comportamentos.
