### PR TITLE
corrige chave da aba de entidades no painel

### DIFF
--- a/src/modules/Panel/components/panel--entity-tabs/template.php
+++ b/src/modules/Panel/components/panel--entity-tabs/template.php
@@ -48,7 +48,7 @@ $this->applyComponentHook('.sortOptions', [&$tabs]);
     </template>
     <?php foreach($tabs as $status => $label): ?>
     <?php $this->applyComponentHook($status, 'before') ?>
-    <mc-tab v-if="showTab('<?=$status?>')" cache key="<?$status?>" label="<?=$label?>" slug="<?=$status?>">
+    <mc-tab v-if="showTab('<?=$status?>')" cache key="<?=$status?>" label="<?=$label?>" slug="<?=$status?>">
         <?php $this->applyComponentHook($status, 'begin') ?>
         <mc-entities :name="type + ':<?=$status?>'" :type="type" 
             :select="select"


### PR DESCRIPTION
## Descrição

Corrige a geração da propriedade `key` das abas de entidades no painel.

## Problema

A variável `$status` estava sendo utilizada sem o operador de saída do PHP:

```php
key="<?$status?>"
```

Com isso, a chave da aba não recebia corretamente o status correspondente.

## Solução

Alterada a expressão para utilizar a short echo tag:

```php
key="<?=$status?>"
```
