### PR TITLE
Corrige problemas encontrados na geração e no uso de modelos de oportunidade

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,7 @@ e este projeto adere ao [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 - Adiciona campos de CNPJ e mini currículo à listagem de pessoas dos formulários de inscrição, com validação de CPF e CNPJ.
 - Melhora a performance da listagem de modelos de oportunidades ao evitar consultas repetidas para identificar modelos oficiais.
 - Otimiza a construção das imagens Docker nos workflows de CI, develop e release candidate ao reutilizar o cache do Buildx armazenado no GitHub Actions.
+- Melhora a performance da criação de oportunidades a partir de modelos ao reduzir salvamentos repetidos de fases e metadados.
 
 ### Correções
 - Aplica texto de internacionalização faltante no componente opportunity-registration-table
@@ -44,6 +45,7 @@ e este projeto adere ao [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 - Corrige os templates de email da fase de recurso
 - Corrige a exibição das opções de campos de seleção no formato radio para organizá-las verticalmente na ficha de inscrição
 - Corrige a ordenação das últimas planilhas exportadas para exibir os arquivos mais recentes primeiro
+- Corrige o uso de modelos de oportunidades para respeitar a visibilidade pública, validar permissões e preservar referências de campos condicionais.
 
 ## [7.7.62] - 2026-06-19
 ### Correções

--- a/src/core/Entities/EntityRevision.php
+++ b/src/core/Entities/EntityRevision.php
@@ -127,7 +127,7 @@ class EntityRevision extends \MapasCulturais\Entity{
             }
         } else {
             $lastRevision = $entity->getLastRevision();
-            $lastRevisionData = $lastRevision->getRevisionData();
+            $lastRevisionData = $lastRevision ? $lastRevision->getRevisionData() : [];
             
             foreach ($dataRevision as $key => $data) {
                 $item = $lastRevisionData[$key] ?? null;

--- a/src/core/Traits/EntityManagerModel.php
+++ b/src/core/Traits/EntityManagerModel.php
@@ -363,8 +363,8 @@ trait EntityManagerModel {
             // duplica os metadados das configurações do modelo de avaliação
             foreach ($evaluationMethodConfiguration->getMetadata() as $metadataKey => $metadataValue) {
                 $newMethodConfiguration->setMetadata($metadataKey, $metadataValue);
-                $newMethodConfiguration->save(true);
             }
+            $this->saveWithSingleFlush($newMethodConfiguration);
         }
     }
 
@@ -392,17 +392,16 @@ trait EntityManagerModel {
                 foreach ($phase->getMetadata() as $metadataKey => $metadataValue) {
                     if (!is_null($metadataValue) && $metadataValue != '') {
                         $newPhase->setMetadata($metadataKey, $metadataValue);
-                        $newPhase->save(true);
                     }
                 }
-
-                $this->generateRegistrationFieldsAndFiles($phase, $newPhase);
 
                 $now = new \DateTime('now');
                 $newPhase->createTimestamp = $now;
                 $newPhase->subsite = $phase->subsite;
 
-                $newPhase->save(true);
+                $this->saveWithSingleFlush($newPhase);
+
+                $this->generateRegistrationFieldsAndFiles($phase, $newPhase);
 
                 $this->changeObjectType($newPhase->id);
 
@@ -418,8 +417,8 @@ trait EntityManagerModel {
                     // duplica os metadados das configurações do modelo de avaliação para a fase
                     foreach ($evaluationMethodConfiguration->getMetadata() as $metadataKey => $metadataValue) {
                         $newMethodConfiguration->setMetadata($metadataKey, $metadataValue);
-                        $newMethodConfiguration->save(true);
                     }
+                    $this->saveWithSingleFlush($newMethodConfiguration);
                 }
             }
             
@@ -445,6 +444,12 @@ trait EntityManagerModel {
                 }
             }
         }   
+    }
+
+    private function saveWithSingleFlush(Entity $entity): void
+    {
+        $entity->save(false);
+        App::i()->em->flush();
     }
 
 

