### PR TITLE
Fix/panel evaluations appeal phases

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,10 @@ Todas as mudanças notáveis no projeto serão documentadas neste arquivo.
 O formato é baseado no [Keep a Changelog](https://keepachangelog.com/pt-BR/1.0.0/)
 e este projeto adere ao [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [UNRELEASED]
+### Correções
+- Corrige a listagem de avaliações para exibir fases de recurso na tela Minhas avaliações
+
 ## [7.7.55] - 2026-06-12
 ### Melhorias
 - Valida integridade entre seções e critérios de avaliação no backend, impedindo salvamento de critérios órfãos ou com campos obrigatórios vazios

--- a/src/modules/Opportunities/components/panel--evaluations-tabs/script.js
+++ b/src/modules/Opportunities/components/panel--evaluations-tabs/script.js
@@ -17,7 +17,7 @@ app.component('panel--evaluations-tabs', {
     data() {
         let query = {
             '@permissions': 'evaluateRegistrations',
-            'status': 'IN(1,-1)',
+            'status': 'IN(1,-1,-20)',
             'isReportingPhase': this.isReportingPhase ? `EQ(1)` : 'OR(EQ(0),NULL())',
         };
 

--- a/tests/src/PanelEvaluationsComponentTest.php
+++ b/tests/src/PanelEvaluationsComponentTest.php
@@ -1,0 +1,23 @@
+<?php
+
+namespace Test;
+
+use Tests\Abstract\TestCase;
+
+class PanelEvaluationsComponentTest extends TestCase
+{
+    function testEvaluationsQueryIncludesAppealPhases(): void
+    {
+        $sourceRoot = realpath(__DIR__ . '/../../src') ?: realpath(__DIR__ . '/../src');
+
+        $component = file_get_contents(
+            $sourceRoot . '/modules/Opportunities/components/panel--evaluations-tabs/script.js'
+        );
+
+        $this->assertStringContainsString(
+            "'status': 'IN(1,-1,-20)'",
+            $component,
+            'A listagem de avaliações deve incluir fases de recurso'
+        );
+    }
+}


### PR DESCRIPTION
## Descrição

Corrige a tela **Minhas avaliações** para exibir avaliações pertencentes às fases de recurso.

As fases de recurso possuem status `-20`, mas a listagem considerava apenas oportunidades com status `1` e `-1`.
