### PR TITLE
fix: Correção de requisições N + 1 na aba "Meus Modelos"

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,7 +13,6 @@ e este projeto adere ao [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 - Adiciona botão para duplicar anexos do formulário de inscrição, incluindo a cópia do arquivo modelo e inserindo o novo anexo logo abaixo do original
 
 ### Melhorias
-- Melhora a performance da listagem de modelos de oportunidades ao evitar consultas repetidas para identificar modelos oficiais.
 - Adiciona um campo de busca para encontrar colunas por palavra-chave na listagem por tabela nas entidades.
 - Implementa a funcionalidade que permite ao saasSuperAdmin ordenar globalmente as colunas das tabelas que utilizam o entity-table, por meio de drag and drop.
 - Suprime campo de RG do cadastro do agente e dos campos @ para prevalecer o uso do CIN (Carteira de  Identidade Nacional)
@@ -26,6 +25,7 @@ e este projeto adere ao [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 - Adiciona configuração para exigir foto de perfil do agente coletivo vinculado na inscrição para proponentes do tipo coletivo e pessoa jurídica
 - Adiciona números sequenciais nos avaliadores das comissões
 - Permite criar agentes no fluxo de inscrição de oportunidades respeitando as permissões: agente individual apenas para administradores e agente coletivo para usuários comuns quando exigido pela inscrição.
+- Melhora a performance da listagem de modelos de oportunidades ao evitar consultas repetidas para identificar modelos oficiais.
 
 ### Correções
 - Aplica texto de internacionalização faltante no componente opportunity-registration-table

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ e este projeto adere ao [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 - Adiciona botão para duplicar anexos do formulário de inscrição, incluindo a cópia do arquivo modelo e inserindo o novo anexo logo abaixo do original
 
 ### Melhorias
+- Melhora a performance da listagem de modelos de oportunidades ao evitar consultas repetidas para identificar modelos oficiais.
 - Adiciona um campo de busca para encontrar colunas por palavra-chave na listagem por tabela nas entidades.
 - Implementa a funcionalidade que permite ao saasSuperAdmin ordenar globalmente as colunas das tabelas que utilizam o entity-table, por meio de drag and drop.
 - Suprime campo de RG do cadastro do agente e dos campos @ para prevalecer o uso do CIN (Carteira de  Identidade Nacional)

--- a/src/core/Traits/EntityManagerModel.php
+++ b/src/core/Traits/EntityManagerModel.php
@@ -118,42 +118,78 @@ trait EntityManagerModel {
     function GET_findOpportunitiesModels()
     {
         $app = App::i();
-        $dataModels = [];
-        
-        $opportunities = $app->em->createQuery("
-            SELECT 
-                o.id
-            FROM
-                MapasCulturais\Entities\OpportunityMeta om
-                JOIN MapasCulturais\Entities\Opportunity o WITH om.owner=o
-            WHERE om.key = 'isModel' AND om.value = '1'
+        $conn = $app->em->getConnection();
+        $verifiedSealIds = $app->config['app.verifiedSealsIds'] ?? [];
+
+        $rows = $conn->fetchAllAssociative("
+            SELECT
+                o.id,
+                o.short_description,
+                o.registration_from,
+                (
+                    SELECT COUNT(*)
+                    FROM opportunity child
+                    LEFT JOIN opportunity_meta om_last
+                        ON om_last.object_id = child.id AND om_last.key = 'isLastPhase'
+                    WHERE child.parent_id = o.id
+                      AND (om_last.value IS NULL OR om_last.value != '1')
+                ) AS numero_fases,
+                (
+                    SELECT lp.publish_timestamp
+                    FROM opportunity lp
+                    JOIN opportunity_meta om_lp
+                        ON om_lp.object_id = lp.id AND om_lp.key = 'isLastPhase' AND om_lp.value = '1'
+                    WHERE lp.parent_id = o.id
+                    LIMIT 1
+                ) AS last_phase_publish_timestamp,
+                (
+                    SELECT om_rpt.value
+                    FROM opportunity_meta om_rpt
+                    WHERE om_rpt.object_id = o.id AND om_rpt.key = 'registrationProponentTypes'
+                ) AS tipo_agente
+            FROM opportunity o
+            JOIN opportunity_meta om_model
+                ON om_model.object_id = o.id AND om_model.key = 'isModel' AND om_model.value = '1'
+            WHERE o.status != -10
         ");
 
-        foreach ($opportunities->getResult() as $opportunity) {
-            $opp = $app->repo('Opportunity')->find($opportunity['id']);
-            $phases = $opp->phases;
-
-            $lastPhase = array_pop($phases);
-
+        $dataModels = [];
+        foreach ($rows as $row) {
             $modelIsOfficial = false;
-            foreach ($opp->getSealRelations() as $sealRelation) {
-                if ( in_array($sealRelation->seal->id, $app->config['app.verifiedSealsIds'])) {
-                    $modelIsOfficial = true;
-                }
+            if (!empty($verifiedSealIds)) {
+                $placeholders = implode(',', array_fill(0, count($verifiedSealIds), '?'));
+                $hasSeal = $conn->fetchOne(
+                    "SELECT 1 FROM seal_relation sr
+                     WHERE sr.object_id = ? AND sr.object_type = 'MapasCulturais\\Entities\\Opportunity'
+                       AND sr.seal_id IN ($placeholders) LIMIT 1",
+                    array_merge([(int) $row['id']], $verifiedSealIds)
+                );
+                $modelIsOfficial = (bool) $hasSeal;
             }
-            
-            $days = !is_null($opp->registrationFrom) && !is_null($lastPhase->publishTimestamp) ? $lastPhase->publishTimestamp->diff($opp->registrationFrom)->days . " Dia(s)" : 'N/A';
-            $tipoAgente = $opp->registrationProponentTypes ? implode(', ', $opp->registrationProponentTypes) : 'N/A';
+
+            $days = 'N/A';
+            if ($row['registration_from'] && $row['last_phase_publish_timestamp']) {
+                $regFrom = new \DateTime($row['registration_from']);
+                $pubTs   = new \DateTime($row['last_phase_publish_timestamp']);
+                $days    = $pubTs->diff($regFrom)->days . ' Dia(s)';
+            }
+
+            $tipoAgente = 'N/A';
+            if ($row['tipo_agente']) {
+                $decoded    = json_decode($row['tipo_agente'], true);
+                $tipoAgente = is_array($decoded) ? implode(', ', $decoded) : $row['tipo_agente'];
+            }
+
             $dataModels[] = [
-                'id' => $opp->id,
-                'numeroFases' => count($opp->phases),
-                'descricao' => $opp->shortDescription,
-                'tempoEstimado' => $days,
-                'tipoAgente'   =>  $tipoAgente,
-                'modelIsOfficial' => $modelIsOfficial
+                'id'             => (int) $row['id'],
+                'numeroFases'    => (int) $row['numero_fases'],
+                'descricao'      => $row['short_description'],
+                'tempoEstimado'  => $days,
+                'tipoAgente'     => $tipoAgente,
+                'modelIsOfficial'=> $modelIsOfficial,
             ];
         }
-        
+
         $this->json($dataModels);
     }
 

--- a/src/core/Traits/EntityManagerModel.php
+++ b/src/core/Traits/EntityManagerModel.php
@@ -126,12 +126,14 @@ trait EntityManagerModel {
                 o.id,
                 o.short_description,
                 o.registration_from,
+                o.registration_proponent_types,
                 (
                     SELECT COUNT(*)
                     FROM opportunity child
                     LEFT JOIN opportunity_meta om_last
                         ON om_last.object_id = child.id AND om_last.key = 'isLastPhase'
                     WHERE child.parent_id = o.id
+                      AND child.status != -10
                       AND (om_last.value IS NULL OR om_last.value != '1')
                 ) AS numero_fases,
                 (
@@ -141,12 +143,7 @@ trait EntityManagerModel {
                         ON om_lp.object_id = lp.id AND om_lp.key = 'isLastPhase' AND om_lp.value = '1'
                     WHERE lp.parent_id = o.id
                     LIMIT 1
-                ) AS last_phase_publish_timestamp,
-                (
-                    SELECT om_rpt.value
-                    FROM opportunity_meta om_rpt
-                    WHERE om_rpt.object_id = o.id AND om_rpt.key = 'registrationProponentTypes'
-                ) AS tipo_agente
+                ) AS last_phase_publish_timestamp
             FROM opportunity o
             JOIN opportunity_meta om_model
                 ON om_model.object_id = o.id AND om_model.key = 'isModel' AND om_model.value = '1'
@@ -175,9 +172,9 @@ trait EntityManagerModel {
             }
 
             $tipoAgente = 'N/A';
-            if ($row['tipo_agente']) {
-                $decoded    = json_decode($row['tipo_agente'], true);
-                $tipoAgente = is_array($decoded) ? implode(', ', $decoded) : $row['tipo_agente'];
+            if ($row['registration_proponent_types']) {
+                $decoded    = json_decode($row['registration_proponent_types'], true);
+                $tipoAgente = is_array($decoded) ? implode(', ', $decoded) : $row['registration_proponent_types'];
             }
 
             $dataModels[] = [

--- a/src/core/Traits/EntityManagerModel.php
+++ b/src/core/Traits/EntityManagerModel.php
@@ -120,6 +120,21 @@ trait EntityManagerModel {
         $app = App::i();
         $conn = $app->em->getConnection();
         $verifiedSealIds = $app->config['app.verifiedSealsIds'] ?? [];
+        $verifiedSealIds = is_array($verifiedSealIds) ? $verifiedSealIds : [$verifiedSealIds];
+        $verifiedSealIds = array_values(array_filter($verifiedSealIds, fn($id) => is_numeric($id)));
+        $modelIsOfficialSql = 'FALSE AS model_is_official';
+
+        if (!empty($verifiedSealIds)) {
+            $placeholders = implode(',', array_fill(0, count($verifiedSealIds), '?'));
+            $modelIsOfficialSql = "EXISTS (
+                SELECT 1
+                FROM seal_relation sr
+                WHERE sr.object_id = o.id
+                  AND sr.object_type = 'MapasCulturais\\Entities\\Opportunity'
+                  AND sr.seal_id IN ($placeholders)
+                LIMIT 1
+            ) AS model_is_official";
+        }
 
         $rows = $conn->fetchAllAssociative("
             SELECT
@@ -127,6 +142,7 @@ trait EntityManagerModel {
                 o.short_description,
                 o.registration_from,
                 o.registration_proponent_types,
+                $modelIsOfficialSql,
                 (
                     SELECT COUNT(*)
                     FROM opportunity child
@@ -148,22 +164,10 @@ trait EntityManagerModel {
             JOIN opportunity_meta om_model
                 ON om_model.object_id = o.id AND om_model.key = 'isModel' AND om_model.value = '1'
             WHERE o.status != -10
-        ");
+        ", $verifiedSealIds);
 
         $dataModels = [];
         foreach ($rows as $row) {
-            $modelIsOfficial = false;
-            if (!empty($verifiedSealIds)) {
-                $placeholders = implode(',', array_fill(0, count($verifiedSealIds), '?'));
-                $hasSeal = $conn->fetchOne(
-                    "SELECT 1 FROM seal_relation sr
-                     WHERE sr.object_id = ? AND sr.object_type = 'MapasCulturais\\Entities\\Opportunity'
-                       AND sr.seal_id IN ($placeholders) LIMIT 1",
-                    array_merge([(int) $row['id']], $verifiedSealIds)
-                );
-                $modelIsOfficial = (bool) $hasSeal;
-            }
-
             $days = 'N/A';
             if ($row['registration_from'] && $row['last_phase_publish_timestamp']) {
                 $regFrom = new \DateTime($row['registration_from']);
@@ -175,6 +179,7 @@ trait EntityManagerModel {
             if ($row['registration_proponent_types']) {
                 $decoded    = json_decode($row['registration_proponent_types'], true);
                 $tipoAgente = is_array($decoded) ? implode(', ', $decoded) : $row['registration_proponent_types'];
+                $tipoAgente = $tipoAgente ?: 'N/A';
             }
 
             $dataModels[] = [
@@ -183,7 +188,7 @@ trait EntityManagerModel {
                 'descricao'      => $row['short_description'],
                 'tempoEstimado'  => $days,
                 'tipoAgente'     => $tipoAgente,
-                'modelIsOfficial'=> $modelIsOfficial,
+                'modelIsOfficial'=> (bool) $row['model_is_official'],
             ];
         }
 

--- a/src/modules/Panel/components/panel--entity-models-card/script.js
+++ b/src/modules/Panel/components/panel--entity-models-card/script.js
@@ -19,17 +19,14 @@ app.component('panel--entity-models-card', {
         onDeleteRemoveFromLists: {
             type: Boolean,
             default: true
+        },
+        models: {
+            type: Array,
+            default: () => []
         }
     },
-    data() {        
-        const api = new API(this.entity.__objectType);
-        const response = api.GET('/opportunity/findOpportunitiesModels');
-        response.then((r) => r.json().then((r) => {
-           this.models = r;
-        }));
-
+    data() {
         let isModelPublic = this.entity.isModelPublic == 1 ? true : false;
-
 
         const MODEL_OFFICIAL = 'MODELO OFICIAL';
         const MODEL_PRIVATE = 'MODELO PRIVADO';
@@ -43,7 +40,6 @@ app.component('panel--entity-models-card', {
 
         return {
             isModelPublic,
-            models: [],
             typeModels
         }
     },

--- a/src/modules/Panel/components/panel--entity-tabs/script.js
+++ b/src/modules/Panel/components/panel--entity-tabs/script.js
@@ -43,6 +43,13 @@ app.component('panel--entity-tabs', {
             grantedQuery['@permissionsUser'] = this.user
         }
 
+        if (this.type == 'opportunity') {
+            const api = new API('opportunity');
+            api.GET('/opportunity/findOpportunitiesModels').then((r) => r.json().then((data) => {
+                this.opportunitiesModels = data;
+            }));
+        }
+
         return {
             description: $DESCRIPTIONS[this.type],
             queries: {
@@ -54,6 +61,7 @@ app.component('panel--entity-tabs', {
                 archived: { status: 'EQ(-2)', ...query },
             },
             showPrivateKey: false,
+            opportunitiesModels: [],
         }
     },
     props: {

--- a/src/modules/Panel/components/panel--entity-tabs/template.php
+++ b/src/modules/Panel/components/panel--entity-tabs/template.php
@@ -111,7 +111,7 @@ $this->applyComponentHook('.sortOptions', [&$tabs]);
                             <slot name="entity-actions-right" :entity="entity"></slot>
                         </template>
                     </panel--entity-card>
-                    <panel--entity-models-card v-if="entity.__objectType == 'opportunity' && entity.isModel == 1" :key="entity.id" :entity="entity"></panel--entity-models-card>
+                    <panel--entity-models-card v-if="entity.__objectType == 'opportunity' && entity.isModel == 1" :key="entity.id" :entity="entity" :models="opportunitiesModels"></panel--entity-models-card>
                 </slot>
                 <slot name='after-list' :entities="entities" :query="queries['<?=$status?>']"></slot>
             </template>

--- a/tests/src/OpportunityFindModelsTest.php
+++ b/tests/src/OpportunityFindModelsTest.php
@@ -1,0 +1,259 @@
+<?php
+
+namespace Test;
+
+use MapasCulturais\App;
+use MapasCulturais\Entities\Opportunity;
+use Psr\Http\Message\ServerRequestInterface;
+use Tests\Abstract\TestCase;
+use Tests\Builders\PhasePeriods\Open;
+use Tests\Traits\OpportunityBuilder;
+use Tests\Traits\RequestFactory;
+use Tests\Traits\SealDirector;
+use Tests\Traits\UserDirector;
+
+/**
+ * Testes para o endpoint GET /opportunity/findOpportunitiesModels
+ * Cobre os ajustes feitos na branch fix/opportunity-models-n-plus-one:
+ *  - leitura de registrationProponentTypes da coluna (não de opportunity_meta)
+ *  - exclusão de modelos com status -10 (lixeira)
+ *  - modelIsOfficial via seal_relation
+ *  - numeroFases excluindo a última fase (isLastPhase)
+ */
+class OpportunityFindModelsTest extends TestCase
+{
+    use OpportunityBuilder,
+        RequestFactory,
+        UserDirector,
+        SealDirector;
+
+    // =================== HELPERS ===================
+
+    private function makeRequest(): ServerRequestInterface
+    {
+        return $this->requestFactory->GET(
+            controller_id: 'opportunity',
+            action: 'findOpportunitiesModels',
+            ajax: true
+        );
+    }
+
+    private function callEndpoint(): array
+    {
+        $app = App::i();
+        $app->reset();
+        $app->run($this->makeRequest(), false);
+        return json_decode((string) $app->response->getBody(), true) ?? [];
+    }
+
+    private function findInResult(array $result, int $id): ?array
+    {
+        foreach ($result as $item) {
+            if ((int) $item['id'] === $id) {
+                return $item;
+            }
+        }
+        return null;
+    }
+
+    private function createModel(array $proponentTypes = []): Opportunity
+    {
+        $admin = $this->userDirector->createUser('admin');
+        $this->login($admin);
+
+        $builder = $this->opportunityBuilder
+            ->reset(owner: $admin->profile, owner_entity: $admin->profile, status: Opportunity::STATUS_PHASE)
+            ->fillRequiredProperties()
+            ->firstPhase()
+                ->setRegistrationPeriod(new Open)
+                ->done();
+
+        $model = $builder->save()->getInstance();
+
+        if (!empty($proponentTypes)) {
+            $model->registrationProponentTypes = $proponentTypes;
+        }
+
+        $model->setMetadata('isModel', 1);
+        $model->save(true);
+
+        return $model;
+    }
+
+    // =================== TESTES ===================
+
+    /**
+     * Endpoint deve responder 200.
+     */
+    function testEndpointRetornaStatus200(): void
+    {
+        $this->assertStatus200($this->makeRequest());
+    }
+
+    /**
+     * Cada item do retorno deve ter os campos definidos pelo endpoint.
+     */
+    function testRetornaEstruturaCorreta(): void
+    {
+        $model = $this->createModel();
+
+        $result = $this->callEndpoint();
+        $item = $this->findInResult($result, $model->id);
+
+        $this->assertNotNull($item, 'O modelo criado deve aparecer na listagem');
+        $this->assertArrayHasKey('id', $item);
+        $this->assertArrayHasKey('numeroFases', $item);
+        $this->assertArrayHasKey('descricao', $item);
+        $this->assertArrayHasKey('tempoEstimado', $item);
+        $this->assertArrayHasKey('tipoAgente', $item);
+        $this->assertArrayHasKey('modelIsOfficial', $item);
+        $this->assertIsInt($item['id']);
+        $this->assertIsInt($item['numeroFases']);
+        $this->assertIsBool($item['modelIsOfficial']);
+    }
+
+    /**
+     * tipoAgente deve ser lido de opportunity.registration_proponent_types (coluna),
+     * não de opportunity_meta — esse era o bug corrigido no commit de revisão.
+     */
+    function testTipoAgenteVemDaColunaRegistrationProponentTypes(): void
+    {
+        $types = ['Pessoa Física', 'Pessoa Jurídica'];
+        $model = $this->createModel($types);
+
+        $result = $this->callEndpoint();
+        $item = $this->findInResult($result, $model->id);
+        
+        $this->assertNotNull($item, 'O modelo deve aparecer na listagem');
+        $this->assertNotEquals('N/A', $item['tipoAgente'], 'tipoAgente não deve ser N/A quando há tipos definidos');
+        $this->assertStringContainsString('Pessoa Física', $item['tipoAgente']);
+        $this->assertStringContainsString('Pessoa Jurídica', $item['tipoAgente']);
+    }
+
+    /**
+     * Modelo sem tipos de proponente deve retornar N/A em tipoAgente.
+     */
+    function testTipoAgenteEhNAQuandoNaoDefinido(): void
+    {
+        $model = $this->createModel();
+
+        $result = $this->callEndpoint();
+        $item = $this->findInResult($result, $model->id);
+
+        $this->assertNotNull($item);
+        $this->assertEquals('N/A', $item['tipoAgente']);
+    }
+
+    /**
+     * Modelo na lixeira (status -10) não deve aparecer no retorno.
+     */
+    function testModeloDescartadoNaoAparece(): void
+    {
+        $model = $this->createModel();
+        $modelId = $model->id;
+
+        $model->delete(true);
+
+        $result = $this->callEndpoint();
+        $item = $this->findInResult($result, $modelId);
+
+        $this->assertNull($item, 'Modelo na lixeira não deve aparecer na listagem');
+    }
+
+    /**
+     * Modelo sem nenhum selo verificado deve ter modelIsOfficial = false.
+     */
+    function testModeloSemSeloNaoEOficial(): void
+    {
+        $model = $this->createModel();
+
+        $result = $this->callEndpoint();
+        $item = $this->findInResult($result, $model->id);
+
+        $this->assertNotNull($item);
+        $this->assertFalse($item['modelIsOfficial'], 'Modelo sem selo verificado não deve ser oficial');
+    }
+
+    /**
+     * Modelo com um selo cujo ID está em app.verifiedSealsIds deve ter modelIsOfficial = true.
+     */
+    function testModeloComSeloVerificadoEOficial(): void
+    {
+        $app = App::i();
+        $admin = $this->userDirector->createUser('admin');
+        $this->login($admin);
+
+        $seal = $this->sealDirector->createSeal($admin->profile, disable_access_control: true);
+
+        $originalSealIds = $app->config['app.verifiedSealsIds'];
+        $app->config['app.verifiedSealsIds'] = [$seal->id];
+
+        $model = $this->opportunityBuilder
+            ->reset(owner: $admin->profile, owner_entity: $admin->profile, status: Opportunity::STATUS_PHASE)
+            ->fillRequiredProperties()
+            ->firstPhase()
+                ->setRegistrationPeriod(new Open)
+                ->done()
+            ->save()
+            ->getInstance();
+
+        $model->setMetadata('isModel', 1);
+        $model->save(true);
+        $model->createSealRelation($seal, save: true, flush: true);
+
+        $result = $this->callEndpoint();
+        $item = $this->findInResult($result, $model->id);
+
+        $app->config['app.verifiedSealsIds'] = $originalSealIds;
+
+        $this->assertNotNull($item);
+        $this->assertTrue($item['modelIsOfficial'], 'Modelo com selo verificado deve ter modelIsOfficial = true');
+    }
+
+    /**
+     * numeroFases deve contar apenas as fases intermediárias —
+     * a última fase (isLastPhase) não deve entrar na contagem.
+     */
+    function testNumeroDeFasesExcluiUltimaFase(): void
+    {
+        $admin = $this->userDirector->createUser('admin');
+        $this->login($admin);
+
+        $model = $this->opportunityBuilder
+            ->reset(owner: $admin->profile, owner_entity: $admin->profile, status: Opportunity::STATUS_PHASE)
+            ->fillRequiredProperties()
+            ->firstPhase()
+                ->setRegistrationPeriod(new Open)
+                ->done()
+            ->save()
+            ->addDataCollectionPhase()
+                ->done()
+            ->addDataCollectionPhase()
+                ->done()
+            ->getInstance();
+
+        $model->setMetadata('isModel', 1);
+        $model->save(true);
+
+        $result = $this->callEndpoint();
+        $item = $this->findInResult($result, $model->id);
+
+        $this->assertNotNull($item);
+
+        $app = App::i();
+        $conn = $app->em->getConnection();
+        $totalFilhos = (int) $conn->fetchOne(
+            'SELECT COUNT(*) FROM opportunity WHERE parent_id = ? AND status != -10',
+            [$model->id]
+        );
+        $ultimasFases = (int) $conn->fetchOne(
+            "SELECT COUNT(*) FROM opportunity o
+             JOIN opportunity_meta om ON om.object_id = o.id AND om.key = 'isLastPhase' AND om.value = '1'
+             WHERE o.parent_id = ? AND o.status != -10",
+            [$model->id]
+        );
+
+        $esperado = $totalFilhos - $ultimasFases;
+        $this->assertEquals($esperado, $item['numeroFases'], 'numeroFases deve excluir apenas as fases marcadas como isLastPhase');
+    }
+}


### PR DESCRIPTION
# Corrige N+1 de requisições na aba "Meus modelos"

## Cenário

Na aba **Meus modelos** do painel (`/minhas-oportunidades/#mymodels`), o usuário vê a listagem dos modelos de oportunidades que criou. Cada card exibe informações como descrição, número de fases, tempo estimado e tipo de agente.

## Problema

Ao abrir essa aba, o sistema estava disparando muito mais requisições do que deveria — e isso acontecia em dois níveis independentes.

**No frontend**, o componente `panel--entity-models-card` fazia uma chamada a `/opportunity/findOpportunitiesModels` dentro do seu `data()`. Como ele é instanciado uma vez por modelo listado, com 6 modelos cadastrados eram 7 requisições HTTP ao total: 1 para listar os modelos e 6 idênticas ao mesmo endpoint — sempre retornando os mesmos dados.

**No backend**, o endpoint `findOpportunitiesModels` também tinha um problema parecido. Ele buscava os IDs dos modelos com uma query, e depois entrava num loop onde para cada modelo carregava a entidade individualmente via `find()`, acessava as fases via lazy-load do Doctrine e buscava as relações com selos — também via lazy-load. Com 6 modelos, isso resultava em ~19 queries SQL por requisição.

## Solução

**Frontend:** o fetch foi movido para o componente pai (`panel--entity-tabs`), que agora faz a chamada uma única vez quando o tipo é `opportunity` e repassa o resultado como prop para cada `panel--entity-models-card`. O comportamento visual não muda — só a origem dos dados.

**Backend:** o método `GET_findOpportunitiesModels` foi reescrito. Em vez do loop com lazy-loading, agora usa uma query SQL única com subqueries que traz tudo de uma vez: contagem de fases, timestamp da última fase para calcular o tempo estimado e os dados do modelo. O resultado passa de ~19 queries para ~4 por requisição.

Durante a revisão também foram corrigidos dois problemas no backend original:
- `registrationProponentTypes` é uma coluna da tabela `opportunity`, não um metadado — a leitura estava apontando para o lugar errado e retornaria sempre `N/A`
- O count de fases filha não filtrava por status, podendo incluir fases descartadas na contagem

| Situação | Requests HTTP | Queries SQL/request |
|---|:---:|:---:|
| Antes (6 modelos) | 7 | ~19 |
| Depois | 2 | ~4 |

## Prints

### Antes 
<img width="1616" height="878" alt="image" src="https://github.com/user-attachments/assets/44d244e4-ad2c-47d5-a488-86bc5f30e999" />

### Depois

<img width="1575" height="821" alt="image" src="https://github.com/user-attachments/assets/618c2be6-6ef3-467d-87da-a04e44685a26" />