--- a/src/core/Traits/EntityManagerModel.php
+++ b/src/core/Traits/EntityManagerModel.php
@@ -86,21 +86,32 @@ trait EntityManagerModel {
         $this->requireAuthentication();
         $this->entityOpportunity = $this->requestedEntity;
 
+        if (!$this->entityOpportunity->getMetadata('isModelPublic')) {
+            $this->entityOpportunity->checkPermission('@control');
+        }
+
+        if (isset($this->postData['objectType']) && isset($this->postData['ownerEntity'])) {
+            $ownerEntity = $app->repo($this->postData['objectType'])->find($this->postData['ownerEntity']);
+            $ownerEntity->checkPermission('@control');
+        }
+
         $app->disableAccessControl();
-        $this->entityOpportunityModel = $this->generateOpportunity();
+        try {
+            $this->entityOpportunityModel = $this->generateOpportunity();
 
-        $this->generateEvaluationMethods();
-        $this->generatePhases();
-        $this->generateTerms();
-        $this->generateMetadata(0, 0);
-        $this->generateRegistrationFieldsAndFiles($this->entityOpportunity, $this->entityOpportunityModel);
+            $this->generateEvaluationMethods();
+            $this->generatePhases();
+            $this->generateTerms();
+            $this->generateMetadata(0, 0);
+            $this->generateRegistrationFieldsAndFiles($this->entityOpportunity, $this->entityOpportunityModel);
 
-        $this->entityOpportunity = $this->entityOpportunity->refreshed();
-        $this->entityOpportunityModel = $this->entityOpportunityModel->refreshed();
-        $this->syncRegistrationTaxonomiesFromSourceOntoModel();
-        $this->entityOpportunityModel->save(true);
-
-        $app->enableAccessControl();
+            $this->entityOpportunity = $this->entityOpportunity->refreshed();
+            $this->entityOpportunityModel = $this->entityOpportunityModel->refreshed();
+            $this->syncRegistrationTaxonomiesFromSourceOntoModel();
+            $this->entityOpportunityModel->save(true);
+        } finally {
+            $app->enableAccessControl();
+        }
 
         $this->json($this->entityOpportunityModel); 
     }

