### PR TITLE
Busca avaliadores por email de usuário

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,7 @@ e este projeto adere ao [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 - Adiciona configuração para exigir foto de perfil do agente coletivo vinculado na inscrição para proponentes do tipo coletivo e pessoa jurídica
 - Adiciona números sequenciais nos avaliadores das comissões
 - Permite criar agentes no fluxo de inscrição de oportunidades respeitando as permissões: agente individual apenas para administradores e agente coletivo para usuários comuns quando exigido pela inscrição.
+- Permite buscar avaliadores por ID do agente no formato #ID e e-mail do usuário ao adicioná-los ou substituí-los nas comissões de avaliação.
 
 ### Correções
 - Aplica texto de internacionalização faltante no componente opportunity-registration-table

--- a/src/modules/Opportunities/Module.php
+++ b/src/modules/Opportunities/Module.php
@@ -33,6 +33,34 @@ class Module extends \MapasCulturais\Module{
 
         $self = $this;
 
+        $evaluator_agent_search = false;
+
+        $app->hook('ApiQuery(agent).params', function (&$api_params) use (&$evaluator_agent_search) {
+            $evaluator_agent_search = !empty($api_params['_evaluatorSearch']);
+            unset($api_params['_evaluatorSearch']);
+        });
+
+        $app->hook('repo(agent).getIdsByKeywordDQL.where', function (&$where, $keyword, $alias) use (&$evaluator_agent_search) {
+            if (!$evaluator_agent_search) {
+                return;
+            }
+
+            $raw_keyword = trim(str_replace('%', '', $keyword));
+
+            if (ctype_digit($raw_keyword)) {
+                $where .= "\n OR e.id = " . (int) $raw_keyword;
+            }
+
+            if (str_contains($raw_keyword, '@')) {
+                $where .= "
+                    OR IDENTITY(e.user) IN (
+                        SELECT evaluation_committee_user.id
+                        FROM MapasCulturais\\Entities\\User evaluation_committee_user
+                        WHERE lower(evaluation_committee_user.email) LIKE lower(:{$alias})
+                    )";
+            }
+        });
+
         // Registro de Jobs
         $app->registerJobType(new Jobs\StartEvaluationPhase(Jobs\StartEvaluationPhase::SLUG));
         $app->registerJobType(new Jobs\StartDataCollectionPhase(Jobs\StartDataCollectionPhase::SLUG));

--- a/src/modules/Opportunities/Module.php
+++ b/src/modules/Opportunities/Module.php
@@ -47,8 +47,8 @@ class Module extends \MapasCulturais\Module{
 
             $raw_keyword = trim(str_replace('%', '', $keyword));
 
-            if (ctype_digit($raw_keyword)) {
-                $where .= "\n OR e.id = " . (int) $raw_keyword;
+            if (preg_match('/^#(\d+)$/', $raw_keyword, $matches)) {
+                $where .= "\n OR e.id = " . (int) $matches[1];
             }
 
             if (str_contains($raw_keyword, '@')) {

--- a/src/modules/Opportunities/components/opportunity-evaluation-committee/script.js
+++ b/src/modules/Opportunities/components/opportunity-evaluation-committee/script.js
@@ -24,6 +24,7 @@ app.component('opportunity-evaluation-committee', {
                 '@order': 'id ASC',
                 '@limit': '25',
                 '@page': '1',
+                '_evaluatorSearch': '1',
                 'type': 'EQ(1)',
                 'parent': 'NULL()'
             };

--- a/src/modules/Opportunities/components/opportunity-evaluation-committee/template.php
+++ b/src/modules/Opportunities/components/opportunity-evaluation-committee/template.php
@@ -33,7 +33,7 @@ $this->import('
                 <span class="icon">
                     <mc-avatar :entity="entity" size="xsmall"></mc-avatar>
                 </span>
-                <span class="label"> #{{entity.id}} - {{entity.name}}</span>
+                <span class="label"> #{{entity.id}} - {{entity.name}}<template v-if="entity.user?.email"> - {{entity.user.email}}</template></span>
             </template>
         </select-entity>
         <?php $this->applyComponentHook('select-entity', 'end'); ?>
@@ -178,7 +178,7 @@ $this->import('
                                 <span class="icon">
                                     <mc-avatar :entity="entity" size="xsmall"></mc-avatar>
                                 </span>
-                                <span class="label"> #{{entity.id}} - {{entity.name}}</span>
+                                <span class="label"> #{{entity.id}} - {{entity.name}}<template v-if="entity.user?.email"> - {{entity.user.email}}</template></span>
                             </template>
                         </select-entity>
                         <mc-confirm-button v-if="infoReviewer.metadata?.summary.sent > 0" @confirm="reopenEvaluations(infoReviewer.agentUserId)">
@@ -244,7 +244,7 @@ $this->import('
                 <span class="icon">
                     <mc-avatar :entity="entity" size="xsmall"></mc-avatar>
                 </span>
-                <span class="label"> #{{entity.id}} - {{entity.name}}</span>
+                <span class="label"> #{{entity.id}} - {{entity.name}}<template v-if="entity.user?.email"> - {{entity.user.email}}</template></span>
             </template>
         </select-entity>
     </div>

--- a/tests/src/AgentApiTest.php
+++ b/tests/src/AgentApiTest.php
@@ -61,7 +61,7 @@ class AgentApiTest extends TestCase
 
             $id_query = new ApiQuery(Agent::class, [
                 '@select' => 'id,name',
-                '@keyword' => (string) $profile->id,
+                '@keyword' => "#{$profile->id}",
                 '_evaluatorSearch' => '1',
                 'type' => 'EQ(1)',
                 'parent' => 'NULL()',
@@ -72,7 +72,7 @@ class AgentApiTest extends TestCase
             $this->assertContains(
                 $profile->id,
                 array_column($id_result, 'id'),
-                'A busca de avaliadores deve encontrar agentes individuais pelo ID do agente.'
+                'A busca de avaliadores deve encontrar agentes individuais pelo ID do agente informado com #.'
             );
         } finally {
             $app->enableAccessControl();

--- a/tests/src/AgentApiTest.php
+++ b/tests/src/AgentApiTest.php
@@ -14,6 +14,71 @@ class AgentApiTest extends TestCase
     use UserDirector,
         AgentDirector;
 
+    function testEvaluationCommitteeSearchFindsAgentByUserEmailAndAgentIdWithoutChangingGlobalKeyword()
+    {
+        $app = App::i();
+        $app->disableAccessControl();
+
+        try {
+            $user = $this->userDirector->createUser();
+            $user->email = 'avaliador-busca-' . uniqid() . '@example.test';
+            $user->save(true);
+
+            $profile = $user->profile;
+            $profile->name = 'Pessoa Avaliadora Busca Escopada';
+            $profile->save(true);
+
+            $global_query = new ApiQuery(Agent::class, [
+                '@select' => 'id,name',
+                '@keyword' => $user->email,
+                'type' => 'EQ(1)',
+                'parent' => 'NULL()',
+                '@order' => 'id ASC',
+            ]);
+            $global_result = $global_query->find();
+
+            $this->assertNotContains(
+                $profile->id,
+                array_column($global_result, 'id'),
+                'A busca global de agentes por @keyword não deve buscar pelo email do usuário.'
+            );
+
+            $email_query = new ApiQuery(Agent::class, [
+                '@select' => 'id,name,user',
+                '@keyword' => $user->email,
+                '_evaluatorSearch' => '1',
+                'type' => 'EQ(1)',
+                'parent' => 'NULL()',
+                '@order' => 'id ASC',
+            ]);
+            $email_result = $email_query->find();
+
+            $this->assertContains(
+                $profile->id,
+                array_column($email_result, 'id'),
+                'A busca de avaliadores deve encontrar agentes individuais pelo email do usuário vinculado.'
+            );
+
+            $id_query = new ApiQuery(Agent::class, [
+                '@select' => 'id,name',
+                '@keyword' => (string) $profile->id,
+                '_evaluatorSearch' => '1',
+                'type' => 'EQ(1)',
+                'parent' => 'NULL()',
+                '@order' => 'id ASC',
+            ]);
+            $id_result = $id_query->find();
+
+            $this->assertContains(
+                $profile->id,
+                array_column($id_result, 'id'),
+                'A busca de avaliadores deve encontrar agentes individuais pelo ID do agente.'
+            );
+        } finally {
+            $app->enableAccessControl();
+        }
+    }
+
     function testFilterAgentsByAvatar()
     {
         $app = App::i();


### PR DESCRIPTION
## Resumo

- Permite buscar pessoas avaliadoras pelo e-mail do usuário vinculado (`usr.email`) ao adicioná-las ou substituí-las nas comissões de avaliação.
- Permite buscar por ID do agente usando o formato `#ID`, por exemplo `#999`.
- Mantém a busca especial escopada ao seletor de avaliadores, sem alterar a busca global de agentes por `@keyword`.
- Exibe o e-mail do usuário nos resultados do autocomplete quando disponível, reduzindo ambiguidade entre agentes.

<img width="341" height="295" alt="image" src="https://github.com/user-attachments/assets/bfb9f586-89bb-4495-8720-b3980ddbf736" />
<img width="349" height="274" alt="image" src="https://github.com/user-attachments/assets/6475343b-0a12-4f39-89d5-512812ec847f" />
