### PR TITLE
Correção do fatal ao exportar PDF de inscrição com campo de endereço

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,10 @@ Todas as mudanças notáveis no projeto serão documentadas neste arquivo.
 O formato é baseado no [Keep a Changelog](https://keepachangelog.com/pt-BR/1.0.0/)
 e este projeto adere ao [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+### Correções
+- Corrige a exportação do PDF da inscrição que falhava quando havia campo de múltiplos endereços, passando a exibir os endereços em lista
+
 ## [7.8.0] - 2026-07-02
 ### Novas Funcionalidades
 - Módulo de **fase de execução** para acompanhar projetos aprovados após o resultado. O agente contemplado pode abrir pedidos de alteração (data, orçamento, local etc.), cada um avaliado por uma comissão. Os pedidos ficam registrados no histórico e não atrapalham as fases seguintes de prestação de informações

--- a/src/modules/Opportunities/views/registration/pdf.php
+++ b/src/modules/Opportunities/views/registration/pdf.php
@@ -171,7 +171,29 @@ $opportunity->registerRegistrationMetadata();
                 <div class="field">
                     <span class="field-label"><?= $config->required ? '* ' : '' ?><?= htmlspecialchars($config->title) ?>:</span>
                     <span class="field-value">
-                        <?php if (is_array($value)): ?>
+                        <?php if ($config->fieldType === 'addresses' && is_array($value)): ?>
+                            <ul class="address-list">
+                                <?php foreach ($value as $address): ?>
+                                    <?php
+                                        $address = (object) $address;
+                                        $line = sprintf(
+                                            '%s, nº %s — %s, %s/%s, %s',
+                                            $address->logradouro ?? '',
+                                            $address->numero ?? '',
+                                            $address->bairro ?? '',
+                                            $address->cidade ?? '',
+                                            $address->estado ?? '',
+                                            $address->cep ?? ''
+                                        );
+                                        $complemento = $address->complemento ?? '';
+                                        if ($complemento !== '') {
+                                            $line .= sprintf(' (%s)', $complemento);
+                                        }
+                                    ?>
+                                    <li><?= htmlspecialchars($line) ?></li>
+                                <?php endforeach; ?>
+                            </ul>
+                        <?php elseif (is_array($value)): ?>
                             <?= htmlspecialchars(implode(', ', $value)) ?>
                         <?php elseif (is_object($value)): ?>
                             <?= htmlspecialchars(json_encode($value, JSON_UNESCAPED_UNICODE)) ?>


### PR DESCRIPTION
# Correção do fatal ao exportar PDF de inscrição com campo de múltiplos endereços

## Cenário

Ao exportar o PDF de uma inscrição (`GET registration.exportPDF`, rota `/inscricao-exportar-pdf/{id}/`) que possui um campo de múltiplos endereços, a requisição quebrava com o fatal `Object of class stdClass could not be converted to string`, mapeado no Sentry. A causa está na view `src/modules/Opportunities/views/registration/pdf.php`: ao renderizar o valor de cada campo, o código tratava o caso `is_array($value)` fazendo `implode(', ', $value)`. O campo de múltiplos endereços (tipo `addresses`) é desserializado via `json_decode` e chega como um array cujos elementos são objetos `stdClass` (cada endereço com as chaves `nome`, `cep`, `logradouro`, `numero`, `bairro`, `complemento`, `estado`, `cidade`). O `implode` tenta converter cada `stdClass` para string e dispara o erro fatal, interrompendo a geração do PDF.

<img width="1327" height="360" alt="image" src="https://github.com/user-attachments/assets/365572f3-5d25-4023-a4dd-ce57124a94a4" />


```
Mapa da Cultura

*MESSAGE*: `Object of class stdClass could not be converted to string`

UserID: 567778

*ROUTE*:  GET registration.exportPDF
*URI*: /inscricao-exportar-pdf/1685999164/
```

## Implementação

Foi adicionado um ramo dedicado na view, ativado apenas quando `$config->fieldType === 'addresses'` e o valor é um array, mantendo o escopo restrito ao campo de múltiplos endereços. Cada endereço é renderizado como um item de lista (`ul > li`), suportando múltiplos endereços, no formato `Logradouro, nº Número — Bairro, Cidade/Estado, CEP (Complemento)`. Os subcampos obrigatórios são exibidos mesmo quando vazios (preservando a estrutura da linha), enquanto o complemento, por ser opcional, só é anexado entre parênteses quando efetivamente preenchido — evitando um ` ()` pendurado no fim da linha. Os ramos genéricos existentes (`implode`, `json_encode`, `nl2br`) permanecem intactos: o endereço apenas deixa de chegar ao `implode`, que era a origem do fatal.

## Prints

<img width="659" height="274" alt="image" src="https://github.com/user-attachments/assets/f214f11b-e062-4989-9941-acf88d034cb4" />