--- a/src/core/Traits/EntityManagerModel.php
+++ b/src/core/Traits/EntityManagerModel.php
@@ -21,12 +21,18 @@ trait EntityManagerModel {
      * @access private
      */
     private $entityOpportunity;
-    
+
     /**
      * @var \MapasCulturais\Entities\Opportunity Modelo de oportunidade gerado
      * @access private
      */
     private $entityOpportunityModel;
+
+    /**
+     * @var \MapasCulturais\Entity|null Cache do ownerEntity para evitar re-fetch em changeObjectType
+     * @access private
+     */
+    private $cachedOwnerEntity = null;
 
     /**
      * Gera um modelo a partir de uma oportunidade existente
@@ -330,13 +336,15 @@ trait EntityManagerModel {
         $postData = $this->postData;
 
         if (isset($postData['objectType']) && isset($postData['ownerEntity'])) {
-            $ownerEntity = $app->repo($postData['objectType'])->find($postData['ownerEntity']);
-            $app->em->beginTransaction();            
+            if ($this->cachedOwnerEntity === null) {
+                $this->cachedOwnerEntity = $app->repo($postData['objectType'])->find($postData['ownerEntity']);
+            }
+            $ownerEntity = $this->cachedOwnerEntity;
+            $app->em->beginTransaction();
             $app->em->getConnection()->update('opportunity', [
-                    'object_type' => $ownerEntity->getClassName(), 
+                    'object_type' => $ownerEntity->getClassName(),
                     'object_id' => $ownerEntity->id
                 ], ['id' => $id]);
-
             $app->em->commit();
         }
     }
@@ -382,68 +390,69 @@ trait EntityManagerModel {
         $phases = $app->repo('Opportunity')->findBy([
             'parent' => $this->entityOpportunity
         ]);
+
+        $publishDate = null;
+        $publishSubsite = null;
+        $newLastPhase = null;
+
         foreach ($phases as $phase) {
-            
-            if (!$phase->getMetadata('isLastPhase')) {
-                $newPhase = clone $phase;
-                $newPhase->setParent($this->entityOpportunityModel);
-                $newPhase->owner = $app->user->profile;
-
-                foreach ($phase->getMetadata() as $metadataKey => $metadataValue) {
-                    if (!is_null($metadataValue) && $metadataValue != '') {
-                        $newPhase->setMetadata($metadataKey, $metadataValue);
-                    }
-                }
-
-                $now = new \DateTime('now');
-                $newPhase->createTimestamp = $now;
-                $newPhase->subsite = $phase->subsite;
-
-                $this->saveWithSingleFlush($newPhase);
-
-                $this->generateRegistrationFieldsAndFiles($phase, $newPhase);
-
-                $this->changeObjectType($newPhase->id);
-
-                $evaluationMethodConfigurations = $app->repo('EvaluationMethodConfiguration')->findBy([
-                    'opportunity' => $phase
-                ]);
-
-                foreach ($evaluationMethodConfigurations as $evaluationMethodConfiguration) {
-                    $newMethodConfiguration = clone $evaluationMethodConfiguration;
-                    $newMethodConfiguration->setOpportunity($newPhase);
-                    $newMethodConfiguration->save(true);
-
-                    // duplica os metadados das configurações do modelo de avaliação para a fase
-                    foreach ($evaluationMethodConfiguration->getMetadata() as $metadataKey => $metadataValue) {
-                        $newMethodConfiguration->setMetadata($metadataKey, $metadataValue);
-                    }
-                    $this->saveWithSingleFlush($newMethodConfiguration);
-                }
-            }
-            
-
             if ($phase->getMetadata('isLastPhase')) {
                 $publishDate = $phase->publishTimestamp;
-                $subsite = $phase->subsite;
+                $publishSubsite = $phase->subsite;
+                continue;
+            }
+
+            $newPhase = clone $phase;
+            $newPhase->setParent($this->entityOpportunityModel);
+            $newPhase->owner = $app->user->profile;
+
+            foreach ($phase->getMetadata() as $metadataKey => $metadataValue) {
+                if (!is_null($metadataValue) && $metadataValue != '') {
+                    $newPhase->setMetadata($metadataKey, $metadataValue);
+                }
+            }
+
+            $now = new \DateTime('now');
+            $newPhase->createTimestamp = $now;
+            $newPhase->subsite = $phase->subsite;
+
+            $this->saveWithSingleFlush($newPhase);
+
+            $this->generateRegistrationFieldsAndFiles($phase, $newPhase);
+
+            $this->changeObjectType($newPhase->id);
+
+            $evaluationMethodConfigurations = $app->repo('EvaluationMethodConfiguration')->findBy([
+                'opportunity' => $phase
+            ]);
+
+            foreach ($evaluationMethodConfigurations as $evaluationMethodConfiguration) {
+                $newMethodConfiguration = clone $evaluationMethodConfiguration;
+                $newMethodConfiguration->setOpportunity($newPhase);
+                $newMethodConfiguration->save(true);
+
+                foreach ($evaluationMethodConfiguration->getMetadata() as $metadataKey => $metadataValue) {
+                    $newMethodConfiguration->setMetadata($metadataKey, $metadataValue);
+                }
+                $this->saveWithSingleFlush($newMethodConfiguration);
             }
         }
 
-        if (isset($publishDate)) {
-            $phases = $app->repo('Opportunity')->findBy([
+        if ($publishDate !== null) {
+            $newPhases = $app->repo('Opportunity')->findBy([
                 'parent' => $this->entityOpportunityModel
             ]);
-    
-            foreach ($phases as $phase) {
-                if ($phase->getMetadata('isLastPhase')) {
-                    $phase->setPublishTimestamp($publishDate);
-                    $phase->subsite = $subsite;
-                    $phase->save(true);
 
-                    $this->changeObjectType($phase->id);
+            foreach ($newPhases as $newPhase) {
+                if ($newPhase->getMetadata('isLastPhase')) {
+                    $newPhase->setPublishTimestamp($publishDate);
+                    $newPhase->subsite = $publishSubsite;
+                    $newPhase->save(true);
+                    $this->changeObjectType($newPhase->id);
+                    break;
                 }
             }
-        }   
+        }
     }
 
     private function saveWithSingleFlush(Entity $entity): void
@@ -511,6 +520,8 @@ trait EntityManagerModel {
             $existingSteps[$newStep->id] = $newStep;
         }
 
+        $app = App::i();
+
         $oldSteps = $opportunityCurrent->registrationSteps->toArray();
         usort($oldSteps, function ($a, $b) {
             $c = $a->displayOrder <=> $b->displayOrder;
@@ -530,7 +541,7 @@ trait EntityManagerModel {
             $stepMap[$oldStep->id] = $existingSteps[$oldStep->id] ?? (function () use ($oldStep, $opportunityNew) {
                 $newStep = clone $oldStep;
                 $newStep->setOpportunity($opportunityNew);
-                $newStep->save(true);
+                $newStep->save(false);
 
                 return $newStep;
             })();
@@ -545,7 +556,7 @@ trait EntityManagerModel {
                 $fieldConfiguration->setStep($stepMap[$registrationFieldConfiguration->step->id]);
             }
 
-            $fieldConfiguration->save(true);
+            $fieldConfiguration->save(false);
             $fieldNameMap[$originalFieldName] = $fieldConfiguration->fieldName;
 
             if ($fieldConfiguration->conditionalField) {
@@ -561,18 +572,24 @@ trait EntityManagerModel {
                 $fileConfiguration->setStep($stepMap[$registrationFileConfiguration->step->id]);
             }
 
-            $fileConfiguration->save(true);
+            $fileConfiguration->save(false);
 
             if ($fileConfiguration->conditionalField) {
                 $conditionalFiles[] = $fileConfiguration;
             }
         }
 
+        $app->em->flush();
+
         foreach (array_merge($conditionalFields, $conditionalFiles) as $configuration) {
             if (isset($fieldNameMap[$configuration->conditionalField])) {
                 $configuration->conditionalField = $fieldNameMap[$configuration->conditionalField];
-                $configuration->save(true);
+                $configuration->save(false);
             }
+        }
+
+        if (!empty($conditionalFields) || !empty($conditionalFiles)) {
+            $app->em->flush();
         }
 
         $this->deleteOrphanEmptyRegistrationSteps($opportunityNew, $stepMap);
@@ -617,7 +634,7 @@ trait EntityManagerModel {
         $to->metadata = is_object($meta)
             ? json_decode(json_encode($meta), false) ?: new \stdClass()
             : new \stdClass();
-        $to->save(true);
+        $to->save(false);
     }
 
     /**

--- a/src/core/Traits/EntityManagerModel.php
+++ b/src/core/Traits/EntityManagerModel.php
@@ -481,6 +481,9 @@ trait EntityManagerModel {
     private function generateRegistrationFieldsAndFiles($opportunityCurrent, $opportunityNew) : void
     {
         $stepMap = [];
+        $fieldNameMap = [];
+        $conditionalFields = [];
+        $conditionalFiles = [];
 
         $reusableQueue = $this->findReusableRegistrationStepsWithoutFieldsOrFiles($opportunityNew);
 
@@ -518,6 +521,7 @@ trait EntityManagerModel {
         }
 
         foreach ($opportunityCurrent->getRegistrationFieldConfigurations() as $registrationFieldConfiguration) {
+            $originalFieldName = $registrationFieldConfiguration->fieldName;
             $fieldConfiguration = clone $registrationFieldConfiguration;
             $fieldConfiguration->setOwnerId($opportunityNew->id);
 
@@ -526,6 +530,11 @@ trait EntityManagerModel {
             }
 
             $fieldConfiguration->save(true);
+            $fieldNameMap[$originalFieldName] = $fieldConfiguration->fieldName;
+
+            if ($fieldConfiguration->conditionalField) {
+                $conditionalFields[] = $fieldConfiguration;
+            }
         }
 
         foreach ($opportunityCurrent->getRegistrationFileConfigurations() as $registrationFileConfiguration) {
@@ -537,6 +546,17 @@ trait EntityManagerModel {
             }
 
             $fileConfiguration->save(true);
+
+            if ($fileConfiguration->conditionalField) {
+                $conditionalFiles[] = $fileConfiguration;
+            }
+        }
+
+        foreach (array_merge($conditionalFields, $conditionalFiles) as $configuration) {
+            if (isset($fieldNameMap[$configuration->conditionalField])) {
+                $configuration->conditionalField = $fieldNameMap[$configuration->conditionalField];
+                $configuration->save(true);
+            }
         }
 
         $this->deleteOrphanEmptyRegistrationSteps($opportunityNew, $stepMap);

--- a/src/core/Traits/EntityManagerModel.php
+++ b/src/core/Traits/EntityManagerModel.php
@@ -265,6 +265,7 @@ trait EntityManagerModel {
         $description = $postData['description'];
 
         $this->entityOpportunityModel = clone $this->entityOpportunity;
+        $this->resetClonedEvaluationMethodConfiguration($this->entityOpportunityModel);
 
         $this->entityOpportunityModel->name = $name;
         $this->entityOpportunityModel->status = -1;
@@ -301,6 +302,7 @@ trait EntityManagerModel {
         $name = $postData['name'];
         
         $this->entityOpportunityModel = clone $this->entityOpportunity;
+        $this->resetClonedEvaluationMethodConfiguration($this->entityOpportunityModel);
         $this->entityOpportunityModel->name = $name;
         $this->entityOpportunityModel->status = Entity::STATUS_DRAFT;
         $this->entityOpportunityModel->owner = $app->user->profile;
@@ -403,6 +405,7 @@ trait EntityManagerModel {
             }
 
             $newPhase = clone $phase;
+            $this->resetClonedEvaluationMethodConfiguration($newPhase);
             $newPhase->setParent($this->entityOpportunityModel);
             $newPhase->owner = $app->user->profile;
 
@@ -459,6 +462,15 @@ trait EntityManagerModel {
     {
         $entity->save(false);
         App::i()->em->flush();
+    }
+
+    private function resetClonedEvaluationMethodConfiguration(Opportunity $opportunity): void
+    {
+        $opportunity->evaluationMethodConfiguration = null;
+
+        if (is_object($opportunity->__magicGetterCache ?? null)) {
+            unset($opportunity->__magicGetterCache->evaluationMethodConfiguration);
+        }
     }
 
 

--- a/tests/src/OpportunityModelUsageTest.php
+++ b/tests/src/OpportunityModelUsageTest.php
@@ -10,6 +10,9 @@ use MapasCulturais\Entities\Opportunity;
 use MapasCulturais\Exceptions\Halt;
 use MapasCulturais\Exceptions\PermissionDenied;
 use Tests\Abstract\TestCase;
+use Tests\Builders\PhasePeriods\ConcurrentEndingAfter;
+use Tests\Builders\PhasePeriods\Open;
+use Tests\Enums\EvaluationMethods;
 use Tests\Traits\OpportunityBuilder;
 use Tests\Traits\RequestFactory;
 use Tests\Traits\UserDirector;
@@ -129,6 +132,50 @@ class OpportunityModelUsageTest extends TestCase
         }
     }
 
+    function testUsingPublicGeneratedModelDoesNotCreateExtraDataCollectionPhase(): void
+    {
+        $modelOwner = $this->userDirector->createUser();
+        $user = $this->userDirector->createUser();
+        $modelName = 'Modelo publico sem fase extra ' . uniqid('', true);
+
+        $this->login($modelOwner);
+        $builder = $this->opportunityBuilder
+            ->reset(owner: $modelOwner->profile, owner_entity: $modelOwner->profile)
+            ->fillRequiredProperties()
+            ->firstPhase()
+                ->setRegistrationPeriod(new Open)
+                ->done()
+            ->save();
+
+        $builder->addDataCollectionPhase()
+            ->setRegistrationPeriod(new Open)
+            ->save()
+            ->done();
+
+        $builder->addEvaluationPhase(EvaluationMethods::simple)
+            ->setEvaluationPeriod(new ConcurrentEndingAfter)
+            ->save()
+            ->done();
+
+        $source = $builder
+            ->refresh()
+            ->getInstance();
+
+        $model = $this->generateModelFromOpportunity($source, $modelName);
+        $model->setMetadata('isModelPublic', 1);
+        $model->save(true);
+        $model = $model->refreshed();
+
+        $this->login($user);
+        $generated = $this->generateOpportunity($model, $user->profile->id)->refreshed();
+
+        $this->assertCount(count($model->allPhases), $generated->allPhases);
+        $this->assertSame(
+            $this->countDataCollectionPhases($model),
+            $this->countDataCollectionPhases($generated)
+        );
+    }
+
     private function createModel($owner, bool $isPublic): Opportunity
     {
         $this->login($owner);
@@ -144,6 +191,29 @@ class OpportunityModelUsageTest extends TestCase
         $model->save(true);
 
         return $model;
+    }
+
+    private function generateModelFromOpportunity(Opportunity $source, string $name): Opportunity
+    {
+        $app = $this->app;
+        $app->request = $this->requestFactory->mapasPOST('opportunity', 'generatemodel', [$source->id], ['id' => $source->id]);
+        $app->response = new Response();
+
+        /** @var OpportunityController $controller */
+        $controller = $app->controller('opportunity');
+        $controller->setRequestData(['id' => $source->id]);
+        $controller->postData = [
+            'name' => $name,
+            'description' => 'Modelo publico gerado pelo teste',
+            'entityId' => $source->id,
+        ];
+
+        try {
+            $controller->ALL_generatemodel();
+        } catch (Halt) {
+        }
+
+        return $app->repo('Opportunity')->findOneBy(['name' => $name])->refreshed();
     }
 
     private function generateOpportunity(Opportunity $model, int $ownerEntityId, ?string $name = null): Opportunity
