### PR TITLE
Corrige N+1 de escritas no banco ao gerar edital a partir do modelo

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -40,6 +40,7 @@ e este projeto adere ao [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 - Corrige a exportação de oportunidades para não incluir datas das fases de avaliação quando a opção de exportar datas das fases estiver desmarcada
 - Corrige o cálculo ponderado dos subtotais na tela de avaliação técnica
 - Corrige os templates de email da fase de recurso
+- Reduz o número de operações de escrita no banco durante a geração de edital a partir do modelo, acumulando escritas de fases, etapas, campos, arquivos e configurações de avaliação em lote e eliminando consultas N+1 na duplicação de formulários
 
 ## [7.7.51] - 2026-06-03
 ### Correções

--- a/src/core/Traits/EntityManagerModel.php
+++ b/src/core/Traits/EntityManagerModel.php
@@ -470,13 +470,14 @@ trait EntityManagerModel {
                 continue;
             }
 
-            $stepMap[$oldStep->id] = $existingSteps[$oldStep->id] ?? (function () use ($oldStep, $opportunityNew) {
+            $newStep = $existingSteps[$oldStep->id] ?? null;
+            if ($newStep === null) {
                 $newStep = clone $oldStep;
                 $newStep->setOpportunity($opportunityNew);
-                $newStep->save(true);
-
-                return $newStep;
-            })();
+            }
+            // save(false) acumula no UoW e já atribui ID via sequence (sem flush)
+            $newStep->save(false);
+            $stepMap[$oldStep->id] = $newStep;
         }
 
         foreach ($opportunityCurrent->getRegistrationFieldConfigurations() as $registrationFieldConfiguration) {
@@ -487,7 +488,7 @@ trait EntityManagerModel {
                 $fieldConfiguration->setStep($stepMap[$registrationFieldConfiguration->step->id]);
             }
 
-            $fieldConfiguration->save(true);
+            $fieldConfiguration->save(false);
         }
 
         foreach ($opportunityCurrent->getRegistrationFileConfigurations() as $registrationFileConfiguration) {
@@ -498,8 +499,11 @@ trait EntityManagerModel {
                 $fileConfiguration->setStep($stepMap[$registrationFileConfiguration->step->id]);
             }
 
-            $fileConfiguration->save(true);
+            $fileConfiguration->save(false);
         }
+
+        // Flush único para steps, campos e arquivos — substitui N saves(true) individuais
+        App::i()->em->flush();
 
         $this->deleteOrphanEmptyRegistrationSteps($opportunityNew, $stepMap);
     }
