### PR TITLE
feat: adiciona cnpj e mini curriculo em pessoas

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@ e este projeto adere ao [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 - Adiciona configuração para exigir foto de perfil do agente coletivo vinculado na inscrição para proponentes do tipo coletivo e pessoa jurídica
 - Adiciona números sequenciais nos avaliadores das comissões
 - Permite criar agentes no fluxo de inscrição de oportunidades respeitando as permissões: agente individual apenas para administradores e agente coletivo para usuários comuns quando exigido pela inscrição.
+- Adiciona campos de CNPJ e mini currículo à listagem de pessoas dos formulários de inscrição, com validação de CPF e CNPJ.
 
 ### Correções
 - Aplica texto de internacionalização faltante no componente opportunity-registration-table

--- a/src/modules/Opportunities/components/registration-field-persons/script.js
+++ b/src/modules/Opportunities/components/registration-field-persons/script.js
@@ -119,6 +119,8 @@ app.component('registration-field-persons', {
                 fullName: '',
                 socialName: '',
                 cpf: '',
+                cnpj: '',
+                miniCurriculum: '',
                 income: '',
                 education: '',
                 telephone: '',
@@ -139,6 +141,8 @@ app.component('registration-field-persons', {
                 'fullName': 'Nome Completo',
                 'socialName': 'Nome Social',
                 'cpf': 'CPF',
+                'cnpj': 'CNPJ',
+                'miniCurriculum': 'Mini currículo',
                 'income': 'Renda',
                 'education': 'Escolaridade',
                 'telephone': 'Telefone do representante',
@@ -153,7 +157,14 @@ app.component('registration-field-persons', {
             };
 
             const errors = this.registration.__validationErrors[this.prop];
-            return (errors?.some(str => str.toLowerCase().includes(fieldNames[field])) && person[field] == '') ?? false;
+            const needle = fieldNames[field]?.toLowerCase();
+            const hasError = needle && errors?.some(str => str.toLowerCase().includes(needle));
+
+            if (!hasError) {
+                return false;
+            }
+
+            return ['cpf', 'cnpj'].includes(field) || person[field] == '';
         },
 
         save() {

--- a/src/modules/Opportunities/components/registration-field-persons/template.php
+++ b/src/modules/Opportunities/components/registration-field-persons/template.php
@@ -52,6 +52,22 @@ $this->import('
                     <input type="text" v-maska data-maska="###.###.###-##" v-model="person.cpf" @change="save()" :disabled="disabled" />
                 </div>
 
+                <div v-if="rules.cnpj" class="field col-12" :class="[{'error': fieldError(person, 'cnpj')}]">
+                    <label>
+                        <?= i::__('CNPJ:') ?>
+                        <span v-if="isFieldRequired?.cnpj" class="required">*<?= i::__('obrigatório') ?></span>
+                    </label>
+                    <input type="text" v-maska data-maska="##.###.###/####-##" v-model="person.cnpj" @change="save()" :disabled="disabled" />
+                </div>
+
+                <div v-if="rules.miniCurriculum" class="field col-12" :class="[{'error': fieldError(person, 'miniCurriculum')}]">
+                    <label>
+                        <?= i::__('Mini currículo') ?>
+                        <span v-if="isFieldRequired?.miniCurriculum" class="required">*<?= i::__('obrigatório') ?></span>
+                    </label>
+                    <textarea v-model="person.miniCurriculum" @change="save()" :disabled="disabled"></textarea>
+                </div>
+
                 <div v-if="rules.income" class="field col-12" :class="[{'error': fieldError(person, 'income')}]">
                     <label>
                         <?= $this->text('renda', i::__('Renda individual em reais (calcular a renda média individual dos últimos três meses)')) ?>

--- a/src/modules/RegistrationFieldTypes/Module.php
+++ b/src/modules/RegistrationFieldTypes/Module.php
@@ -360,6 +360,38 @@ class Module extends \MapasCulturais\Module
             }
         });
 
+        $app->hook("entity(Registration).sendValidationErrors", function(&$errorsResult) use($module) {
+            /** @var Registration $this */
+            $registration = $this;
+            $opportunity = $registration->opportunity;
+
+            foreach ($opportunity->registrationFieldConfigurations as $field) {
+                if ($field->fieldType !== 'persons') {
+                    continue;
+                }
+                if (!$registration->isFieldVisisble($field)) {
+                    continue;
+                }
+
+                $prop_name = $field->getFieldName();
+                $val = $registration->$prop_name;
+
+                if (!is_array($val)) {
+                    continue;
+                }
+
+                $field_name = 'field_' . $field->id;
+                $personErrors = $module->validatePersonsField($field, $val);
+
+                if (!empty($personErrors)) {
+                    if (!isset($errorsResult[$field_name])) {
+                        $errorsResult[$field_name] = [];
+                    }
+                    $errorsResult[$field_name] = array_merge($errorsResult[$field_name], $personErrors);
+                }
+            }
+        });
+
         $app->hook("entity(Registration).save:before", function() use($module, $app) {
             /** @var Registration $this */
             $fix_field = function($entity, $field) use($module){
@@ -547,6 +579,87 @@ class Module extends \MapasCulturais\Module
         }
 
         return $errors;
+    }
+
+    function validatePersonsField(RegistrationFieldConfiguration $field, array $persons): array
+    {
+        $errors = [];
+        $config = $field->config ?? [];
+        $requiredFields = $config['requiredFields'] ?? [];
+
+        $fieldLabels = [
+            'name' => i::__('Nome'),
+            'fullName' => i::__('Nome completo'),
+            'socialName' => i::__('Nome social'),
+            'cpf' => i::__('CPF'),
+            'cnpj' => i::__('CNPJ'),
+            'miniCurriculum' => i::__('Mini currículo'),
+            'income' => i::__('Renda'),
+            'education' => i::__('Escolaridade'),
+            'telephone' => i::__('Telefone do representante'),
+            'email' => i::__('Email'),
+            'race' => i::__('Raça/Cor'),
+            'gender' => i::__('Gênero'),
+            'sexualOrientation' => i::__('Orientação sexual'),
+            'deficiencies' => i::__('Deficiências'),
+            'comunty' => i::__('Comunidade tradicional'),
+            'area' => i::__('Áreas de atuação'),
+            'funcao' => i::__('Funções/Profissões'),
+        ];
+
+        foreach ($persons as $index => $person) {
+            if (!is_array($person) && !is_object($person)) {
+                continue;
+            }
+
+            $personData = (array) $person;
+            $personNumber = $index + 1;
+
+            foreach ($fieldLabels as $key => $label) {
+                if (!$this->isTruthyConfig($config[$key] ?? false)) {
+                    continue;
+                }
+
+                $value = $personData[$key] ?? null;
+
+                if ($this->isTruthyConfig($requiredFields[$key] ?? false) && $this->isEmptyPersonField($value)) {
+                    $errors[] = sprintf(i::__('O campo %s da pessoa %d é obrigatório.'), $label, $personNumber);
+                    continue;
+                }
+
+                if ($this->isEmptyPersonField($value)) {
+                    continue;
+                }
+
+                if ($key === 'cpf' && !\Respect\Validation\Validator::cpf()->validate((string) $value)) {
+                    $errors[] = sprintf(i::__('CPF inválido na pessoa %d.'), $personNumber);
+                }
+
+                if ($key === 'cnpj' && !\Respect\Validation\Validator::cnpj()->validate((string) $value)) {
+                    $errors[] = sprintf(i::__('CNPJ inválido na pessoa %d.'), $personNumber);
+                }
+            }
+        }
+
+        return $errors;
+    }
+
+    protected function isTruthyConfig($value): bool
+    {
+        return $value === true || $value === 1 || $value === '1' || $value === 'true';
+    }
+
+    protected function isEmptyPersonField($value): bool
+    {
+        if (is_array($value)) {
+            return count(array_filter($value)) === 0;
+        }
+
+        if (is_object($value)) {
+            return count(array_filter((array) $value)) === 0;
+        }
+
+        return trim((string) $value) === '';
     }
 
     function normalizeAndValidateCustomTableConfig(RegistrationFieldConfiguration $field): void

--- a/src/modules/RegistrationFieldTypes/layouts/parts/registration-field-types/persons-config.php
+++ b/src/modules/RegistrationFieldTypes/layouts/parts/registration-field-types/persons-config.php
@@ -13,6 +13,8 @@ use MapasCulturais\i; ?>
     <label class="checkbox-label"><input type="checkbox" ng-model="field.config.fullName" ng-true-value="'true'" ng-false-value=""> <?php i::_e('nome completo') ?></label>
     <label class="checkbox-label"><input type="checkbox" ng-model="field.config.socialName" ng-true-value="'true'" ng-false-value=""> <?php i::_e('nome social') ?></label>
     <label class="checkbox-label"><input type="checkbox" ng-model="field.config.cpf" ng-true-value="'true'" ng-false-value=""> <?php i::_e('CPF') ?></label>
+    <label class="checkbox-label"><input type="checkbox" ng-model="field.config.cnpj" ng-true-value="'true'" ng-false-value=""> <?php i::_e('CNPJ') ?></label>
+    <label class="checkbox-label"><input type="checkbox" ng-model="field.config.miniCurriculum" ng-true-value="'true'" ng-false-value=""> <?php i::_e('Mini currículo') ?></label>
     <label class="checkbox-label"><input type="checkbox" ng-model="field.config.income" ng-true-value="'true'" ng-false-value=""> <?php i::_e('Renda') ?></label>
     <label class="checkbox-label"><input type="checkbox" ng-model="field.config.education" ng-true-value="'true'" ng-false-value=""> <?php i::_e('Escolaridade') ?></label>
     <label class="checkbox-label"><input type="checkbox" ng-model="field.config.telephone" ng-true-value="'true'" ng-false-value=""> <?php i::_e('Telefone do representante') ?></label>
@@ -33,6 +35,8 @@ use MapasCulturais\i; ?>
     <label ng-if="field.config.fullName" class="checkbox-label"><input type="checkbox" ng-model="field.config.requiredFields.fullName" ng-true-value="'true'" ng-false-value=""> <?php i::_e('nome completo') ?></label>
     <label ng-if="field.config.socialName" class="checkbox-label"><input type="checkbox" ng-model="field.config.requiredFields.socialName" ng-true-value="'true'" ng-false-value=""> <?php i::_e('nome social') ?></label>
     <label ng-if="field.config.cpf" class="checkbox-label"><input type="checkbox" ng-model="field.config.requiredFields.cpf" ng-true-value="'true'" ng-false-value=""> <?php i::_e('CPF') ?></label>
+    <label ng-if="field.config.cnpj" class="checkbox-label"><input type="checkbox" ng-model="field.config.requiredFields.cnpj" ng-true-value="'true'" ng-false-value=""> <?php i::_e('CNPJ') ?></label>
+    <label ng-if="field.config.miniCurriculum" class="checkbox-label"><input type="checkbox" ng-model="field.config.requiredFields.miniCurriculum" ng-true-value="'true'" ng-false-value=""> <?php i::_e('Mini currículo') ?></label>
     <label ng-if="field.config.income" class="checkbox-label"><input type="checkbox" ng-model="field.config.requiredFields.income" ng-true-value="'true'" ng-false-value=""> <?php i::_e('Renda') ?></label>
     <label ng-if="field.config.education" class="checkbox-label"><input type="checkbox" ng-model="field.config.requiredFields.education" ng-true-value="'true'" ng-false-value=""> <?php i::_e('Escolaridade') ?></label>
     <label ng-if="field.config.telephone" class="checkbox-label"><input type="checkbox" ng-model="field.config.requiredFields.telephone" ng-true-value="'true'" ng-false-value=""> <?php i::_e('Telefone do representante') ?></label>

--- a/src/modules/RegistrationFieldTypes/layouts/parts/registration-field-types/persons.php
+++ b/src/modules/RegistrationFieldTypes/layouts/parts/registration-field-types/persons.php
@@ -19,6 +19,14 @@ use MapasCulturais\i; ?>
             <?php i::_e('CPF') ?>: <br>
             <input ng-model="person.cpf" ng-blur="saveField(field, entity[fieldName])" js-mask="999.999.999-99" placeholder="___.___.___-__" required>
         </label>
+        <label ng-if="::field.config.cnpj" style="display:inline-block">
+            <?php i::_e('CNPJ') ?>: <br>
+            <input ng-model="person.cnpj" ng-blur="saveField(field, entity[fieldName])" js-mask="99.999.999/9999-99" placeholder="__.___.___/____-__" required>
+        </label>
+        <label ng-if="::field.config.miniCurriculum" style="display:block">
+            <?php i::_e('Mini currículo') ?>: <br>
+            <textarea ng-model="person.miniCurriculum" ng-blur="saveField(field, entity[fieldName])" required></textarea>
+        </label>
         <label ng-if="::field.config.function" style="display:inline-block">
             <?php i::_e('Função') ?>: <br>
             <input ng-model="person.function" ng-blur="saveField(field, entity[fieldName])" required>

--- a/src/themes/BaseV1/layouts/parts/singles/registration-field-view.php
+++ b/src/themes/BaseV1/layouts/parts/singles/registration-field-view.php
@@ -42,6 +42,8 @@
             <div ng-if="field.config.fullName && person.fullName"><strong><?php \MapasCulturais\i::_e("Nome completo"); ?>: </strong>{{person.fullName}}</div>
             <div ng-if="field.config.socialName && person.socialName"><strong><?php \MapasCulturais\i::_e("Nome social"); ?>: </strong>{{person.socialName}}</div>
             <div ng-if="field.config.cpf && person.cpf"><strong><?php \MapasCulturais\i::_e("CPF"); ?>: </strong>{{person.cpf}}</div>
+            <div ng-if="field.config.cnpj && person.cnpj"><strong><?php \MapasCulturais\i::_e("CNPJ"); ?>: </strong>{{person.cnpj}}</div>
+            <div ng-if="field.config.miniCurriculum && person.miniCurriculum"><strong><?php \MapasCulturais\i::_e("Mini currículo"); ?>: </strong><span style="white-space: pre-line">{{person.miniCurriculum}}</span></div>
             <div ng-if="field.config.income && person.income"><strong><?php \MapasCulturais\i::_e("Renda"); ?>: </strong>{{person.income}}</div>
             <div ng-if="field.config.education && person.education"><strong><?php \MapasCulturais\i::_e("Escolaridade"); ?>: </strong>{{person.education}}</div>
             <div ng-if="field.config.telephone && person.telephone"><strong><?php \MapasCulturais\i::_e("Telefone"); ?>: </strong>{{person.telephone}}</div>


### PR DESCRIPTION
## O que foi feito

Adiciona dois novos campos configuráveis ao campo de listagem de pessoas nos formulários de inscrição:

- CNPJ
- Mini currículo

Também adiciona validação backend para documentos na listagem de pessoas:

- CPF inválido agora é bloqueado quando informado.
- CNPJ inválido é bloqueado quando informado.
- Campos internos marcados como obrigatórios na configuração da listagem de pessoas são validados por pessoa.