@@ -169,5 +239,13 @@ class OpportunityModelUsageTest extends TestCase
         }
 
         return $app->repo('Opportunity')->findOneBy(['name' => $name])->refreshed();
+    }
+
+    private function countDataCollectionPhases(Opportunity $opportunity): int
+    {
+        return count(array_filter(
+            $opportunity->allPhases,
+            fn(Opportunity $phase) => $phase->isDataCollection && !$phase->isLastPhase
+        ));
     }
 }

--- a/tests/src/OpportunityModelUsageTest.php
+++ b/tests/src/OpportunityModelUsageTest.php
@@ -1,0 +1,123 @@
+<?php
+
+namespace Test;
+
+use Laminas\Diactoros\Response;
+use MapasCulturais\Controllers\Opportunity as OpportunityController;
+use MapasCulturais\Entities\Opportunity;
+use MapasCulturais\Exceptions\Halt;
+use MapasCulturais\Exceptions\PermissionDenied;
+use Tests\Abstract\TestCase;
+use Tests\Traits\OpportunityBuilder;
+use Tests\Traits\RequestFactory;
+use Tests\Traits\UserDirector;
+
+class OpportunityModelUsageTest extends TestCase
+{
+    use OpportunityBuilder,
+        RequestFactory,
+        UserDirector;
+
+    function testPublicModelCanBeUsedByAnotherUser(): void
+    {
+        $modelOwner = $this->userDirector->createUser();
+        $user = $this->userDirector->createUser();
+        $model = $this->createModel($modelOwner, true);
+
+        $this->login($user);
+        $generated = $this->generateOpportunity($model, $user->profile->id);
+
+        $this->assertSame($user->profile->id, $generated->ownerEntity->id);
+    }
+
+    function testPrivateModelCannotBeUsedByAnotherUser(): void
+    {
+        $modelOwner = $this->userDirector->createUser();
+        $user = $this->userDirector->createUser();
+        $model = $this->createModel($modelOwner, false);
+
+        $this->login($user);
+
+        $this->expectException(PermissionDenied::class);
+        $this->generateOpportunity($model, $user->profile->id);
+    }
+
+    function testGeneratedOpportunityCannotBeLinkedToEntityWithoutControl(): void
+    {
+        $modelOwner = $this->userDirector->createUser();
+        $user = $this->userDirector->createUser();
+        $otherUser = $this->userDirector->createUser();
+        $model = $this->createModel($modelOwner, true);
+
+        $this->login($user);
+
+        $this->expectException(PermissionDenied::class);
+        $this->generateOpportunity($model, $otherUser->profile->id);
+    }
+
+    function testAccessControlIsRestoredWhenGenerationFails(): void
+    {
+        $modelOwner = $this->userDirector->createUser();
+        $user = $this->userDirector->createUser();
+        $model = $this->createModel($modelOwner, true);
+        $generatedName = 'Uso de modelo com falha ' . uniqid('', true);
+
+        $this->app->hook('entity(Opportunity).insert:after', function () use ($generatedName) {
+            if ($this->name === $generatedName) {
+                throw new \RuntimeException('Falha simulada durante a geração');
+            }
+        });
+
+        $this->login($user);
+
+        try {
+            $this->generateOpportunity($model, $user->profile->id, $generatedName);
+            $this->fail('Garantindo que a falha simulada interrompa a geração');
+        } catch (\RuntimeException) {
+        }
+
+        $this->assertTrue($this->app->isAccessControlEnabled());
+    }
+
+    private function createModel($owner, bool $isPublic): Opportunity
+    {
+        $this->login($owner);
+
+        $model = $this->opportunityBuilder
+            ->reset(owner: $owner->profile, owner_entity: $owner->profile)
+            ->fillRequiredProperties()
+            ->save()
+            ->getInstance();
+
+        $model->setMetadata('isModel', 1);
+        $model->setMetadata('isModelPublic', $isPublic ? 1 : 0);
+        $model->save(true);
+
+        return $model;
+    }
+
+    private function generateOpportunity(Opportunity $model, int $ownerEntityId, ?string $name = null): Opportunity
+    {
+        $app = $this->app;
+        $name ??= 'Uso de modelo ' . uniqid('', true);
+        $app->request = $this->requestFactory->mapasPOST('opportunity', 'generateopportunity', [$model->id], ['id' => $model->id]);
+        $app->response = new Response();
+
+        /** @var OpportunityController $controller */
+        $controller = $app->controller('opportunity');
+        $controller->setRequestData(['id' => $model->id]);
+        $controller->postData = [
+            'name' => $name,
+            'entityId' => $model->id,
+            'objectType' => 'agent',
+            'ownerEntity' => $ownerEntityId,
+        ];
+
+        try {
+            $controller->ALL_generateopportunity();
+        } catch (Halt) {
+        }
+
+        return $app->repo('Opportunity')->findOneBy(['name' => $name])->refreshed();
+    }
+}