@@ -543,7 +547,7 @@ trait EntityManagerModel {
         $to->metadata = is_object($meta)
             ? json_decode(json_encode($meta), false) ?: new \stdClass()
             : new \stdClass();
-        $to->save(true);
+        $to->save(false);
     }
 
     /**

--- a/src/core/Traits/EntityManagerModel.php
+++ b/src/core/Traits/EntityManagerModel.php
@@ -425,16 +425,12 @@ trait EntityManagerModel {
         $em = $app->em;
         $conn = $em->getConnection();
 
-        $sql = "
-            SELECT 
-                om.*
-            FROM
-                opportunity_meta om
-            WHERE om.object_id = {$this->entityOpportunity->id}
-        ";
-        $stmt = $conn->query($sql);
+        $rows = $conn->fetchAllAssociative(
+            'SELECT om.* FROM opportunity_meta om WHERE om.object_id = :id',
+            ['id' => $this->entityOpportunity->id]
+        );
 
-        while (($row = $stmt->fetchAssociative()) !== false) {
+        foreach ($rows as $row) {
             $this->entityOpportunityModel->setMetadata($row['key'], $row['value']);
         }
 
@@ -540,15 +536,20 @@ trait EntityManagerModel {
             [$oppId]
         );
 
-        $steps = [];
-        foreach ($ids as $id) {
-            $step = $app->repo('RegistrationStep')->find((int) $id);
-            if ($step && (int) $step->opportunity->id === $oppId) {
-                $steps[] = $step;
-            }
+        if (empty($ids)) {
+            return [];
         }
 
-        return $steps;
+        // uma query IN(...) em vez de N queries find() individuais
+        $steps = $app->repo('RegistrationStep')->findBy(
+            ['id' => array_map('intval', $ids)],
+            ['displayOrder' => 'ASC', 'id' => 'ASC']
+        );
+
+        return array_values(array_filter(
+            $steps,
+            fn($step) => (int) $step->opportunity->id === $oppId
+        ));
     }
 
     private function copyRegistrationStepPropertiesFromTo(RegistrationStep $from, RegistrationStep $to): void

--- a/src/core/Traits/EntityManagerModel.php
+++ b/src/core/Traits/EntityManagerModel.php
@@ -309,13 +309,18 @@ trait EntityManagerModel {
         foreach ($evaluationMethodConfigurations as $evaluationMethodConfiguration) {
             $newMethodConfiguration = clone $evaluationMethodConfiguration;
             $newMethodConfiguration->setOpportunity($this->entityOpportunityModel);
-            $newMethodConfiguration->save(true);
 
-            // duplica os metadados das configurações do modelo de avaliação
             foreach ($evaluationMethodConfiguration->getMetadata() as $metadataKey => $metadataValue) {
                 $newMethodConfiguration->setMetadata($metadataKey, $metadataValue);
-                $newMethodConfiguration->save(true);
             }
+
+            // acumula config + todos os metadados no UoW sem flush individual
+            $newMethodConfiguration->save(false);
+        }
+
+        // flush único para todos os eval configs e seus metadados
+        if (!empty($evaluationMethodConfigurations)) {
+            $app->em->flush();
         }
     }
 
@@ -334,26 +339,29 @@ trait EntityManagerModel {
             'parent' => $this->entityOpportunity
         ]);
         foreach ($phases as $phase) {
-            
+
             if (!$phase->getMetadata('isLastPhase')) {
                 $newPhase = clone $phase;
                 $newPhase->setParent($this->entityOpportunityModel);
                 $newPhase->owner = $app->user->profile;
 
-                foreach ($phase->getMetadata() as $metadataKey => $metadataValue) {
-                    if (!is_null($metadataValue) && $metadataValue != '') {
-                        $newPhase->setMetadata($metadataKey, $metadataValue);
-                        $newPhase->save(true);
-                    }
-                }
-
-                $this->generateRegistrationFieldsAndFiles($phase, $newPhase);
-
                 $now = new \DateTime('now');
                 $newPhase->createTimestamp = $now;
                 $newPhase->subsite = $phase->subsite;
 
+                // cria a fase no banco primeiro para que insert:finish possa criar o step com FK válida
                 $newPhase->save(true);
+
+                // acumula todos os metadados na memória sem flush individual
+                foreach ($phase->getMetadata() as $metadataKey => $metadataValue) {
+                    if (!is_null($metadataValue) && $metadataValue != '') {
+                        $newPhase->setMetadata($metadataKey, $metadataValue);
+                    }
+                }
+                // persiste metadata no UoW; o flush ocorre dentro de generateRegistrationFieldsAndFiles
+                $newPhase->saveMetadata(false);
+
+                $this->generateRegistrationFieldsAndFiles($phase, $newPhase);
 
                 $this->changeObjectType($newPhase->id);
 
@@ -364,13 +372,17 @@ trait EntityManagerModel {
                 foreach ($evaluationMethodConfigurations as $evaluationMethodConfiguration) {
                     $newMethodConfiguration = clone $evaluationMethodConfiguration;
                     $newMethodConfiguration->setOpportunity($newPhase);
-                    $newMethodConfiguration->save(true);
 
-                    // duplica os metadados das configurações do modelo de avaliação para a fase
                     foreach ($evaluationMethodConfiguration->getMetadata() as $metadataKey => $metadataValue) {
                         $newMethodConfiguration->setMetadata($metadataKey, $metadataValue);
-                        $newMethodConfiguration->save(true);
                     }
+
+                    // acumula config + todos os metadados no UoW sem flush individual
+                    $newMethodConfiguration->save(false);
+                }
+
+                if (!empty($evaluationMethodConfigurations)) {
+                    $app->em->flush();
                 }
             }
             


### PR DESCRIPTION
# Corrige N+1 de escritas no banco ao gerar edital a partir do modelo

## Cenário

O fluxo **"usar modelo"** permite ao gestor salvar um edital como modelo e, posteriormente, criar novos editais a partir dele. Internamente, os endpoints `generatemodel` e `generateopportunity` do `EntityManagerModel` duplicam toda a estrutura: fases, etapas de formulário (`registration_step`), campos, anexos, configurações de avaliação e metadados.

## Problema

A implementação anterior realizava um `em->flush()` individual para cada entidade criada dentro dos loops de duplicação — o equivalente a uma transação separada por campo, por etapa e por metadado. Havia três focos independentes de desperdício.

**Em `generateRegistrationFieldsAndFiles`**, cada etapa, campo e arquivo de inscrição era salvo com `save(true)`, disparando um flush por entidade. Para um modelo com 4 etapas, 10 campos e 2 arquivos, isso significava **16 flushes** para copiar a estrutura de uma única fase.

**Em `generateEvaluationMethods` e no loop de metadados de `generatePhases`**, cada metadado da configuração de avaliação era persistido individualmente com `save(true)`. Com ~8 metadados por configuração, eram mais **8 flushes** adicionais.

**Em `findReusableRegistrationStepsWithoutFieldsOrFiles`**, o código carregava os IDs das etapas reaproveitáveis em uma query e depois entrava num loop chamando `$app->repo('RegistrationStep')->find($id)` para cada ID individualmente — um N+1 clássico. Com 4 etapas, eram **4 queries** onde bastaria 1.

Além disso, `generateMetadata` construía a SQL de leitura via concatenação de string, sem parâmetros vinculados.

## Solução

**`generateRegistrationFieldsAndFiles`:** todas as entidades (steps, campos, arquivos) passaram a usar `save(false)`, acumulando no Unit of Work do Doctrine. Um único `em->flush()` ao final persiste tudo de uma vez.

**`generateEvaluationMethods` e `generatePhases`:** os metadados de configuração de avaliação também passaram a acumular via `save(false)` / `saveMetadata(false)`, com um único `em->flush()` por bloco.

**`findReusableRegistrationStepsWithoutFieldsOrFiles`:** substituído o loop de `find()` por uma única chamada `findBy(['id' => $ids])`, resolvendo o N+1.

**`generateMetadata`:** a query SQL passou a usar parâmetros nomeados via PDO (`:id`), eliminando a concatenação direta.

| Operação | Antes (modelo com 4 etapas, 10 campos, 2 arquivos) | Depois |
|---|:---:|:---:|
| Flushes em `generateRegistrationFieldsAndFiles` | 16 | 1 |
| Flushes em `generateEvaluationMethods` (8 metadados) | 8 | 1 |
| Queries em `findReusableRegistrationSteps` (4 etapas) | 4 | 1 |
| SQL parametrizada em `generateMetadata` | ✗ | ✓ |
| **Total de operações DB por fase duplicada** | **~28** | **~3** |
