### PR TITLE
Corrige cast de job_id em executeJob para usar pk inteiro

### DIFF
--- a/src/core/App.php
+++ b/src/core/App.php
@@ -2515,7 +2515,7 @@ class App
             $this->applyHookBoundTo($this, "app.executeJob:after");
             // $this->enableAccessControl();
             $this->persistPCachePendingQueue();
-            return (int) $job_id;
+            return (int) $job->pk;
         } else {
             return false;
         }


### PR DESCRIPTION
# Corrige cast de job_id em executeJob para usar pk inteiro

## context

`App::executeJob()` é o dispatcher central de jobs assíncronos do Mapas Culturais. 
É chamado em loop (`while ($app->executeJob())`) pelos workers de background (`docker/jobs-cron.sh`) e por qualquer código que precise processar a fila de jobs pendentes, incluindo integrações externas como o plugin AldirBlanc.

## O problema

`executeJob()` retornava `(int) $job_id`, onde `$job_id` é o campo `id` da entidade `Job` — uma string MD5 gerada no momento da criação do job.

Strings MD5 que começam com um dígito hexadecimal de letra (`a`–`f`) são interpretadas pelo cast `(int)` do PHP como `0`. Zero é falsy, então o loop `while ($app->executeJob())` encerrava imediatamente ao encontrar qualquer job cujo hash começasse com letra — sem erro, sem log, sem aviso.

Em amostra de produção (20 jobs), ~40% dos jobs tinham `(int) id == 0`, confirmando que a perda era sistemática e silenciosa.

## A solução

Substituir `$job_id` por `$job->pk` no retorno de `executeJob()`.

`pk` é a chave primária inteira da tabela (`SERIAL` no Postgres, mapeada como `@ORM\GeneratedValue(strategy="SEQUENCE")` no Doctrine). Sempre um inteiro positivo sequencial — nunca zero, nunca uma string com letras.

```php
// antes
return (int) $job_id;

// depois
return (int) $job->pk;
```

`$job` já estava carregado no escopo neste ponto (`findOneBy(["id" => $job_id])`), portanto nenhuma query adicional é necessária. O branch `else` existente (que retorna `false`) continua cobrindo o caso em que nenhum job elegível existe na fila.
