### PR TITLE
Fix/google oauth profile scope

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ e este projeto adere ao [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 ## [Unreleased]
 ### Correções
 - Corrige a listagem de fases da oportunidade para exibir corretamente fases de avaliação na configuração
+- Corrige login via Google que não salvava o nome do usuário no perfil, por não solicitar o escopo de perfil na autenticação
 
 ## [7.8.0] - 2026-07-02
 ### Novas Funcionalidades

--- a/config/authentication.php
+++ b/config/authentication.php
@@ -24,6 +24,7 @@ return [
                 'client_secret' => env('AUTH_GOOGLE_CLIENT_SECRET', null),
                 'redirect_uri' => env('BASE_URL', '') . 'autenticacao/google/oauth2callback',
                 'scope' => env('AUTH_GOOGLE_SCOPE', 'email profile'),
+                'prompt' => env('AUTH_GOOGLE_PROMPT', null),
             ],
 
             'LinkedIn' => [

--- a/config/authentication.php
+++ b/config/authentication.php
@@ -23,7 +23,7 @@ return [
                 'client_id' => env('AUTH_GOOGLE_CLIENT_ID', null),
                 'client_secret' => env('AUTH_GOOGLE_CLIENT_SECRET', null),
                 'redirect_uri' => env('BASE_URL', '') . 'autenticacao/google/oauth2callback',
-                'scope' => env('AUTH_GOOGLE_SCOPE', 'email'),
+                'scope' => env('AUTH_GOOGLE_SCOPE', 'email profile'),
             ],
 
             'LinkedIn' => [

--- a/dev/config.d/auth.php
+++ b/dev/config.d/auth.php
@@ -23,7 +23,7 @@ return [
                 'client_id' => env('AUTH_GOOGLE_CLIENT_ID', null),
                 'client_secret' => env('AUTH_GOOGLE_CLIENT_SECRET', null),
                 'redirect_uri' => '/autenticacao/google/oauth2callback',
-                'scope' => env('AUTH_GOOGLE_SCOPE', 'email'),
+                'scope' => env('AUTH_GOOGLE_SCOPE', 'email profile'),
             ],
             'Twitter' => [
                 'app_id' => env('AUTH_TWITTER_APP_ID', null),

--- a/dev/config.d/auth.php
+++ b/dev/config.d/auth.php
@@ -24,6 +24,7 @@ return [
                 'client_secret' => env('AUTH_GOOGLE_CLIENT_SECRET', null),
                 'redirect_uri' => '/autenticacao/google/oauth2callback',
                 'scope' => env('AUTH_GOOGLE_SCOPE', 'email profile'),
+                'prompt' => env('AUTH_GOOGLE_PROMPT', null),
             ],
             'Twitter' => [
                 'app_id' => env('AUTH_TWITTER_APP_ID', null),


### PR DESCRIPTION
## Problema

Login via Google não trazia o nome do usuário para o sistema (campo "Nome do Agente" ficava vazio no perfil).

Causa raiz: o escopo padrão configurado em `config/authentication.php` e `dev/config.d/auth.php` era `env('AUTH_GOOGLE_SCOPE', 'email')` — sem `profile`. Como a chave `strategies.Google` já vinha totalmente definida aqui, o default interno do plugin (`email profile`) nunca era usado. Com isso, o Google só concedia acesso a `email` e `openid`, e a API `userinfo` nunca retornava `name`, `given_name` ou `family_name`.

Confirmado em produção: captura da URL de callback do OAuth mostrou `scope=email https://www.googleapis.com/auth/userinfo.email openid`, sem `profile`.

## Mudanças

- Corrige o fallback de `AUTH_GOOGLE_SCOPE` para `'email profile'` em `config/authentication.php` e `dev/config.d/auth.php`.
- Adiciona a variável `AUTH_GOOGLE_PROMPT` (default `null`, ou seja, sem alterar o comportamento atual). Quando setada como `consent`, força a tela de consentimento do Google em todo login — útil para fazer usuários que já autorizaram o app com o escopo antigo (só `email`) re-autorizarem com o escopo completo, já que o Google não pede permissão nova automaticamente em logins silenciosos.

## Ação necessária no deploy

- Conferir se `AUTH_GOOGLE_SCOPE` está definida no `.env` de produção. Se estiver setada como `email` (sem `profile`), precisa ser removida ou alterada para `email profile` — env sempre tem prioridade sobre o fallback do código.
- Opcional: setar `AUTH_GOOGLE_PROMPT=consent` temporariamente após o deploy, para forçar o re-consentimento de usuários que já logaram via Google antes dessa correção. Pode ser removida depois que a base de usuários existente já tiver re-autorizado.

## Depende de / relacionado

Complementa o fix no plugin `MultipleLocalAuth` (branch `fix/google-agent-name-sync`), que adiciona a sincronização do nome/e-mail do perfil a cada login via Google.