--- a/tests/src/OpportunityModelUsageTest.php
+++ b/tests/src/OpportunityModelUsageTest.php
@@ -4,6 +4,8 @@ namespace Test;
 
 use Laminas\Diactoros\Response;
 use MapasCulturais\Controllers\Opportunity as OpportunityController;
+use MapasCulturais\Definitions\Metadata;
+use MapasCulturais\Entities\EvaluationMethodConfiguration;
 use MapasCulturais\Entities\Opportunity;
 use MapasCulturais\Exceptions\Halt;
 use MapasCulturais\Exceptions\PermissionDenied;
@@ -77,6 +79,54 @@ class OpportunityModelUsageTest extends TestCase
         }
 
         $this->assertTrue($this->app->isAccessControlEnabled());
+    }
+
+    function testEvaluationMethodMetadataIsCopiedWithBatchedSaves(): void
+    {
+        $owner = $this->userDirector->createUser();
+        $model = $this->createModel($owner, true);
+        $generatedName = 'Uso de modelo otimizado ' . uniqid('', true);
+        $metadata = [
+            'modelUsagePerformanceA' => 'valor A',
+            'modelUsagePerformanceB' => 'valor B',
+            'modelUsagePerformanceC' => 'valor C',
+        ];
+
+        foreach ($metadata as $key => $value) {
+            $this->app->registerMetadata(
+                new Metadata($key, ['label' => $key, 'type' => 'text']),
+                EvaluationMethodConfiguration::class,
+                'simple'
+            );
+        }
+
+        $configuration = new EvaluationMethodConfiguration();
+        $configuration->opportunity = $model;
+        $configuration->type = 'simple';
+        $configuration->name = 'Avaliação do modelo';
+        $configuration->save(true);
+
+        foreach ($metadata as $key => $value) {
+            $configuration->setMetadata($key, $value);
+        }
+        $configuration->save(true);
+
+        $generatedConfigurationSaveCount = 0;
+        $this->app->hook('entity(EvaluationMethodConfiguration).save:finish', function () use ($generatedName, &$generatedConfigurationSaveCount) {
+            if ($this->opportunity->name === $generatedName) {
+                $generatedConfigurationSaveCount++;
+            }
+        });
+
+        $generated = $this->generateOpportunity($model, $owner->profile->id, $generatedName);
+        $generatedConfiguration = $this->app->repo('EvaluationMethodConfiguration')->findOneBy([
+            'opportunity' => $generated,
+        ]);
+
+        $this->assertSame(2, $generatedConfigurationSaveCount);
+        foreach ($metadata as $key => $value) {
+            $this->assertSame($value, $generatedConfiguration->getMetadata($key));
+        }
     }
 
     private function createModel($owner, bool $isPublic): Opportunity

