### PR TITLE
Corrige erro no salvamento de metadados já existentes durante a sincronização de inscrições entre fases

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,10 @@ Todas as mudanças notáveis no projeto serão documentadas neste arquivo.
 O formato é baseado no [Keep a Changelog](https://keepachangelog.com/pt-BR/1.0.0/)
 e este projeto adere ao [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [UNRELEASED]
+### Correções
+- Corrige salvamento de metadados já existentes, evitando erro de chave duplicada ao sincronizar inscrições entre fases
+
 ## [7.5.58] - 2026-06-16
 ### Correções
 - Evita que os ponteiros nextPhaseRegistrationId e previousPhaseRegistrationId fiquem vazios durante o sincronismo da fase de recurso

--- a/src/core/EntityMetadata.php
+++ b/src/core/EntityMetadata.php
@@ -51,10 +51,13 @@ class EntityMetadata extends Entity {
         ]);
 
         if ($has_metadata) {
-            // Se já existe, carrega o ID e marca como não-novo para poder atualizar
-            $this->id = (int) $has_metadata;
-            parent::save($flush);
-            return;
+            $metadata_object = $app->repo($this->className)->find((int) $has_metadata);
+            if ($metadata_object) {
+                $metadata_object->value = $this->value;
+                $metadata_object->save($flush);
+                $this->id = $metadata_object->id;
+                return;
+            }
         }
         
         parent::save($flush);

--- a/tests/src/PhaseRegistrationSyncTest.php
+++ b/tests/src/PhaseRegistrationSyncTest.php
@@ -67,6 +67,54 @@ class PhaseRegistrationSyncTest extends TestCase
         }
     }
 
+    function testCreatePhaseRegistrationUpdatesExistingNextMetadataWhenEntityHasStaleCreatedMetadata(): void
+    {
+        $context = $this->buildPnabLikeOpportunity();
+        $this->createRegistrationsByStatus($context->coletaMerito);
+        $context = $this->refreshContext($context);
+
+        $registration = $this->findRegistration($context->coletaMerito, '333');
+        $registration->getMetadata('nextPhaseRegistrationId', true);
+
+        $this->app->conn->executeStatement(
+            "INSERT INTO registration_meta (object_id, key, value, id) VALUES (:object_id, :key, :value, nextval('registration_meta_id_seq'::regclass))",
+            [
+                'object_id' => $registration->id,
+                'key' => 'nextPhaseRegistrationId',
+                'value' => '0',
+            ]
+        );
+
+        $module = $this->getOpportunityPhasesModule();
+        $this->app->disableAccessControl();
+        try {
+            $created = $module->createPhaseRegistration($context->anexos, $registration);
+        } finally {
+            $this->app->enableAccessControl();
+        }
+
+        $this->assertEquals(
+            1,
+            (int) $this->app->conn->fetchScalar(
+                "SELECT COUNT(*) FROM registration_meta WHERE object_id = :object_id AND key = :key",
+                [
+                    'object_id' => $registration->id,
+                    'key' => 'nextPhaseRegistrationId',
+                ]
+            )
+        );
+        $this->assertEquals(
+            $created->id,
+            (int) $this->app->conn->fetchScalar(
+                "SELECT value FROM registration_meta WHERE object_id = :object_id AND key = :key",
+                [
+                    'object_id' => $registration->id,
+                    'key' => 'nextPhaseRegistrationId',
+                ]
+            )
+        );
+    }
+
     /**
      * Garante que a publicação final exiba apenas inscrições enviadas e com consolidatedResult correto da fase de mérito.
      */


### PR DESCRIPTION
## Resumo

Corrige erro no salvamento de metadados já existentes durante a sincronização de inscrições entre fases.

O problema acontecia quando o sistema tentava salvar novamente o metadata `nextPhaseRegistrationId` para uma inscrição que já possuía essa chave em `registration_meta`. Nesses casos, o Doctrine ainda tratava o objeto de metadata como novo e tentava fazer um `INSERT`, causando violação da constraint única.

## Erro observado

```txt
PDOException: SQLSTATE[23505]: Unique violation: 7 ERROR: duplicate key value violates unique constraint "registration_meta_unique_object_id_key_value"
DETAIL: Key (object_id, key)=(1920270426, nextPhaseRegistrationId) already exists.
```

## Print do erro (11 selecionadas, passou apenas 8)

<img width="490" height="830" alt="Captura de Tela 2026-06-17 às 02 08 31" src="https://github.com/user-attachments/assets/83507991-b490-4b13-aa33-631ac26af695" />
