### PR TITLE
Corrige a validação da resposta do recurso em avaliações contínuas para impedir que o avaliador conclua ou envie a avaliação sem selecionar o status da inscrição

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,10 @@ Todas as mudanças notáveis no projeto serão documentadas neste arquivo.
 O formato é baseado no [Keep a Changelog](https://keepachangelog.com/pt-BR/1.0.0/)
 e este projeto adere ao [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+### Correções
+- Corrige a validação da resposta do recurso para impedir concluir ou enviar avaliação contínua sem selecionar o status da inscrição
+
 ## [7.8.0] - 2026-07-02
 ### Novas Funcionalidades
 - Módulo de **fase de execução** para acompanhar projetos aprovados após o resultado. O agente contemplado pode abrir pedidos de alteração (data, orçamento, local etc.), cada um avaliado por uma comissão. Os pedidos ficam registrados no histórico e não atrapalham as fases seguintes de prestação de informações

--- a/src/modules/EvaluationMethodContinuous/Module.php
+++ b/src/modules/EvaluationMethodContinuous/Module.php
@@ -138,14 +138,12 @@ class Module extends \MapasCulturais\EvaluationMethod
     {   
         $errors = [];
 
-        foreach($data as $key => $val){
-            if($key === i::__('status') && !trim($val)) {
-                $errors[] = i::__('O campo Status é obrigatório');
-            }
-            
-            if($key === i::__('obs') && !trim($val)) {
-                $errors[] = i::__('O campo Observações é obrigatório');
-            }
+        if (!array_key_exists('status', $data) || trim((string) $data['status']) === '') {
+            $errors[] = i::__('O campo Status é obrigatório');
+        }
+
+        if (!array_key_exists('obs', $data) || trim((string) $data['obs']) === '') {
+            $errors[] = i::__('O campo Observações é obrigatório');
         }
 
         return $errors;

--- a/src/modules/EvaluationMethodContinuous/components/continuous-evaluation-form/script.js
+++ b/src/modules/EvaluationMethodContinuous/components/continuous-evaluation-form/script.js
@@ -32,8 +32,8 @@ app.component('continuous-evaluation-form', {
     },
 
     created() {
-        this.formData['data'] = {};
-        const formData = this.evaluationData || this.skeleton();
+        this.formData['data'] = this.skeleton().data;
+        const formData = this.evaluationData;
 
         for (let key in formData.data) {
             this.formData.data[key] = formData.data[key];
@@ -155,8 +155,9 @@ app.component('continuous-evaluation-form', {
             let error = false;
             const global = useGlobalState();
 
-            Object.keys(this.formData.data).forEach(key => {
-                if (!this.formData.data[key] || this.formData.data[key] === '') {
+            ['status', 'obs'].forEach(key => {
+                const value = this.formData.data[key];
+                if (value === null || value === undefined || String(value).trim() === '') {
                     messages.error(this.text('emptyField') + ' ' + this.dictFields(key) + ' ' + this.text('required'));
                     error = true;
                 }

--- a/tests/src/EvaluationRoutesTest.php
+++ b/tests/src/EvaluationRoutesTest.php
@@ -152,6 +152,65 @@ class EvaluationRoutesTest extends Abstract\TestCase
         $this->assertNotNull($evaluation_id, 'Garantindo que DEPOIS de salvar a avaliação pela rota /registration/saveEvaluation a avaliação foi criada e o id da avaliação NÃO é mais NULL');
     }
 
+    function testContinuousEvaluationRequiresStatusWhenFinishing()
+    {
+        $admin = $this->userDirector->createUser('admin');
+        $this->login($admin);
+
+        $opportunity = $this->opportunityBuilder
+            ->reset(owner: $admin->profile, owner_entity: $admin->profile)
+            ->fillRequiredProperties()
+            ->firstPhase()
+                ->setRegistrationPeriod(new Open)
+                ->done()
+            ->save()
+            ->addEvaluationPhase(EvaluationMethods::simple)
+                ->setEvaluationPeriod(new ConcurrentEndingAfter)
+                ->setCommitteeValuersPerRegistration('committee 1', 1)
+                ->save()
+                ->addValuers(2, 'committee 1')
+                ->done()
+            ->getInstance();
+
+        $opportunity->evaluationMethodConfiguration->type = 'continuous';
+        $opportunity->evaluationMethodConfiguration->save(true);
+
+        $registration = $this->registrationDirector->createSentRegistration(
+            $opportunity,
+            data: []
+        );
+
+        $committee = $opportunity->evaluationMethodConfiguration->relatedAgents['committee 1'];
+
+        $opportunity->evaluationMethodConfiguration->redistributeCommitteeRegistrations();
+
+        $registration = $registration->refreshed();
+
+        $valuer_user_id = array_keys($registration->valuers)[0];
+
+        foreach ($committee as $valuer) {
+            if ($valuer->user->id == $valuer_user_id) {
+                $registration_valuer = $valuer->user->refreshed();
+            }
+        }
+
+        $this->login($registration_valuer);
+
+        $request = $this->requestFactory->POST(
+            controller_id: 'registration',
+            action: 'saveEvaluation',
+            url_params: [
+                'id' => $registration->id,
+                'status' => 'evaluated'
+            ],
+            payload: [
+                'data' => []
+            ]
+        );
+
+        $this->assertStatus400($request, 'Garantindo que avaliação contínua finalizada sem status retorna 400');
+    }
+
     function testValuerAccessToAnotherValuerRegistration()
     {
         $admin = $this->userDirector->createUser('admin');


### PR DESCRIPTION
## Resumo

Corrige a validação da resposta do recurso em avaliações contínuas para impedir que o avaliador conclua ou envie a avaliação sem selecionar o status da inscrição.

## O que foi alterado

- A avaliação contínua agora inicializa o formulário com os campos esperados (`status`, `obs`, `uid`), evitando payload vazio.
- A validação no frontend passa a verificar explicitamente `status` e `obs`.
- A validação no backend passa a bloquear avaliações finalizadas sem `status` ou `obs`, mesmo quando as chaves não vêm no payload.
- Adicionado teste cobrindo a tentativa de finalizar avaliação contínua sem status.