### PR TITLE
Fix/avaliacao tecnica calculo peso

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,7 @@ e este projeto adere ao [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 - Evita erro ao hidratar campos de data inválidos em entidades
 - Corrige a importação de formulários de inscrição para preservar os formatos aceitos configurados nos campos de anexo
 - Corrige erro ao reordenar etapas na configuração do formulário de oportunidades
+- Corrige o cálculo ponderado dos subtotais na tela de avaliação técnica
 
 ## [7.7.36] - 2026-05-08
 ### Correções

--- a/src/modules/EvaluationMethodTechnical/components/technical-evaluation-form/script.js
+++ b/src/modules/EvaluationMethodTechnical/components/technical-evaluation-form/script.js
@@ -63,10 +63,7 @@ app.component('technical-evaluation-form', {
             let result = 0;
             for (let sectionIndex in this.sections) {
                 for (let criterion of this.sections[sectionIndex].criteria) {
-                    const value = this.formData.data[criterion.id];
-                    if (value !== null && value !== undefined) {
-                        result += parseFloat(value * criterion.weight);
-                    }
+                    result += this.weightedCriterionScore(criterion);
                 }
             }
             return parseFloat(result.toFixed(2));
@@ -77,15 +74,31 @@ app.component('technical-evaluation-form', {
                 const section = this.sections[sectionKey];
                 if (section.criteria && Array.isArray(section.criteria)) {
                     total +=  section.criteria.reduce((acc, criterion) => {
-                        return acc + (criterion.max * criterion.weight);
+                        return acc + (this.toNumber(criterion.max) * this.toNumber(criterion.weight));
                     }, 0);
                 }
             }
-            return total;
+            return parseFloat(total.toFixed(2));
         }
     },
 
     methods: {
+        toNumber(value) {
+            const number = Number(value);
+
+            return Number.isFinite(number) ? number : 0;
+        },
+
+        weightedCriterionScore(criterion) {
+            const value = this.formData.data[criterion.id];
+
+            if (value === null || value === undefined || value === '') {
+                return 0;
+            }
+
+            return this.toNumber(value) * this.toNumber(criterion.weight);
+        },
+
         handleInput(sectionIndex, criterionId) {
             let value = this.formData.data[criterionId];
             const max = this.sections[sectionIndex].criteria.find(criterion => criterion.id === criterionId).max;
@@ -107,10 +120,7 @@ app.component('technical-evaluation-form', {
             let subtotal = 0;
             const section = this.sections[sectionIndex];
             for (let criterion of section.criteria) {
-                const value = this.formData.data[criterion.id];
-                if (value !== null && value !== undefined) {
-                    subtotal += parseFloat(value);
-                }
+                subtotal += this.weightedCriterionScore(criterion);
             }
 
             return parseFloat(subtotal.toFixed(2));

--- a/src/modules/EvaluationMethodTechnical/components/technical-evaluation-form/template.php
+++ b/src/modules/EvaluationMethodTechnical/components/technical-evaluation-form/template.php
@@ -17,7 +17,7 @@ $this->import('
             <div class="field tecnical-evaluation-form__maxScore grid-12">
                 <label> 
                     <strong>{{ criterion.title }}</strong>
-                    <input class="maxScore-input" v-if="isEditable" v-model="formData.data[criterion.id]" min="0" step="0.1" type="number" @input="handleInput(sectionIndex, criterion.id)">
+                    <input class="maxScore-input" v-if="isEditable" v-model.number="formData.data[criterion.id]" min="0" step="0.1" type="number" @input="handleInput(sectionIndex, criterion.id)">
                     <input class="maxScore-input" v-if="!isEditable" disabled min="0" step="0.1" type="number" :value="formData.data[criterion.id]" @input="handleInput(sectionIndex, criterion.id)">
                 </label>
             </div>


### PR DESCRIPTION
## Resumo

Corrige o cálculo dos subtotais na tela de avaliação técnica do avaliador para considerar o peso configurado em cada critério.

## O que foi alterado

- Ajusta o subtotal por seção para calcular `nota x peso`, seguindo a mesma regra usada na gestão da oportunidade.
- Centraliza o cálculo ponderado no componente `technical-evaluation-form`.
- Garante que o input de nota seja tratado como número com `v-model.number`.