### PR TITLE
fix: filtrar avaliação de desempate por status SENT

### DIFF
--- a/src/core/EvaluationMethod.php
+++ b/src/core/EvaluationMethod.php
@@ -344,7 +344,11 @@ abstract class EvaluationMethod extends Module implements \JsonSerializable{
     function getTiebreakerEvaluation(Entities\Registration $registration) {
         $app = App::i();
 
-        $tiebreaker_evaluations = $app->repo('RegistrationEvaluation')->findOneBy(['registration' => $registration, 'isTiebreaker' => true]);
+        $tiebreaker_evaluations = $app->repo('RegistrationEvaluation')->findOneBy([
+            'registration' => $registration,
+            'isTiebreaker' => true,
+            'status' => RegistrationEvaluation::STATUS_SENT
+        ]);
 
         if(empty($tiebreaker_evaluations)){
             return null;


### PR DESCRIPTION
# Cenário
`getTiebreakerEvaluation`, que buscava a avaliação de desempate sem filtrar por status, permitindo que um rascunho do avaliador de desempate sobrescrevesse o resultado consolidado.

# Correção
No `getTiebreakerEvaluation`, foi adicionado o filtro `status => STATUS_SENT` na busca, garantindo que apenas avaliações formalmente enviadas sejam consideradas no desempate.

# Pull Request Original
Esse ajuste pode ser visto no https://github.com/culturagovbr/mapadacultura/pull/136, especificamente no commit https://github.com/culturagovbr/mapadacultura/pull/136/changes/970f32c4e7f3e4a06bd086d3ccacbd64079a172f

# Observações
@rafaelchavesfreitas 
@erleibiazzio 

Abri diretamente para master, pois:
- develop não está atualizada com master (https://github.com/mapasculturais/mapasculturais/compare/develop...mapasculturais:mapasculturais:master)
- se trata de uma implementação devidamente validada em ambiente produtivo do MinC