### PR TITLE
Adiciona uma configuração na oportunidade para ocultar as datas das fases nas telas públicas e de acompanhamento da inscrição

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ e este projeto adere ao [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 ## [Unreleased]
 ### Novas Funcionalidades
+- Adiciona configuração na oportunidade para ocultar todas as datas das fases na página pública, na linha do tempo de acompanhamento da inscrição e nos avisos de prazo da ficha, mantendo as datas operacionais ativas para validações e gestão interna.
 - **Avaliação automática por selos**: o gestor pode indicar, em uma fase de avaliação, quais selos validam o proponente. Se a pessoa já tiver esses selos válidos no perfil, a inscrição é **dispensada automaticamente** daquela fase (marcada como “Dispensada por selos”) e segue para a próxima etapa, sem precisar de avaliador
 - **Novos anexos no cadastro do agente** (também usáveis como campos `@` no formulário de inscrição): CPF, CNPJ, CNH, RG, passaporte, comprovante de residência, vínculo territorial, currículo, portfólio, certidões fiscal, trabalhista e de prestação de contas, além de comprovantes de raça/cor, pessoa com deficiência e comunidades tradicionais. Os arquivos ficam no perfil e acompanham a inscrição automaticamente
 

--- a/src/modules/FAQ/questions/es_ES/editais-oportunidades/configuracoes/ocultar-datas-fases.md
+++ b/src/modules/FAQ/questions/es_ES/editais-oportunidades/configuracoes/ocultar-datas-fases.md
@@ -1,0 +1,9 @@
+# ¿Qué significa ocultar las fechas de las fases para el público?
+
+Esta configuración oculta las fechas de las fases en la página pública de la oportunidad, en la línea de tiempo de seguimiento de la inscripción y en los avisos de plazo de la ficha de inscripción.
+
+Las fechas continúan registradas y utilizadas internamente por el sistema para validaciones, automatizaciones y gestión de la oportunidad. La opción solamente impide que estas fechas sean visibles para el público.
+
+Utiliza esta configuración cuando sea necesario ajustar fechas operativas durante el proceso de la convocatoria sin exponer estos cambios a las personas inscritas.
+
+> **Atención:** La configuración no modifica los plazos ni el funcionamiento de las fases. Solo oculta la visualización de las fechas en las pantallas públicas y de seguimiento.

--- a/src/modules/FAQ/questions/pt_BR/editais-oportunidades/configuracoes/ocultar-datas-fases.md
+++ b/src/modules/FAQ/questions/pt_BR/editais-oportunidades/configuracoes/ocultar-datas-fases.md
@@ -1,0 +1,9 @@
+# O que significa ocultar datas das fases para o público?
+
+Esta configuração esconde as datas das fases na página pública da oportunidade, na linha do tempo de acompanhamento da inscrição e nos avisos de prazo da ficha de inscrição.
+
+As datas continuam cadastradas e sendo usadas internamente pelo sistema para validações, automações e gestão da oportunidade. A opção apenas impede que essas datas fiquem visíveis para o público.
+
+Use esta configuração quando for necessário ajustar datas operacionais durante o andamento do edital sem expor essas alterações aos inscritos.
+
+> **Atenção:** A configuração não altera os prazos nem o funcionamento das fases. Ela apenas oculta a exibição das datas nas telas públicas e de acompanhamento.

--- a/src/modules/Opportunities/Module.php
+++ b/src/modules/Opportunities/Module.php
@@ -1371,6 +1371,13 @@ class Module extends \MapasCulturais\Module{
             'default' => false,
         ]);
 
