### PR TITLE
Corrige a ordenação da lista de “Últimas exportações” no componente de exportação de planilhas

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -42,6 +42,7 @@ e este projeto adere ao [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 - Corrige o cálculo ponderado dos subtotais na tela de avaliação técnica
 - Corrige os templates de email da fase de recurso
 - Corrige a exibição das opções de campos de seleção no formato radio para organizá-las verticalmente na ficha de inscrição
+- Corrige a ordenação das últimas planilhas exportadas para exibir os arquivos mais recentes primeiro
 
 ## [7.7.54] - 2026-06-10
 ### Correções

--- a/src/modules/Spreadsheets/Controller.php
+++ b/src/modules/Spreadsheets/Controller.php
@@ -158,7 +158,13 @@ class Controller extends \MapasCulturais\Controller
         $files = $entity->files;
 
         if($files && in_array($this->data['group'], array_keys($files))) {
-            return $this->json($files[$this->data['group']]);
+            $group_files = $files[$this->data['group']];
+
+            if (is_array($group_files)) {
+                $group_files = Module::sortExportedFilesByNewestFirst($group_files);
+            }
+
+            return $this->json($group_files);
         }
     }
 }

--- a/src/modules/Spreadsheets/Module.php
+++ b/src/modules/Spreadsheets/Module.php
@@ -3,6 +3,7 @@
 namespace Spreadsheets;
 
 use MapasCulturais\App;
+use DateTimeInterface;
 
 class Module extends \MapasCulturais\Module {
 
@@ -27,5 +28,43 @@ class Module extends \MapasCulturais\Module {
 
         $app->registerJobType(new JobTypes\Entities('entities-spreadsheets'));  
         $app->registerJobType(new JobTypes\Registrations('registrations-spreadsheets'));  
+    }
+
+    static function sortExportedFilesByNewestFirst(array $files): array
+    {
+        $files = array_values($files);
+
+        usort($files, function ($file_a, $file_b) {
+            $timestamp_a = self::getExportedFileTimestamp($file_a);
+            $timestamp_b = self::getExportedFileTimestamp($file_b);
+
+            if ($timestamp_a === $timestamp_b) {
+                return self::getExportedFileId($file_b) <=> self::getExportedFileId($file_a);
+            }
+
+            return $timestamp_b <=> $timestamp_a;
+        });
+
+        return $files;
+    }
+
+    private static function getExportedFileTimestamp($file): int
+    {
+        $timestamp = $file->createTimestamp ?? null;
+
+        if ($timestamp instanceof DateTimeInterface) {
+            return $timestamp->getTimestamp();
+        }
+
+        if (is_string($timestamp)) {
+            return strtotime($timestamp) ?: 0;
+        }
+
+        return 0;
+    }
+
+    private static function getExportedFileId($file): int
+    {
+        return (int) ($file->id ?? 0);
     }
 }

--- a/src/modules/Spreadsheets/components/mc-export-spreadsheet/init.php
+++ b/src/modules/Spreadsheets/components/mc-export-spreadsheet/init.php
@@ -5,8 +5,15 @@
  */
 
 $entity = $this->controller->requestedEntity;
+$files = $entity ? $entity->files : [];
+
+foreach ($files as $group => $group_files) {
+    if (is_array($group_files)) {
+        $files[$group] = \Spreadsheets\Module::sortExportedFilesByNewestFirst($group_files);
+    }
+}
 
 $this->jsObject['config']['mcExportSpreadsheet'] = [
-    'files' => $entity ? $entity->files : [],
+    'files' => $files,
     'evaluation_type' => $entity ? ($entity->evaluationMethod ? $entity->evaluationMethod->slug."-spreadsheets" : null) : null
 ];

--- a/tests/src/SpreadsheetExportsTest.php
+++ b/tests/src/SpreadsheetExportsTest.php
@@ -1,0 +1,38 @@
+<?php
+
+namespace Test;
+
+use DateTime;
+use Spreadsheets\Module;
+use Tests\Abstract\TestCase;
+
+class SpreadsheetExportsTest extends TestCase
+{
+    function testExportedFilesAreSortedByNewestFirst(): void
+    {
+        $older = (object) [
+            'id' => 10,
+            'createTimestamp' => new DateTime('2026-04-30 01:41:10'),
+        ];
+        $newer = (object) [
+            'id' => 20,
+            'createTimestamp' => new DateTime('2026-06-03 15:45:50'),
+        ];
+        $sameTimestampHigherId = (object) [
+            'id' => 30,
+            'createTimestamp' => new DateTime('2026-06-03 15:45:50'),
+        ];
+
+        $sorted = Module::sortExportedFilesByNewestFirst([
+            $older,
+            $newer,
+            $sameTimestampHigherId,
+        ]);
+
+        $this->assertSame(
+            [30, 20, 10],
+            array_map(fn($file) => $file->id, $sorted),
+            'Garantindo que os arquivos exportados sejam listados do mais recente para o mais antigo'
+        );
+    }
+}


### PR DESCRIPTION
## Resumo

Corrige a ordenação da lista de “Últimas exportações” no componente de exportação de planilhas.

Antes, os arquivos eram exibidos na ordem retornada por `$entity->files`, sem garantia cronológica. Agora a listagem exibe primeiro as planilhas mais recentes, usando `createTimestamp` em ordem decrescente e `id` como desempate.

## Como é hoje

<img width="662" height="395" alt="Captura de Tela 2026-06-16 às 02 11 51" src="https://github.com/user-attachments/assets/1386dbf0-e430-4535-a09e-fbbc9a66c4ed" />