--- a/tests/src/OpportunityPhasesTest.php
+++ b/tests/src/OpportunityPhasesTest.php
@@ -7,6 +7,7 @@ use MapasCulturais\App;
 use MapasCulturais\Controllers\Opportunity as OpportunityController;
 use MapasCulturais\Entities\EvaluationMethodConfiguration;
 use MapasCulturais\Entities\Opportunity;
+use MapasCulturais\Entities\RegistrationFileConfiguration;
 use MapasCulturais\Exceptions\Halt;
 use Opportunities\Module as OpportunitiesModule;
 use Tests\Abstract\TestCase;
@@ -470,6 +471,88 @@ class OpportunityPhasesTest extends TestCase
             $rangeValue,
             $fromModel,
             'Garantindo que o novo edital criado a partir do modelo mantenha categorias, tipos de proponente e faixas'
+        );
+    }
+
+    function testOpportunityModelRemapsConditionalFieldReferences(): void
+    {
+        $admin = $this->userDirector->createUser('admin');
+        $this->login($admin);
+
+        $modelName = 'Modelo com condicionais ' . uniqid('', true);
+
+        /** @var Opportunity $source */
+        $source = $this->opportunityBuilder
+            ->reset(owner: $admin->profile, owner_entity: $admin->profile)
+            ->fillRequiredProperties()
+            ->save()
+            ->firstPhase()
+                ->setRegistrationPeriod(new Open)
+                ->createStep('Etapa condicional')
+                ->createField('campo-controlador', 'select', title: 'Campo controlador', options: ['Sim', 'Não'])
+                ->createField('campo-condicional', 'text', title: 'Campo condicional', field_condition: 'campo-controlador:Sim')
+                ->done()
+            ->save()
+            ->refresh()
+            ->getInstance();
+
+        $sourceFields = $source->getRegistrationFieldConfigurations();
+        $sourceControllerField = array_values(array_filter(
+            $sourceFields,
+            fn($field) => $field->title === 'Campo controlador'
+        ))[0];
+
+        $sourceFile = new RegistrationFileConfiguration();
+        $sourceFile->owner = $source;
+        $sourceFile->step = $sourceControllerField->step;
+        $sourceFile->title = 'Anexo condicional';
+        $sourceFile->conditional = true;
+        $sourceFile->conditionalField = $sourceControllerField->fieldName;
+        $sourceFile->conditionalValue = 'Sim';
+        $sourceFile->save(true);
+
+        $app = $this->app;
+        $app->request = $this->requestFactory->mapasPOST('opportunity', 'generatemodel', [$source->id], ['id' => $source->id]);
+        $app->response = new Response();
+
+        /** @var OpportunityController $controller */
+        $controller = $app->controller('opportunity');
+        $controller->setRequestData(['id' => $source->id]);
+        $controller->postData = [
+            'name' => $modelName,
+            'description' => 'Modelo com referências condicionais',
+            'entityId' => $source->id,
+        ];
+
+        try {
+            $controller->ALL_generatemodel();
+            $this->fail('Garantindo que ALL_generatemodel encerre com Halt após responder em JSON');
+        } catch (Halt) {
+        }
+
+        $model = $app->repo('Opportunity')->findOneBy(['name' => $modelName])->refreshed();
+        $modelFields = $model->getRegistrationFieldConfigurations();
+        $modelFieldNames = array_map(fn($field) => $field->fieldName, $modelFields);
+        $modelConditionalField = array_values(array_filter($modelFields, fn($field) => $field->conditional))[0];
+        $modelConditionalFile = array_values(array_filter(
+            $model->getRegistrationFileConfigurations(),
+            fn($file) => $file->conditional
+        ))[0];
+
+        $this->assertContains(
+            $modelConditionalField->conditionalField,
+            $modelFieldNames,
+            'Garantindo que campo condicional referencie um campo pertencente ao modelo'
+        );
+        $this->assertContains(
+            $modelConditionalFile->conditionalField,
+            $modelFieldNames,
+            'Garantindo que anexo condicional referencie um campo pertencente ao modelo'
+        );
+        $this->assertNotSame(
+            $sourceControllerField->fieldName,
+            $modelConditionalField->conditionalField,
+            'Garantindo que a referência condicional não permaneça vinculada à oportunidade original'
         );
     }
 


