### PR TITLE
Fix/registration radio options vertical

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -40,6 +40,7 @@ e este projeto adere ao [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 - Corrige a exportação de oportunidades para não incluir datas das fases de avaliação quando a opção de exportar datas das fases estiver desmarcada
 - Corrige o cálculo ponderado dos subtotais na tela de avaliação técnica
 - Corrige os templates de email da fase de recurso
+- Corrige a exibição das opções de campos de seleção no formato radio para organizá-las verticalmente na ficha de inscrição
 
 ## [7.7.51] - 2026-06-03
 ### Correções

--- a/src/modules/Entities/components/entity-field/template.php
+++ b/src/modules/Entities/components/entity-field/template.php
@@ -73,9 +73,11 @@ $this->import('
 
             <template v-else-if="is('select')">
                 <template v-if="description.registrationFieldConfiguration?.config?.viewMode === 'radio'">
-                    <label class="input__label input__radioLabel" v-for="(optionLabel, optionValue) in description.options">
-                        <input :checked="isRadioChecked(value, optionValue)" type="radio" :value="optionValue" @input="change($event,true)" @blur="change($event)" :disabled="readonly || disabled"> {{description.options[optionValue]}}
-                    </label>
+                    <div class="field__group">
+                        <label class="input__label input__radioLabel" v-for="(optionLabel, optionValue) in description.options">
+                            <input :checked="isRadioChecked(value, optionValue)" type="radio" :value="optionValue" @input="change($event,true)" @blur="change($event)" :disabled="readonly || disabled"> {{description.options[optionValue]}}
+                        </label>
+                    </div>
                 </template>
 
                 <select v-else :value="value" :id="propId" :name="prop" @input="change($event)" @blur="change($event,true)" :disabled="readonly || disabled">
@@ -294,4 +296,4 @@ $this->import('
     </small>
     <?php $this->applyTemplateHook('entity-field','end') ?>
 </div>
-<?php $this->applyTemplateHook('entity-field','after') ?>   
+<?php $this->applyTemplateHook('entity-field','after') ?>


### PR DESCRIPTION
## Descrição

Corrige a exibição das opções de campos de seleção configurados no formato radio na ficha de inscrição.

As opções eram exibidas lado a lado. Agora são organizadas verticalmente, mantendo uma opção por linha.

## Solução

Adicionado o contêiner `.field__group` ao campo `select` configurado com `viewMode: radio`, reutilizando o estilo vertical já aplicado aos campos radio nativos.

## Evidências

### Antes: opções lado a lado

<img width="751" height="252" alt="Captura de Tela 2026-06-09 às 00 33 59" src="https://github.com/user-attachments/assets/4c211046-8aea-4607-aafa-028769236460" />
