### PR TITLE
Fix/angular number config normalization

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,10 @@ Todas as mudanças notáveis no projeto serão documentadas neste arquivo.
 O formato é baseado no [Keep a Changelog](https://keepachangelog.com/pt-BR/1.0.0/)
 e este projeto adere ao [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+### Correções
+- Corrige erro na configuração de formulário causado por valores numéricos salvos como texto em campos de limite de opções, linhas e arquivos
+
 ## [7.8.0] - 2026-07-02
 ### Novas Funcionalidades
 - Módulo de **fase de execução** para acompanhar projetos aprovados após o resultado. O agente contemplado pode abrir pedidos de alteração (data, orçamento, local etc.), cada um avaliado por uma comissão. Os pedidos ficam registrados no histórico e não atrapalham as fases seguintes de prestação de informações

--- a/src/themes/BaseV1/assets/js/ng.entity.module.opportunity.js
+++ b/src/themes/BaseV1/assets/js/ng.entity.module.opportunity.js
@@ -35,6 +35,32 @@
         return field.groupName || field.fieldName || ('id-' + field.id);
     }
 
+    var NUMERIC_FIELD_CONFIG_KEYS = ['maxOptions', 'minRows', 'maxRows', 'maxFiles', 'maxVideos'];
+
+    function normalizeNumericFieldConfig(config) {
+        if (!config || typeof config !== 'object' || Array.isArray(config)) {
+            return;
+        }
+
+        NUMERIC_FIELD_CONFIG_KEYS.forEach(function(key) {
+            var value = config[key];
+
+            if (typeof value !== 'string') {
+                return;
+            }
+
+            var trimmed = value.trim();
+            if (trimmed === '') {
+                return;
+            }
+
+            var numberValue = Number(trimmed);
+            if (Number.isFinite(numberValue)) {
+                config[key] = numberValue;
+            }
+        });
+    }
+
     function _getStatusSlug(status) {
         switch (status) {
             case 0: return 'draft'; break;
@@ -207,6 +233,7 @@
                     if (typeof field.config !== 'object' || field.config instanceof Array) {
                         field.config = {};
                     }
+                    normalizeNumericFieldConfig(field.config);
 
                     // Suporte ao novo formato (Brazil/Other) e retrocompatibilidade (requiredAddressFields)
                     if (field.config && field.config.entityField === '@location') {
@@ -518,6 +545,7 @@ module.controller('RegistrationConfigurationsController', ['$scope', '$rootScope
         if (typeof field.config !== 'object' || field.config instanceof Array) {
             field.config = {};
         }
+        normalizeNumericFieldConfig(field.config);
         if (field.config && field.config.entityField === '@location') {
             // Suporta novo formato (Brazil/Other) ou legado
             var hasBrazil = field.config.requiredAddressFieldsBrazil !== undefined;
@@ -634,6 +662,8 @@ module.controller('RegistrationConfigurationsController', ['$scope', '$rootScope
             } else if (typeof config !== 'object' || Array.isArray(config)) {
                 field.config = {};
             }
+
+            normalizeNumericFieldConfig(field.config);
         }
 
         function normalizeFieldOptionsForDisplay(field) {


### PR DESCRIPTION
# Corrige erro ngModel:numfmt na configuração de formulário

## Resumo

Corrige erro na tela de configuração de formulário de oportunidades quando campos numéricos eram carregados com valores salvos como texto.

## Erro corrigido

Na tela `/configuracao-de-formulario/XX/`, o AngularJS exibia o erro abaixo:

```text
Error: [ngModel:numfmt] Expected `1` to be a number
http://errors.angularjs.org/1.5.5/ngModel/numfmt?p0=1
```

O problema acontecia porque alguns `<input type="number">` recebiam valores como `"1"` em vez de `1`.
