### PR TITLE
Corrige a validação de datas no importador de eventos para permitir ocorrências que começam em um dia e terminam no dia seguinte

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -42,6 +42,7 @@ e este projeto adere ao [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 - Corrige o cálculo ponderado dos subtotais na tela de avaliação técnica
 - Corrige os templates de email da fase de recurso
 - Corrige a exibição das opções de campos de seleção no formato radio para organizá-las verticalmente na ficha de inscrição
+- Corrige a validação de ocorrências do importador de eventos para considerar data e hora ao importar eventos que terminam no dia seguinte.
 
 ## [7.5.58] - 2026-06-16
 ### Correções

--- a/src/modules/EventImporter/Controller.php
+++ b/src/modules/EventImporter/Controller.php
@@ -503,12 +503,6 @@ class Controller extends \MapasCulturais\Controller
                if($ends_at != $value['ENDS_AT']){
                   $errors['errors'][$key+1][] = i::__("A coluna Hora final é inválida. O formato esperado é HH:MM Ex.: 12:00");
                }
-               
-               
-               if((new DateTime($value['STARTS_AT'])) > (new DateTime($value['ENDS_AT']))){
-                  $errors['errors'][$key+1][] = i::__("A data inicial é maior que a data final.");
-               }
-
                // Valida a data inicial
                if (empty($value['STARTS_ON']) || $value['STARTS_ON'] == "") {
                   $errors['errors'][$key+1][] = i::__("A Coluna Data inícial Está vazia");
@@ -528,6 +522,12 @@ class Controller extends \MapasCulturais\Controller
                   $ends_on = $this->formatDate($value['ENDS_ON'], "Y-m-d");
                   if ($ends_on != $value['ENDS_ON']) {
                      $errors['errors'][$key+1][] = i::__("A coluna data final é inválida. O formato esperado é DD/MM/YYYY Ex.: 01/01/2022");
+                  }
+               }
+
+               if(!empty($value['STARTS_ON']) && !empty($value['STARTS_AT']) && !empty($value['ENDS_AT'])){
+                  if($this->getOccurrenceStartDateTime($value) > $this->getOccurrenceEndDateTime($value)){
+                     $errors['errors'][$key+1][] = i::__("A data inicial é maior que a data final.");
                   }
                }
 
@@ -741,11 +741,7 @@ class Controller extends \MapasCulturais\Controller
          $ocurrence = new EventOccurrence();    
    
          $duration = function() use ($value){
-            $start = $this->formatDate($value['STARTS_AT']);
-            $stop = $this->formatDate($value['ENDS_AT']);
-            $diferenca = strtotime($stop) - strtotime($start);
-   
-            return ($diferenca / 60);
+            return $this->getOccurrenceDurationInMinutes($value);
          };
    
          $collum = $this->checkCollum($value['SPACE']);
@@ -1076,6 +1072,26 @@ class Controller extends \MapasCulturais\Controller
    public function error($message)
    {
       throw new Exception(i::__($message));
+   }
+
+   public function getOccurrenceStartDateTime($value)
+   {
+      return new DateTime("{$value['STARTS_ON']} {$value['STARTS_AT']}");
+   }
+
+   public function getOccurrenceEndDateTime($value)
+   {
+      $ends_on = !empty($value['ENDS_ON']) ? $value['ENDS_ON'] : $value['STARTS_ON'];
+
+      return new DateTime("{$ends_on} {$value['ENDS_AT']}");
+   }
+
+   public function getOccurrenceDurationInMinutes($value)
+   {
+      $starts_at = $this->getOccurrenceStartDateTime($value);
+      $ends_at = $this->getOccurrenceEndDateTime($value);
+
+      return (int) (($ends_at->getTimestamp() - $starts_at->getTimestamp()) / 60);
    }
 
    public function formatDate($date, $formatOut = "Y-m-d H:i")

--- a/tests/src/EventImporterControllerTest.php
+++ b/tests/src/EventImporterControllerTest.php
@@ -1,0 +1,40 @@
+<?php
+
+namespace Tests;
+
+use EventImporter\Controller;
+use Tests\Abstract\TestCase;
+
+class EventImporterControllerTest extends TestCase
+{
+    function testOccurrenceEndDateTimeUsesEndsOnWhenProvided(): void
+    {
+        $controller = Controller::i('eventimporter');
+
+        $value = [
+            'STARTS_ON' => '2026-06-12',
+            'ENDS_ON' => '2026-06-13',
+            'STARTS_AT' => '18:00',
+            'ENDS_AT' => '01:00',
+        ];
+
+        $this->assertEquals(
+            '2026-06-13 01:00',
+            $controller->getOccurrenceEndDateTime($value)->format('Y-m-d H:i')
+        );
+    }
+
+    function testOccurrenceDurationConsidersEndsOn(): void
+    {
+        $controller = Controller::i('eventimporter');
+
+        $value = [
+            'STARTS_ON' => '2026-06-12',
+            'ENDS_ON' => '2026-06-13',
+            'STARTS_AT' => '18:00',
+            'ENDS_AT' => '01:00',
+        ];
+
+        $this->assertEquals(420, $controller->getOccurrenceDurationInMinutes($value));
+    }
+}


### PR DESCRIPTION
## Resumo

Corrige a validação de datas no importador de eventos para permitir ocorrências que começam em um dia e terminam no dia seguinte.

Antes, um evento importado com início em `12/06 18:00` e fim em `13/06 01:00` era rejeitado com a mensagem “A data inicial é maior que a data final”, porque o importador comparava apenas as horas.

## O que foi alterado

- A validação agora compara `DATA INICIAL + HORA INICIAL` com `DATA FINAL + HORA FINAL`.
- O cálculo da duração da ocorrência passou a considerar a data final.
- Foi adicionado teste cobrindo evento de `2026-06-12 18:00` até `2026-06-13 01:00`, com duração de `420` minutos.