+        $this->registerOpportunityMetadata('hidePhaseDates', [
+            'label' => i::__('Ocultar datas das fases para o público'),
+            'type' => 'boolean',
+            'default' => false,
+            'description' => i::__('As datas continuam sendo usadas pelo sistema, mas não aparecem na página pública da oportunidade nem no acompanhamento da inscrição.'),
+        ]);
+
         $this->registerOpportunityMetadata('publicityOnly', [
             'label' => i::__('Oportunidade apenas para divulgação'),
             'type' => 'boolean',

--- a/src/modules/Opportunities/Module.php
+++ b/src/modules/Opportunities/Module.php
@@ -1375,7 +1375,6 @@ class Module extends \MapasCulturais\Module{
             'label' => i::__('Ocultar datas das fases para o público'),
             'type' => 'boolean',
             'default' => false,
-            'description' => i::__('As datas continuam sendo usadas pelo sistema, mas não aparecem na página pública da oportunidade nem no acompanhamento da inscrição.'),
         ]);
 
         $this->registerOpportunityMetadata('publicityOnly', [

--- a/src/modules/Opportunities/components/opportunity-phase-config-data-collection/template.php
+++ b/src/modules/Opportunities/components/opportunity-phase-config-data-collection/template.php
@@ -25,6 +25,7 @@ $this->import('
             <entity-field v-if="!phase.isFirstPhase" :entity="phase" prop="name" :autosave="3000" classes="col-12 sm:col-12"></entity-field>
             <entity-field :entity="phase" prop="registrationFrom" :autosave="3000"  classes="col-6 sm:col-12"></entity-field>
             <entity-field v-if="!firstPhase?.isContinuousFlow || firstPhase?.hasEndDate" :entity="phase" prop="registrationTo" :autosave="3000"  classes="col-6 sm:col-12"></entity-field>
+            <entity-field v-if="phase.isFirstPhase" :entity="phase" prop="hidePhaseDates" type="checkbox" :autosave="3000" hide-required classes="col-12 sm:col-12"></entity-field>
             <entity-field v-if="phase.isReportingPhase" :entity="phase" prop="includesWorkPlan" classes="col-12"></entity-field>
 
             <div v-if="phase.isFirstPhase && firstPhase?.isContinuousFlow && !firstPhase?.hasEndDate" class="col-12 opportunity-data-collection__enable-end-date">

--- a/src/modules/Opportunities/components/opportunity-phase-config-data-collection/template.php
+++ b/src/modules/Opportunities/components/opportunity-phase-config-data-collection/template.php
@@ -25,7 +25,11 @@ $this->import('
             <entity-field v-if="!phase.isFirstPhase" :entity="phase" prop="name" :autosave="3000" classes="col-12 sm:col-12"></entity-field>
             <entity-field :entity="phase" prop="registrationFrom" :autosave="3000"  classes="col-6 sm:col-12"></entity-field>
             <entity-field v-if="!firstPhase?.isContinuousFlow || firstPhase?.hasEndDate" :entity="phase" prop="registrationTo" :autosave="3000"  classes="col-6 sm:col-12"></entity-field>
-            <entity-field v-if="phase.isFirstPhase" :entity="phase" prop="hidePhaseDates" type="checkbox" :autosave="3000" hide-required classes="col-12 sm:col-12"></entity-field>
+            <entity-field v-if="phase.isFirstPhase" :entity="phase" prop="hidePhaseDates" type="checkbox" :autosave="3000" hide-required classes="col-12 sm:col-12">
+                <template #info>
+                    <?php $this->info('editais-oportunidades -> configuracoes -> ocultar-datas-fases') ?>
+                </template>
+            </entity-field>
             <entity-field v-if="phase.isReportingPhase" :entity="phase" prop="includesWorkPlan" classes="col-12"></entity-field>
 
             <div v-if="phase.isFirstPhase && firstPhase?.isContinuousFlow && !firstPhase?.hasEndDate" class="col-12 opportunity-data-collection__enable-end-date">

--- a/src/modules/Opportunities/components/opportunity-phases-timeline/script.js
+++ b/src/modules/Opportunities/components/opportunity-phases-timeline/script.js
@@ -47,6 +47,10 @@ app.component('opportunity-phases-timeline', {
 	},
 
 	methods: {
+		showPhaseDates(item) {
+			return !this.firstPhase?.hidePhaseDates;
+		},
+
 		dateFrom(item) {
 			if (item.registrationFrom) {
 				return item.registrationFrom.date('2-digit year');

--- a/src/modules/Opportunities/components/opportunity-phases-timeline/template.php
+++ b/src/modules/Opportunities/components/opportunity-phases-timeline/template.php
@@ -22,12 +22,12 @@ $this->import('
                     <?php $this->applyComponentHook('item', 'begin'); ?>
                     <div v-if="item.isFirstPhase" class="item__content--title"> <?= $this->text('phase_registration', i::__('Fase de inscrições')) ?> </div>
                     <div v-if="!item.isFirstPhase" class="item__content--title"> {{item.name}} </div> 
-                    <div v-if="!item.isLastPhase && (!firstPhase.isContinuousFlow || firstPhase.hasEndDate)" class="item__content--description">
+                    <div v-if="!item.isLastPhase && showPhaseDates(item) && (!firstPhase.isContinuousFlow || firstPhase.hasEndDate)" class="item__content--description">
                         <h5 class="semibold"><?= i::__('de') ?> <span v-if="dateFrom(item)">{{dateFrom(item)}}</span>
                         <?= i::__('a') ?> <span v-if="dateTo(item)">{{dateTo(item)}}</span>
                         <?= i::__('às') ?> <span v-if="hour(item)">{{hour(item)}}</span></h5>
                     </div>
-                    <div v-if="item.isLastPhase && item.publishTimestamp" class="item__content--description">
+                    <div v-if="item.isLastPhase && showPhaseDates(item) && item.publishTimestamp" class="item__content--description">
                         <span v-if="item.publishTimestamp">
                             {{item.publishTimestamp.date('2-digit year')}}
                             <?= i::__('às') ?>

--- a/src/modules/Opportunities/components/registration-status/script.js
+++ b/src/modules/Opportunities/components/registration-status/script.js
@@ -89,6 +89,11 @@ app.component('registration-status', {
     },
 
     methods: {
+        showPhaseDates() {
+            const firstPhase = $MAPAS.opportunityPhases?.find((phase) => phase.isFirstPhase) || this.firstPhase;
+            return !firstPhase?.hidePhaseDates;
+        },
+
         shouldDisplayEvaluationResults(registration) {
             return $MAPAS.config.registrationResults.shouldDisplayEvaluationResults[registration.id];
         },

--- a/src/modules/Opportunities/components/registration-status/template.php
+++ b/src/modules/Opportunities/components/registration-status/template.php
@@ -56,7 +56,7 @@ $this->import('
     <div class="item__dot-appeal-phase"> <span class="dot"></span> </div>
     <div class="item__content">
         <div class="item__content--title"> <?= i::__('[Recurso]') ?> </div>
-        <div class="item__content--description">
+        <div v-if="showPhaseDates()" class="item__content--description">
             <h5 class="semibold"><?= i::__('de') ?> <span v-if="dateFrom()">{{dateFrom()}}</span>
             <?= i::__('a') ?> <span v-if="dateTo()">{{dateTo()}}</span>
             <?= i::__('às') ?> <span v-if="hour()">{{hour()}}</span></h5>

--- a/src/modules/Opportunities/views/registration/single.php
+++ b/src/modules/Opportunities/views/registration/single.php
@@ -48,6 +48,7 @@ if($all_registrations = $app->repo('Registration')->findBy(['number' => $entity-
 $this->jsObject['config']['registrationResults']['shouldDisplayEvaluationResults'] = $result;
 
 $today = new DateTime();
+$hide_phase_dates = $entity->opportunity->firstPhase->hidePhaseDates;
 ?>
 
 <div class="main-app registration single">
@@ -276,8 +277,11 @@ $today = new DateTime();
                         <?php endif ?>
                         <?php if($phase->status < 1 && !$opportunity->isFirstPhase && $today <= $opportunity->registrationTo): ?>
                             <mc-alert type="warning">
-                                <?= i::__('Nesta etapa, é necessário inserir informações. Por favor, clique no botão para acessar o formulário e preenchê-lo') ?> <br>
-                                <?= i::__('dentro do período de') ?>  <?=$phase->opportunity->registrationFrom->format("d/m/Y")?> <?= i::__('à') ?> <?=$phase->opportunity->registrationTo->format("d/m/Y H:i:s")?>
+                                <?= i::__('Nesta etapa, é necessário inserir informações. Por favor, clique no botão para acessar o formulário e preenchê-lo') ?>
+                                <?php if(!$hide_phase_dates): ?>
+                                    <br>
+                                    <?= i::__('dentro do período de') ?>  <?=$phase->opportunity->registrationFrom->format("d/m/Y")?> <?= i::__('à') ?> <?=$phase->opportunity->registrationTo->format("d/m/Y H:i:s")?>
+                                <?php endif; ?>
                             </mc-alert>
                             <div class="grid-12">
                                 <div class="col-3 sm:col-12">
@@ -289,7 +293,13 @@ $today = new DateTime();
                                     <?php if($today > $opportunity->registrationTo):?>
                                         <mc-alert type="warning">
                                             <?= i::__("Você não enviou o formulário desta fase") ?> <br>
-                                            <small><?= i::__("O prazo para envio dessa inscrição foi até {$opportunity->registrationTo->format('d/m/Y H:i:s')}") ?></small> <br>
+                                            <small>
+                                                <?php if($hide_phase_dates): ?>
+                                                    <?= i::__("O prazo para envio dessa inscrição foi encerrado") ?>
+                                                <?php else: ?>
+                                                    <?= i::__("O prazo para envio dessa inscrição foi até {$opportunity->registrationTo->format('d/m/Y H:i:s')}") ?>
+                                                <?php endif; ?>
+                                            </small> <br>
                                         </mc-alert>
                                     <?php else: ?>
                                         <mc-alert type="warning">
@@ -322,7 +332,13 @@ $today = new DateTime();
                                     <?php if($today > $appeal_phase->registrationTo):?>
                                         <mc-alert type="warning">
                                             <?= i::__("Você não enviou o formulário desta fase") ?> <br>
-                                            <small><?= i::__("O prazo para envio dessa inscrição foi até {$appeal_phase->registrationTo->format('d/m/Y H:i:s')}") ?></small> <br>
+                                            <small>
+                                                <?php if($hide_phase_dates): ?>
+                                                    <?= i::__("O prazo para envio dessa inscrição foi encerrado") ?>
+                                                <?php else: ?>
+                                                    <?= i::__("O prazo para envio dessa inscrição foi até {$appeal_phase->registrationTo->format('d/m/Y H:i:s')}") ?>
+                                                <?php endif; ?>
+                                            </small> <br>
                                         </mc-alert>
                                     <?php else: ?>
                                         <mc-alert type="warning">

--- a/src/modules/OpportunityPhases/Module.php
+++ b/src/modules/OpportunityPhases/Module.php
@@ -892,7 +892,7 @@ class Module extends \MapasCulturais\Module{
                     if($opportunity->isDataCollection || $opportunity->isFirstPhase || $opportunity->isLastPhase){
                         $app->applyHook('module(OpportunityPhases).dataCollectionPhaseData', [&$mout_simplify]);
 
-                        $item = $opportunity->simplify("{$mout_simplify},type,publishedRegistrations,publishTimestamp,registrationFrom,registrationTo,isContinuousFlow,hasEndDate,isDataCollection,isFirstPhase,isLastPhase,isReportingPhase,isLastReportingPhase,files,statusLabels");
+                        $item = $opportunity->simplify("{$mout_simplify},type,publishedRegistrations,publishTimestamp,registrationFrom,registrationTo,isContinuousFlow,hasEndDate,hidePhaseDates,isDataCollection,isFirstPhase,isLastPhase,isReportingPhase,isLastReportingPhase,files,statusLabels");
                         $item->appealPhase = $opportunity->appealPhase;
 
                         $item->registrationSteps = [];
@@ -920,7 +920,7 @@ class Module extends \MapasCulturais\Module{
                         $item = $emc->simplify("{$mout_simplify},type,opportunity,infos,evaluationFrom,evaluationTo,relatedAgents,agentRelations");
                         if($appeal_phase = $emc->appealPhase) {
                             $item->appealPhase = $appeal_phase;
-                            $item->opportunity = $opportunity->simplify('id,isFirstPhase,isLastPhase,isReportingPhase,isLastReportingPhase,isContinuousFlow,hasEndDate,files,statusLabels,relatedAgents,agentRelations');
+                            $item->opportunity = $opportunity->simplify('id,isFirstPhase,isLastPhase,isReportingPhase,isLastReportingPhase,isContinuousFlow,hasEndDate,hidePhaseDates,files,statusLabels,relatedAgents,agentRelations');
                             $item->opportunity->appealPhase = (object) $appeal_phase->jsonSerialize();
                             $item->opportunity->appealPhase->relatedAgents = $appeal_phase->relatedAgents;
                             $item->opportunity->appealPhase->agentRelations = $appeal_phase->agentRelations;

--- a/tests/src/OpportunityPhaseDatesVisibilityStaticTest.php
+++ b/tests/src/OpportunityPhaseDatesVisibilityStaticTest.php
@@ -1,0 +1,64 @@
+<?php
+
+use PHPUnit\Framework\TestCase;
+
+class OpportunityPhaseDatesVisibilityStaticTest extends TestCase
+{
+    private string $root;
+
+    protected function setUp(): void
+    {
+        $this->root = dirname(__DIR__);
+    }
+
+    public function testOpportunityRegistersHidePhaseDatesMetadata(): void
+    {
+        $module = file_get_contents($this->root . '/src/modules/Opportunities/Module.php');
+
+        $this->assertStringContainsString("registerOpportunityMetadata('hidePhaseDates'", $module);
+        $this->assertStringContainsString("Ocultar datas das fases para o público", $module);
+        $this->assertStringContainsString("'default' => false", $module);
+    }
+
+    public function testPhasesPayloadExposesHidePhaseDatesToTimelineConsumers(): void
+    {
+        $module = file_get_contents($this->root . '/src/modules/OpportunityPhases/Module.php');
+
+        $this->assertMatchesRegularExpression(
+            '/simplify\("[^"]*registrationFrom,registrationTo,isContinuousFlow,hasEndDate,hidePhaseDates,isDataCollection/s',
+            $module
+        );
+        $this->assertMatchesRegularExpression(
+            "/simplify\\('id,isFirstPhase,isLastPhase,isReportingPhase,isLastReportingPhase,isContinuousFlow,hasEndDate,hidePhaseDates,files/s",
+            $module
+        );
+    }
+
+    public function testTimelineDatesRespectHidePhaseDatesFlag(): void
+    {
+        $template = file_get_contents($this->root . '/src/modules/Opportunities/components/opportunity-phases-timeline/template.php');
+        $script = file_get_contents($this->root . '/src/modules/Opportunities/components/opportunity-phases-timeline/script.js');
+
+        $this->assertStringContainsString('showPhaseDates(item)', $script);
+        $this->assertStringContainsString('!item.isLastPhase && showPhaseDates(item)', $template);
+        $this->assertStringContainsString('item.isLastPhase && showPhaseDates(item) && item.publishTimestamp', $template);
+    }
+
+    public function testRegistrationAppealDatesRespectHidePhaseDatesFlag(): void
+    {
+        $template = file_get_contents($this->root . '/src/modules/Opportunities/components/registration-status/template.php');
+        $script = file_get_contents($this->root . '/src/modules/Opportunities/components/registration-status/script.js');
+
+        $this->assertStringContainsString('showPhaseDates()', $script);
+        $this->assertStringContainsString('v-if="showPhaseDates()"', $template);
+    }
+
+    public function testRegistrationViewDeadlineMessagesRespectHidePhaseDatesFlag(): void
+    {
+        $view = file_get_contents($this->root . '/src/modules/Opportunities/views/registration/single.php');
+
+        $this->assertStringContainsString('$hide_phase_dates = $entity->opportunity->firstPhase->hidePhaseDates;', $view);
+        $this->assertStringContainsString('if(!$hide_phase_dates):', $view);
+        $this->assertStringContainsString('O prazo para envio dessa inscrição foi encerrado', $view);
+    }
+}

--- a/tests/src/OpportunityPhaseDatesVisibilityStaticTest.php
+++ b/tests/src/OpportunityPhaseDatesVisibilityStaticTest.php
@@ -14,10 +14,27 @@ class OpportunityPhaseDatesVisibilityStaticTest extends TestCase
     public function testOpportunityRegistersHidePhaseDatesMetadata(): void
     {
         $module = file_get_contents($this->root . '/src/modules/Opportunities/Module.php');
+        $metadataStart = strpos($module, "registerOpportunityMetadata('hidePhaseDates'");
+        $metadataEnd = strpos($module, "registerOpportunityMetadata('publicityOnly'", $metadataStart);
+        $metadata = substr($module, $metadataStart, $metadataEnd - $metadataStart);
 
         $this->assertStringContainsString("registerOpportunityMetadata('hidePhaseDates'", $module);
         $this->assertStringContainsString("Ocultar datas das fases para o público", $module);
-        $this->assertStringContainsString("'default' => false", $module);
+        $this->assertStringContainsString("'default' => false", $metadata);
+        $this->assertStringNotContainsString("'description'", $metadata);
+    }
+
+    public function testOpportunityConfigurationShowsHidePhaseDatesFaqInfo(): void
+    {
+        $template = file_get_contents($this->root . '/src/modules/Opportunities/components/opportunity-phase-config-data-collection/template.php');
+        $ptBrFaq = file_get_contents($this->root . '/src/modules/FAQ/questions/pt_BR/editais-oportunidades/configuracoes/ocultar-datas-fases.md');
+        $esFaq = file_get_contents($this->root . '/src/modules/FAQ/questions/es_ES/editais-oportunidades/configuracoes/ocultar-datas-fases.md');
+
+        $this->assertStringContainsString('prop="hidePhaseDates"', $template);
+        $this->assertStringContainsString('<template #info>', $template);
+        $this->assertStringContainsString("editais-oportunidades -> configuracoes -> ocultar-datas-fases", $template);
+        $this->assertStringContainsString('O que significa ocultar datas das fases para o público?', $ptBrFaq);
+        $this->assertStringContainsString('¿Qué significa ocultar las fechas de las fases para el público?', $esFaq);
     }
 
     public function testPhasesPayloadExposesHidePhaseDatesToTimelineConsumers(): void


### PR DESCRIPTION
## Resumo

Adiciona uma configuração na oportunidade para ocultar as datas das fases nas telas públicas e de acompanhamento da inscrição.

Essa opção atende ao cenário em que, durante o andamento de um edital, o gestor precisa ajustar datas operacionais das fases sem expor essas alterações ao público, evitando ruídos e reclamações.

## O que foi alterado

- Criado o campo **“Ocultar datas das fases para o público”** na configuração da oportunidade.
- Ocultadas as datas da timeline de fases na página pública da oportunidade.
- Ocultadas as datas da timeline/acompanhamento da inscrição.
- Ocultadas as datas nos avisos de prazo da ficha de inscrição.
- Mantidas as datas funcionando internamente para regras, validações, automações e gestão.

<img width="1120" height="307" alt="Captura de Tela 2026-06-28 às 00 52 36" src="https://github.com/user-attachments/assets/c6da71c3-66ef-4fc4-b2b7-442ba944ac95" />

## Antes

<img width="363" height="316" alt="Captura de Tela 2026-06-28 às 00 53 02" src="https://github.com/user-attachments/assets/d32e4508-148c-4a54-a0a2-af00d104f7b5" />

<img width="386" height="342" alt="Captura de Tela 2026-06-28 às 00 54 48" src="https://github.com/user-attachments/assets/8894a340-276a-40e1-9b22-460b6cfe8909" />

## Depois

<img width="339" height="403" alt="Captura de Tela 2026-06-28 às 00 53 23" src="https://github.com/user-attachments/assets/294a84e3-2dca-4c9f-b2b9-3d04c4cadb6d" />

<img width="376" height="291" alt="Captura de Tela 2026-06-28 às 00 55 28" src="https://github.com/user-attachments/assets/f0adcb35-1beb-44a2-90b3-22e9fe27a7de" />