### PR TITLE
Inclui faixa no relatório de avaliações

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,6 +34,7 @@ e este projeto adere ao [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 - Corrige erro ao reordenar etapas na configuração do formulário de oportunidades
 - Corrige a exportação de oportunidades para não incluir datas das fases de avaliação quando a opção de exportar datas das fases estiver desmarcada
 - Corrige o cálculo ponderado dos subtotais na tela de avaliação técnica
+- Corrige a exportação da lista de avaliações para incluir os dados da coluna Faixa/Linha
 
 ## [7.7.48] - 2026-05-29
 ### Correções

--- a/src/core/EvaluationMethod.php
+++ b/src/core/EvaluationMethod.php
@@ -235,6 +235,15 @@ abstract class EvaluationMethod extends Module implements \JsonSerializable{
             ];
         }
 
+        if($opportunity->registrationRanges){
+            $registration_columns['range'] = (object) [
+                'label' => i::__('Faixa/Linha'),
+                'getValue' => function(Entities\RegistrationEvaluation $evaluation){
+                    return $evaluation->registration->range;
+                }
+            ];
+        }
+
         $registration_columns = $registration_columns + [
             'owner' => (object) [
                 'label' => i::__('Agente Responsável'),

--- a/src/modules/Opportunities/views/opportunity/report-evaluations.php
+++ b/src/modules/Opportunities/views/opportunity/report-evaluations.php
@@ -3,6 +3,22 @@ $columns_counter = $status_order = 0;
 $columns = [];
 
 $sum = count($cfg["registration"]->columns) + count($cfg["committee"]->columns);
+
+$get_pending_registration_value = function(array $registration, string $column) {
+    if ($column === 'owner') {
+        return $registration['owner']['name'] ?? '--';
+    }
+
+    return $registration[$column] ?? '--';
+};
+
+$get_pending_committee_value = function(array $valuer, string $column) {
+    if ($column === 'evaluator') {
+        return $valuer['name'] ?? '--';
+    }
+
+    return $valuer[$column] ?? '--';
+};
 ?>
 <table width="100%">
     <thead>
@@ -80,28 +96,24 @@ $sum = count($cfg["registration"]->columns) + count($cfg["committee"]->columns);
 
             if (is_array($valuer_pending) && is_null($valuer_pending["evaluation"])) {
                 echo '<tr>';
-                foreach ($valuer_pending["valuer"] as $key => $v) {
-                    if ($key === "name") {
-                        if (isset($cfg["registration"]->columns['category'])) { ?>
-                            <td style="text-align: center;"> <?php echo ($valuer_pending["registration"]["category"]) ?? "--"; ?> </td>
-                        <?php } ?>
-                        <td style="text-align: center;"> <?php echo $valuer_pending["registration"]["owner"]["name"] ?> </td>
-                        <td style="text-align: center;"> <?php echo $valuer_pending["registration"]["number"] ?> </td>
-                        <td style="text-align: center;"> <?php echo $valuer_pending["valuer"][$key]; ?> </td>
+                foreach ($cfg["registration"]->columns as $key => $column) { ?>
+                    <td style="text-align: center;"> <?php echo $get_pending_registration_value($valuer_pending["registration"], $key); ?> </td>
+                <?php }
 
-                        <?php for($i=0; $i < $total; $i++) { ?>
-                            <td style="text-align: center; font-style: italic;">
-                                <?php
-                                if ($i + $sum === $status_order) {
-                                    echo "Não avaliado";
-                                } else {
-                                    echo "--";
-                                } ?>
-                            </td>
-                    <?php
-                        } // for
-                    }
-                }
+                foreach ($cfg["committee"]->columns as $key => $column) { ?>
+                    <td style="text-align: center;"> <?php echo $get_pending_committee_value($valuer_pending["valuer"], $key); ?> </td>
+                <?php }
+
+                for($i=0; $i < $total; $i++) { ?>
+                    <td style="text-align: center; font-style: italic;">
+                        <?php
+                        if ($i + $sum === $status_order) {
+                            echo "Não avaliado";
+                        } else {
+                            echo "--";
+                        } ?>
+                    </td>
+                <?php }
                 echo '</tr>';
             }            
         endforeach;

--- a/tests/src/EvaluationReportConfigurationTest.php
+++ b/tests/src/EvaluationReportConfigurationTest.php
@@ -1,0 +1,69 @@
+<?php
+
+namespace Tests;
+
+use Tests\Traits\Faker;
+use Tests\Traits\UserDirector;
+use Tests\Enums\EvaluationMethods;
+use Tests\Traits\OpportunityBuilder;
+use Tests\Builders\PhasePeriods\Open;
+use Tests\Builders\PhasePeriods\ConcurrentEndingAfter;
+
+class EvaluationReportConfigurationTest extends Abstract\TestCase
+{
+    use Faker,
+        UserDirector,
+        OpportunityBuilder;
+
+    function testEvaluationReportIncludesRangeColumnWhenOpportunityHasRanges()
+    {
+        $admin = $this->userDirector->createUser('admin');
+        $this->login($admin);
+
+        $opportunity = $this->opportunityBuilder
+            ->reset(owner: $admin->profile, owner_entity: $admin->profile)
+            ->fillRequiredProperties()
+            ->setRanges(ranges: [[
+                'label' => 'Linha A',
+                'limit' => 10,
+                'value' => 0
+            ]], save: false)
+            ->firstPhase()
+                ->setRegistrationPeriod(new Open)
+                ->done()
+            ->save()
+            ->addEvaluationPhase(EvaluationMethods::simple)
+                ->setEvaluationPeriod(new ConcurrentEndingAfter)
+                ->save()
+                ->done()
+            ->getInstance();
+
+        $cfg = $opportunity->getEvaluationMethod()->getReportConfiguration($opportunity);
+
+        $this->assertArrayHasKey('range', $cfg['registration']->columns, 'Garantindo que o relatório de avaliações inclui a coluna Faixa/Linha');
+        $this->assertEquals('Faixa/Linha', $cfg['registration']->columns['range']->label);
+    }
+
+    function testEvaluationReportDoesNotIncludeRangeColumnWhenOpportunityHasNoRanges()
+    {
+        $admin = $this->userDirector->createUser('admin');
+        $this->login($admin);
+
+        $opportunity = $this->opportunityBuilder
+            ->reset(owner: $admin->profile, owner_entity: $admin->profile)
+            ->fillRequiredProperties()
+            ->firstPhase()
+                ->setRegistrationPeriod(new Open)
+                ->done()
+            ->save()
+            ->addEvaluationPhase(EvaluationMethods::simple)
+                ->setEvaluationPeriod(new ConcurrentEndingAfter)
+                ->save()
+                ->done()
+            ->getInstance();
+
+        $cfg = $opportunity->getEvaluationMethod()->getReportConfiguration($opportunity);
+
+        $this->assertArrayNotHasKey('range', $cfg['registration']->columns, 'Garantindo que o relatório não adiciona Faixa/Linha quando a oportunidade não usa faixas');
+    }
+}


### PR DESCRIPTION
## Resumo

Inclui a coluna **Faixa/Linha** na planilha exportada pela lista de avaliações quando a oportunidade possui faixas configuradas.

## O que mudou

- Adiciona `range` à configuração do relatório de avaliações quando `registrationRanges` está presente.
- Ajusta a renderização de avaliações pendentes no relatório para seguir dinamicamente as colunas configuradas.
- Adiciona teste de regressão garantindo que:
  - oportunidades com faixas exibem a coluna `Faixa/Linha`;
  - oportunidades sem faixas não exibem essa coluna.
