### PR TITLE
Otimização do Build usando Cache no GitHub Actions para reduzir drasticamente o tempo de CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -64,4 +64,6 @@ jobs:
           push: ${{ github.event_name != 'pull_request' }}
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
 

--- a/.github/workflows/develop.yml
+++ b/.github/workflows/develop.yml
@@ -55,6 +55,8 @@ jobs:
           push: ${{ github.event_name != 'pull_request' }}
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
 
       -
         name: Configure kubectl

--- a/.github/workflows/rc.yml
+++ b/.github/workflows/rc.yml
@@ -50,4 +50,6 @@ jobs:
           push: ${{ github.event_name != 'pull_request' }}
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,7 @@ e este projeto adere ao [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 - Permite buscar avaliadores por ID do agente no formato #ID e e-mail do usuário ao adicioná-los ou substituí-los nas comissões de avaliação.
 - Adiciona campos de CNPJ e mini currículo à listagem de pessoas dos formulários de inscrição, com validação de CPF e CNPJ.
 - Melhora a performance da listagem de modelos de oportunidades ao evitar consultas repetidas para identificar modelos oficiais.
+- Otimiza a construção das imagens Docker nos workflows de CI, develop e release candidate ao reutilizar o cache do Buildx armazenado no GitHub Actions.
 
 ### Correções
 - Aplica texto de internacionalização faltante no componente opportunity-registration-table


### PR DESCRIPTION
# Otimização do Build usando Cache no GitHub Actions

## Cenário

Os workflows estavam executando processos repetitivos de instalação de dependências a cada execução do CI, mesmo quando não havia mudanças relevantes no ambiente.

Isso resultava em:
- Tempo elevado de execução dos pipelines
- Maior consumo de minutos de GitHub Actions

---

## Solução

Foi implementado e ajustado o uso de cache no GitHub Actions para dependências e etapas repetitivas do build.

Principais melhorias:
- Cache de dependências entre execuções
- Chaves de cache mais eficientes para melhor taxa de reutilização
- Redução de etapas redundantes no pipeline

Resultado: reutilização de artefatos entre execuções, reduzindo drasticamente o tempo de build.

---

## Comparativo de tempo

| Cenário        | Tempo médio |
|----------------|------------|
| Sem cache      | ~4 minutos |
| Com cache      | ~7 segundos |
| Redução        | ~97%       |

<img width="1544" height="583" alt="image" src="https://github.com/user-attachments/assets/8191eb66-9f67-4d62-8d53-709aa2339c35" />
<img width="1509" height="710" alt="image" src="https://github.com/user-attachments/assets/2bba8041-a214-496d-a990-14551451f0f5" />

---

## Configurações recomendadas (Repository Settings)

Para evitar crescimento excessivo de cache e possíveis impactos no armazenamento:

### Caminho:
**Repository → Settings → Actions → General → Cache storage**

### Ajustes recomendados:

- **Cache size limit**
  - Definir conforme volume do projeto
  - Sugestão inicial: entre **1GB e 5GB por repositório**
  - Evitar valores ilimitados em projetos com múltiplos forks

- **Cache retention (tempo de retenção)**
  - Reduzir conforme frequência de deploy/CI
  - Sugestão:
    - Projetos ativos: **3 a 7 dias**
    - Projetos estáveis: até **14 dias**