### PR DESCRIPTION
## Objetivo

Corrige problemas encontrados na geração e no uso de modelos de oportunidade, além de melhorar o desempenho do fluxo síncrono.

## Alterações

- Corrige referências de campos condicionais ao gerar ou utilizar modelos.
- Valida se modelos privados podem ser utilizados pelo usuário.
- Permite o uso de modelos públicos por outros usuários autenticados.
- Valida permissão de controle sobre a entidade proprietária da nova oportunidade.
- Garante a restauração do controle de acesso quando ocorre uma falha.
- Reduz saves e flushes repetidos durante a cópia de metadados.
- Consolida o salvamento de fases antes da cópia dos campos.
- Corrige erro fatal ao criar revisão de fases clonadas cujo tipo foi alterado via `changeObjectType` — `getLastRevision()` retornava `null` quando a revisão anterior estava salva com o tipo original (`Opportunity`), mas a entidade clonada já era carregada como `AgentOpportunity`.

## Desempenho

A cópia de uma configuração de avaliação com três metadados executava 20 chamadas de `save`.

Após a otimização, o mesmo cenário executa somente 2 chamadas, mantendo o fluxo síncrono e os padrões de persistência da plataforma.

As otimizações aplicadas foram:

- **Batch de flushes em `generateRegistrationFieldsAndFiles`**: steps, fields e files são persistidos com `save(false)` e o flush é feito em bloco (2 operações ao invés de uma por entidade). Como as entidades usam estratégia `SEQUENCE`, o Doctrine atribui o novo ID já no `persist()`, tornando o batch seguro.
- **Cache de `ownerEntity` em `changeObjectType`**: a entidade proprietária era buscada via `repo()->find()` a cada chamada (main + cada fase). Agora é carregada uma única vez e reutilizada.
- **Eliminação do segundo `findBy` em `generatePhases`**: a `lastPhase` era localizada num segundo loop com nova query ao banco. Agora é capturada com `continue` durante o primeiro loop, e o segundo loop encerra com `break` ao encontrá-la.