### PR TITLE
Fix/agent owner birthdate registration v77x

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,10 @@ Todas as mudanças notáveis no projeto serão documentadas neste arquivo.
 O formato é baseado no [Keep a Changelog](https://keepachangelog.com/pt-BR/1.0.0/)
 e este projeto adere ao [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [UNRELEASED]
+### Correções
+- Corrige o formato da data de nascimento em campos do agente responsável no formulário de inscrição
+
 ##[UNRELEASED]
 ### Correções
 - Corrige erro que impedia enviar a inscrição devido a ero na data de nascimento

--- a/src/themes/BaseV1/assets/js/ng.entity.module.opportunity.js
+++ b/src/themes/BaseV1/assets/js/ng.entity.module.opportunity.js
@@ -1561,6 +1561,54 @@ module.controller('RegistrationFieldsController', ['$scope', '$rootScope', '$int
     $scope.data.editableEntity = {
         id: MapasCulturais.registration.id
     };
+
+    $scope.isDateField = function(field) {
+        if (!field) {
+            return false;
+        }
+
+        if (field.fieldType === 'date') {
+            return true;
+        }
+
+        const relatedFieldType = field?.fieldType;
+        const entityField = field?.config?.entityField;
+
+        if (!entityField) {
+            return false;
+        }
+
+        if (['agent-owner-field', 'agent-collective-field'].includes(relatedFieldType)) {
+            return MapasCulturais.EntitiesDescription.agent?.[entityField]?.type === 'date';
+        }
+
+        if (relatedFieldType === 'space-field') {
+            return MapasCulturais.EntitiesDescription.space?.[entityField]?.type === 'date';
+        }
+
+        return false;
+    }
+
+    $scope.normalizeDateFieldValue = function(field, value) {
+        if (!$scope.isDateField(field) || value === undefined || value === null || value === '') {
+            return value;
+        }
+
+        if (value instanceof Date) {
+            return moment(value).format('YYYY-MM-DD');
+        }
+
+        if (value?._date) {
+            return moment(value._date).format('YYYY-MM-DD');
+        }
+
+        if (typeof value === 'string' && moment(value, moment.ISO_8601, true).isValid()) {
+            return moment(value).format('YYYY-MM-DD');
+        }
+
+        return value;
+    }
+
     $scope.saveField = function (field, value, delay) {
 
         if(field.fieldType === "agent-owner-field") {
@@ -1570,6 +1618,7 @@ module.controller('RegistrationFieldsController', ['$scope', '$rootScope', '$int
             }
         }
 
+        value = $scope.normalizeDateFieldValue(field, value);
 
         delete field.error;
 


### PR DESCRIPTION
## Objetivo

Corrigir o preenchimento e o salvamento do campo `@campo data de nascimento do agente responsável` no formulário de inscrição.

## Problema

Mesmo com a data de nascimento preenchida no perfil do agente, o campo no formulário:
- não trazia a data corretamente em alguns cenários;
- ao salvar, podia retornar erro de validação no `registration_meta`.
