### PR TITLE
Corrige erro ao carregar a configuração de cotas em oportunidades antigas que não possuem `quotaConfiguration.rules` cadastrado

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -56,6 +56,7 @@ e este projeto adere ao [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 - Corrige a exibição das opções de campos de seleção no formato radio para organizá-las verticalmente na ficha de inscrição
 - Corrige a ordenação das últimas planilhas exportadas para exibir os arquivos mais recentes primeiro
 - Corrige o uso de modelos de oportunidades para respeitar a visibilidade pública, validar permissões e preservar referências de campos condicionais.
+- Corrige o carregamento da configuração de cotas em oportunidades antigas sem regras de cotas cadastradas.
 
 ## [7.7.63] - 2026-06-24
 ### Melhorias

--- a/src/modules/EvaluationMethodTechnical/components/affirmative-policies--quota-configuration/script.js
+++ b/src/modules/EvaluationMethodTechnical/components/affirmative-policies--quota-configuration/script.js
@@ -18,10 +18,11 @@ app.component('affirmative-policies--quota-configuration', {
     },
 
     mounted() {
+        this.normalizeQuotaConfiguration();
         
-        if(this.phase.quotaConfiguration && this.phase.quotaConfiguration.rules.length > 0) {
+        if(this.quotaRules.length > 0) {
             if(this.totalVacancies > 0) {
-                this.phase.quotaConfiguration.rules.forEach((quota, index) => {
+                this.quotaRules.forEach((quota, index) => {
                     this.updateRuleQuotaPercentage(quota, true);
                 });
             } else {
@@ -54,7 +55,7 @@ app.component('affirmative-policies--quota-configuration', {
             autoSaveTime: 3000,
             firstPhase,
             totalVacancies: firstPhase.vacancies ?? 0,
-            totalQuota: this.phase.quotaConfiguration ? this.phase.quotaConfiguration.vacancies : 0,
+            totalQuota: this.phase.quotaConfiguration?.vacancies ?? 0,
             totalPercentage: 0,
             fields: $MAPAS.config.affirmativePoliciesQuotaConfiguration.fields[this.phase.opportunity.id]
         }
@@ -62,7 +63,11 @@ app.component('affirmative-policies--quota-configuration', {
 
     computed: {
         isActive() {
-            return this.phase?.quotaConfiguration?.rules.length > 0;
+            return this.quotaRules.length > 0;
+        },
+
+        quotaRules() {
+            return this.phase?.quotaConfiguration?.rules || [];
         },
 
         proponentTypes() {
@@ -77,6 +82,22 @@ app.component('affirmative-policies--quota-configuration', {
     },
 
     methods: {
+        normalizeQuotaConfiguration() {
+            if (Array.isArray(this.phase.quotaConfiguration)) {
+                this.phase.quotaConfiguration = { rules: this.phase.quotaConfiguration };
+                return;
+            }
+
+            if (!this.phase.quotaConfiguration) {
+                this.phase.quotaConfiguration = { rules: [] };
+                return;
+            }
+
+            if (!Array.isArray(this.phase.quotaConfiguration.rules)) {
+                this.phase.quotaConfiguration.rules = [];
+            }
+        },
+
         skeleton() {
             const fields = {};
 
@@ -111,24 +132,19 @@ app.component('affirmative-policies--quota-configuration', {
         },
 
         addConfig() {
-            if (!this.phase.quotaConfiguration) {
-                this.phase.quotaConfiguration = {
-                    rules: [{
-                        title: '',
-                        vacancies: 0,
-                        fields: this.skeleton()
-                    }]
-                };
-            } else {
-                this.phase.quotaConfiguration.rules.push({
-                    vacancies: 0,
-                    fields: this.skeleton()
-                });
-            }
+            this.normalizeQuotaConfiguration();
+
+            this.phase.quotaConfiguration.rules.push({
+                title: '',
+                vacancies: 0,
+                fields: this.skeleton()
+            });
         },
 
         removeConfig(item) {
-            this.phase.quotaConfiguration.rules = this.phase.quotaConfiguration.rules.filter(function(value, key) {
+            this.normalizeQuotaConfiguration();
+
+            this.phase.quotaConfiguration.rules = this.quotaRules.filter(function(value, key) {
                 return item != key;
             });
             this.distributeQuotas(true);
@@ -156,8 +172,8 @@ app.component('affirmative-policies--quota-configuration', {
             let countVacancies = 0;
             let removeQuota = deleteQuota;
 
-            if(this.phase.quotaConfiguration && this.phase.quotaConfiguration.rules.length > 0 || removeQuota) {
-                this.phase.quotaConfiguration.rules.forEach((quota, index) => {
+            if(this.quotaRules.length > 0 || removeQuota) {
+                this.quotaRules.forEach((quota, index) => {
                     countVacancies += quota.vacancies;
                 });
                 this.totalQuota = countVacancies;
@@ -177,7 +193,7 @@ app.component('affirmative-policies--quota-configuration', {
         },
 
         autoSave(updated = false) {
-            const filled = Object.values(this.phase.quotaConfiguration.rules).filter(
+            const filled = Object.values(this.quotaRules).filter(
                 quotaConfiguration => {
                     return quotaConfiguration.title !== undefined 
                         && quotaConfiguration.title 
@@ -196,7 +212,7 @@ app.component('affirmative-policies--quota-configuration', {
         },
 
         validateFields() {
-            for (let quota of this.phase.quotaConfiguration.rules) {
+            for (let quota of this.quotaRules) {
                 for (let field of Object.values(quota.fields)) {
                     // Verifica se o campo foi selecionado
                     if (!field.fieldName) {
@@ -226,7 +242,7 @@ app.component('affirmative-policies--quota-configuration', {
 
         fixConfiguration() {
             const proponentTypes = this.proponentTypes;
-            for (let quota of this.phase.quotaConfiguration?.rules || []) {
+            for (let quota of this.quotaRules) {
                 for(let key in quota.fields) {
                     if(!proponentTypes.includes(key)) {
                         delete quota.fields[key];
@@ -234,7 +250,7 @@ app.component('affirmative-policies--quota-configuration', {
                 }
             }
 
-            for (let quota of this.phase.quotaConfiguration?.rules || []) {
+            for (let quota of this.quotaRules) {
                 for (let proponentType of proponentTypes) {
                     if(!quota.fields[proponentType]) {
                         quota.fields[proponentType] = {


### PR DESCRIPTION
## Resumo

Corrige erro ao carregar a configuração de cotas em oportunidades antigas que não possuem `quotaConfiguration.rules` cadastrado.

## Erro encontrado

Ao acessar uma oportunidade antiga, a tela quebrava com o erro:

```text
TypeError: Cannot read properties of undefined (reading 'length')
    at Proxy.isActive (script.affirmative-policies--quota-configuration...js:65:57)
    at Proxy.mounted (script.affirmative-policies--quota-configuration...js:22:81)
```

## Motivação

O componente de configuração de cotas passou a esperar o formato `quotaConfiguration.rules`, mas oportunidades criadas antes dessa estrutura podem ter a configuração ausente, vazia ou em formato legado.

Com isso, o Vue tentava acessar `.length` de `rules` quando o campo estava indefinido, impedindo o carregamento da tela de gestão da oportunidade.

## Alterações

- Normaliza `quotaConfiguration` ao montar o componente.
- Garante que `quotaConfiguration.rules` sempre seja tratado como array.
- Preserva compatibilidade com configurações legadas em formato de array.
- Substitui acessos diretos a `phase.quotaConfiguration.rules` por uma computed defensiva.