### PR TITLE
feat: hook de comparador customizado na distribuição de avaliações

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,10 @@ Todas as mudanças notáveis no projeto serão documentadas neste arquivo.
 O formato é baseado no [Keep a Changelog](https://keepachangelog.com/pt-BR/1.0.0/)
 e este projeto adere ao [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [UNRELEASED]
+### Melhorias não funcionais
+- Adiciona hook `evaluationMethod.distributionComparator` para permitir que temas personalizem a ordem de prioridade dos avaliadores durante a redistribuição de comissões
+
 ## [7.8.0] - 2026-07-02
 ### Novas Funcionalidades
 - Módulo de **fase de execução** para acompanhar projetos aprovados após o resultado. O agente contemplado pode abrir pedidos de alteração (data, orçamento, local etc.), cada um avaliado por uma comissão. Os pedidos ficam registrados no histórico e não atrapalham as fases seguintes de prestação de informações

--- a/src/core/EvaluationMethod.php
+++ b/src/core/EvaluationMethod.php
@@ -750,6 +750,11 @@ abstract class EvaluationMethod extends Module implements \JsonSerializable{
 
         $evaluation_config = $opportunity->evaluationMethodConfiguration;
 
+        // Permite que temas e plugins especializem somente a ordem dos avaliadores.
+        // Sem um callable, ou quando ele retorna null, o balanceamento por quotas permanece inalterado.
+        $distribution_comparator = null;
+        $app->applyHookBoundTo($this, 'evaluationMethod.distributionComparator', [&$distribution_comparator, $opportunity]);
+
         /** @var Connection */
         $conn = $app->em->getConnection();
 
@@ -778,6 +783,10 @@ abstract class EvaluationMethod extends Module implements \JsonSerializable{
          * @var bool[][]
          **/
         $registration_list_exclusive_per_valuer = [];
+
+        // Conta somente as atribuições criadas nesta redistribuição. Avaliações já existentes
+        // continuam preservadas pelo fluxo abaixo, mas não entram neste contador separado.
+        $pending_assignments_count = [];
 
         foreach($evaluation_config->getAgentRelationsGrouped() as $committee => $agent_relations) {
             $registrations_per_valuer[$committee] = $registrations_per_valuer[$committee] ?? [];
@@ -1060,6 +1069,10 @@ abstract class EvaluationMethod extends Module implements \JsonSerializable{
                     // atualiza o número de avaliadores da inscrição
                     $valuers_committee_registrations_count[$committee_name][$user_id]++;
 
+                    // Inclusões manuais também compõem a carga pendente da rodada.
+                    $pending_assignments_count[$committee_name][$user_id] =
+                        ($pending_assignments_count[$committee_name][$user_id] ?? 0) + 1;
+
                     // incrementa o número de avaliações que a inscrição tem por comissão
                     $registration_valuers_count[$registration->id][$committee_name]++;
 
@@ -1095,7 +1108,7 @@ abstract class EvaluationMethod extends Module implements \JsonSerializable{
                     }
                 }
 
-                usort($users, function($u1, $u2) use ($registration, $registration_lists_per_valuer, $registration_list_exclusive_per_valuer, $committee_name, $valuers_committee_registrations_count, $committee_quotas) {
+                usort($users, function($u1, $u2) use ($registration, $registration_lists_per_valuer, $registration_list_exclusive_per_valuer, $committee_name, $valuers_committee_registrations_count, $committee_quotas, $distribution_comparator, $pending_assignments_count) {
                     $registration_number = $registration->number;
 
                     $list1 = $registration_lists_per_valuer[$committee_name][$u1->id] ?? [];
@@ -1120,6 +1133,21 @@ abstract class EvaluationMethod extends Module implements \JsonSerializable{
                     // Quem tiver prioridade maior vem antes; em empate, segue as quotas.
                     if($priority1 !== $priority2) {
                         return $priority2 <=> $priority1;
+                    }
+
+                    // O comparador personalizado atua depois das prioridades de lista. Ao retornar
+                    // null, delega a decisão para a ordenação por quotas já existente no core.
+                    if(is_callable($distribution_comparator)) {
+                        $custom_result = $distribution_comparator(
+                            $u1,
+                            $u2,
+                            $committee_name,
+                            $pending_assignments_count[$committee_name] ?? []
+                        );
+
+                        if($custom_result !== null) {
+                            return (int) $custom_result;
+                        }
                     }
 
                     // Se há quotas calculadas para esta comissão, ordena por espaço restante na quota
@@ -1193,6 +1221,10 @@ abstract class EvaluationMethod extends Module implements \JsonSerializable{
 
                     // atualiza o número de avaliações do usuário
                     $valuers_committee_registrations_count[$committee_name][$user->id]++;
+
+                    // Atualiza a carga usada pelo comparador nas próximas inscrições da comissão.
+                    $pending_assignments_count[$committee_name][$user->id] =
+                        ($pending_assignments_count[$committee_name][$user->id] ?? 0) + 1;
 
                     // incrementa o número de avaliações que a inscrição tem por comissão
                     $registration_valuers_count[$registration->id][$committee_name]++;

--- a/src/core/EvaluationMethod.php
+++ b/src/core/EvaluationMethod.php
@@ -1150,6 +1150,11 @@ abstract class EvaluationMethod extends Module implements \JsonSerializable{
                         }
                     }
 
+                    // Ordena por contagem na comissão
+                    $count1 = $valuers_committee_registrations_count[$committee_name][$u1->id] ?? 0;
+                    $count2 = $valuers_committee_registrations_count[$committee_name][$u2->id] ?? 0;
+                    $result = $count1 <=> $count2;
+
                     // Se há quotas calculadas para esta comissão, ordena por espaço restante na quota
                     if(isset($committee_quotas[$committee_name])) {
                         $current1 = $valuers_committee_registrations_count[$committee_name][$u1->id] ?? 0;
@@ -1162,14 +1167,11 @@ abstract class EvaluationMethod extends Module implements \JsonSerializable{
                         $remaining2 = $quota2 - $current2;
                         
                         if($remaining1 !== $remaining2) {
-                            return $remaining2 <=> $remaining1;
+                            $result = $remaining2 <=> $remaining1;
                         }
                     }
-                    
-                    // Fallback: ordena por contagem na comissão (quem tem menos vem primeiro)
-                    $count1 = $valuers_committee_registrations_count[$committee_name][$u1->id] ?? 0;
-                    $count2 = $valuers_committee_registrations_count[$committee_name][$u2->id] ?? 0;
-                    return $count1 <=> $count2;
+
+                    return $result;
                 });
                 
                 // adiciona os avaliadores da comissão na inscrição

--- a/tests/src/EvaluationsDistributionTest.php
+++ b/tests/src/EvaluationsDistributionTest.php
@@ -15,6 +15,7 @@ use Tests\Builders\PhasePeriods\Past;
 use Tests\Builders\PhasePeriods\After;
 use Tests\Traits\RegistrationDirector;
 use MapasCulturais\Entities\Opportunity;
+use MapasCulturais\Entities\User;
 use MapasCulturais\Entities\RegistrationEvaluation;
 use Tests\Builders\PhasePeriods\ConcurrentEndingAfter;
 use MapasCulturais\Entities\EvaluationMethodConfiguration;
@@ -2511,5 +2512,473 @@ class EvaluationsDistributionTest extends TestCase
             'Garantindo que o total de avaliações na fase corresponde a 3 por inscrição'
         );
     }
-     
+
+    function testCustomDistributionComparatorBalancesPendingAssignmentsPerCommittee()
+    {
+        $admin = $this->userDirector->createUser('admin');
+        $this->login($admin);
+
+        $opportunity = $this->opportunityBuilder
+            ->reset(owner: $admin->profile, owner_entity: $admin->profile)
+            ->fillRequiredProperties()
+            ->firstPhase()
+                ->setRegistrationPeriod(new Open)
+                ->done()
+            ->save()
+            ->createSentRegistrations(35)
+            ->addEvaluationPhase(EvaluationMethods::simple)
+                ->setEvaluationPeriod(new ConcurrentEndingAfter)
+                ->setCommitteeValuersPerRegistration('committee 1', 1)
+                ->save()
+                ->addValuer('committee 1', name: 'avaliador01')->done()
+                ->addValuer('committee 1', name: 'avaliador02')->done()
+                ->addValuer('committee 1', name: 'avaliador03')->done()
+                ->addValuer('committee 1', name: 'avaliador04')->done()
+                ->done()
+            ->getInstance();
+
+        $emc = $opportunity->evaluationMethodConfiguration;
+        $emc->ignoreStartedEvaluations = (object) ['committee 1' => true];
+        $emc->save(true);
+
+        $registrations = $this->app->repo('Registration')->findBy(
+            ['opportunity' => $opportunity],
+            ['id' => 'ASC']
+        );
+        $relations = $emc->agentRelations;
+        $historical_counts = [5, 1, 4, 2];
+        $historical_statuses = [
+            RegistrationEvaluation::STATUS_DRAFT,
+            RegistrationEvaluation::STATUS_EVALUATED,
+            RegistrationEvaluation::STATUS_SENT,
+        ];
+        $historical_registration_ids = [];
+        $offset = 0;
+
+        $this->app->disableAccessControl();
+        try {
+            foreach ($historical_counts as $relation_index => $count) {
+                $user = $relations[$relation_index]->agent->user;
+
+                for ($i = 0; $i < $count; $i++) {
+                    $registration = $registrations[$offset++];
+                    $historical_registration_ids[$registration->id] = $user->id;
+
+                    $evaluation = new RegistrationEvaluation();
+                    $evaluation->registration = $registration;
+                    $evaluation->user = $user;
+                    $evaluation->committee = 'committee 1';
+                    $evaluation->evaluationData = ['status' => null];
+                    $evaluation->status = $historical_statuses[$offset % count($historical_statuses)];
+                    $evaluation->save(true);
+                }
+            }
+        } finally {
+            $this->app->enableAccessControl();
+        }
+
+        $target_opportunity_id = $opportunity->id;
+        $this->app->hook('evaluationMethod.distributionComparator', function (&$comparator, Opportunity $hook_opportunity) use ($target_opportunity_id) {
+            if ($hook_opportunity->id !== $target_opportunity_id) {
+                return;
+            }
+
+            $comparator = function (User $valuer1, User $valuer2, string $committee, array $pending_assignments): ?int {
+                $pending1 = $pending_assignments[$valuer1->id] ?? 0;
+                $pending2 = $pending_assignments[$valuer2->id] ?? 0;
+
+                if ($pending1 !== $pending2) {
+                    return $pending1 <=> $pending2;
+                }
+
+                return $valuer1->id <=> $valuer2->id;
+            };
+        });
+
+        $emc->redistributeCommitteeRegistrations();
+
+        $pending_by_user = [];
+        foreach ($relations as $relation) {
+            $pending_by_user[$relation->agent->user->id] = 0;
+        }
+
+        foreach ($registrations as $registration) {
+            $registration = $registration->refreshed();
+            $valuers = (array) $registration->valuers;
+
+            if (isset($historical_registration_ids[$registration->id])) {
+                $this->assertArrayHasKey(
+                    $historical_registration_ids[$registration->id],
+                    $valuers,
+                    'A redistribuição deve preservar todas as avaliações existentes'
+                );
+                $this->assertCount(1, $valuers);
+                continue;
+            }
+
+            $this->assertCount(1, $valuers);
+            $pending_by_user[(int) array_key_first($valuers)]++;
+        }
+
+        sort($pending_by_user);
+        $this->assertSame([5, 6, 6, 6], array_values($pending_by_user));
+    }
+
+    function testManualInclusionCountsTowardCustomComparatorPendingAssignments()
+    {
+        $admin = $this->userDirector->createUser('admin');
+        $this->login($admin);
+
+        $opportunity = $this->opportunityBuilder
+            ->reset(owner: $admin->profile, owner_entity: $admin->profile)
+            ->fillRequiredProperties()
+            ->firstPhase()
+                ->setRegistrationPeriod(new Open)
+                ->done()
+            ->save()
+            ->addEvaluationPhase(EvaluationMethods::simple)
+                ->setEvaluationPeriod(new ConcurrentEndingAfter)
+                ->setCommitteeValuersPerRegistration('committee 1', 1)
+                ->save()
+                ->addValuer('committee 1', name: 'valuerA')->done()
+                ->addValuer('committee 1', name: 'valuerB')->done()
+                ->done()
+            ->getInstance();
+
+        $this->registrationDirector->createSentRegistrations(
+            $opportunity,
+            number_of_registrations: 2
+        );
+
+        $emc = $opportunity->evaluationMethodConfiguration;
+        $relations = $emc->agentRelations;
+        $valuerA_user_id = $relations[0]->agent->user->id;
+        $valuerB_user_id = $relations[1]->agent->user->id;
+
+        $registrations = $this->app->repo('Registration')->findBy(
+            ['opportunity' => $opportunity],
+            ['id' => 'ASC']
+        );
+
+        /** @var Connection */
+        $conn = $this->app->em->getConnection();
+
+        // Força a inclusão manual do avaliador A na primeira inscrição, fora do fluxo normal do usort.
+        // Usa SQL direto (como o próprio core faz ao persistir `valuers`) porque
+        // Registration::setValuersIncludeList muta o objeto interno in-place e o
+        // Doctrine, ao comparar por identidade, não detecta a mudança no flush.
+        $conn->update(
+            'registration',
+            ['valuers_exceptions_list' => json_encode(['include' => [$valuerA_user_id], 'exclude' => []])],
+            ['id' => $registrations[0]->id]
+        );
+
+        $target_opportunity_id = $opportunity->id;
+        $this->app->hook('evaluationMethod.distributionComparator', function (&$comparator, Opportunity $hook_opportunity) use ($target_opportunity_id) {
+            if ($hook_opportunity->id !== $target_opportunity_id) {
+                return;
+            }
+
+            $comparator = function (object $valuer1, object $valuer2, string $committee, array $pending_assignments): ?int {
+                $pending1 = $pending_assignments[$valuer1->id] ?? 0;
+                $pending2 = $pending_assignments[$valuer2->id] ?? 0;
+
+                if ($pending1 !== $pending2) {
+                    return $pending1 <=> $pending2;
+                }
+
+                return $valuer1->id <=> $valuer2->id;
+            };
+        });
+
+        $emc->redistributeCommitteeRegistrations();
+
+        $registration_0 = $registrations[0]->refreshed();
+        $registration_1 = $registrations[1]->refreshed();
+
+        $valuers_0 = array_map('intval', array_keys((array) $registration_0->valuers));
+        $valuers_1 = array_map('intval', array_keys((array) $registration_1->valuers));
+
+        $this->assertEquals(
+            [$valuerA_user_id],
+            $valuers_0,
+            'A inclusão manual deve atribuir a primeira inscrição ao avaliador incluído'
+        );
+
+        $this->assertEquals(
+            [$valuerB_user_id],
+            $valuers_1,
+            'A carga da inclusão manual deve contar como pendência no comparador, fazendo a segunda inscrição ir para o avaliador B (sem pendências)'
+        );
+    }
+
+    function testCustomComparatorPendingAssignmentsAreIsolatedPerCommittee()
+    {
+        $admin = $this->userDirector->createUser('admin');
+        $this->login($admin);
+
+        $multi_valuer = $this->userDirector->createUser();
+
+        $opportunity = $this->opportunityBuilder
+            ->reset(owner: $admin->profile, owner_entity: $admin->profile)
+            ->fillRequiredProperties()
+            ->firstPhase()
+                ->setRegistrationPeriod(new Open)
+                ->done()
+            ->save()
+            ->addEvaluationPhase(EvaluationMethods::simple)
+                ->setEvaluationPeriod(new ConcurrentEndingAfter)
+                ->setCommitteeValuersPerRegistration('committee 1', 1)
+                ->setCommitteeValuersPerRegistration('committee 2', 1)
+                ->save()
+                ->addValuer('committee 1', 'multi', $multi_valuer->profile)->done()
+                ->addValuer('committee 1', name: 'uniqueA')->done()
+                ->addValuer('committee 2', 'multi', $multi_valuer->profile)->done()
+                ->addValuer('committee 2', name: 'uniqueB')->done()
+                ->done()
+            ->getInstance();
+
+        $this->registrationDirector->createSentRegistrations(
+            $opportunity,
+            number_of_registrations: 4
+        );
+
+        $target_opportunity_id = $opportunity->id;
+        $this->app->hook('evaluationMethod.distributionComparator', function (&$comparator, Opportunity $hook_opportunity) use ($target_opportunity_id) {
+            if ($hook_opportunity->id !== $target_opportunity_id) {
+                return;
+            }
+
+            $comparator = function (object $valuer1, object $valuer2, string $committee, array $pending_assignments): ?int {
+                $pending1 = $pending_assignments[$valuer1->id] ?? 0;
+                $pending2 = $pending_assignments[$valuer2->id] ?? 0;
+
+                if ($pending1 !== $pending2) {
+                    return $pending1 <=> $pending2;
+                }
+
+                return $valuer1->id <=> $valuer2->id;
+            };
+        });
+
+        $opportunity->evaluationMethodConfiguration->redistributeCommitteeRegistrations();
+
+        /** @var Connection */
+        $conn = $this->app->em->getConnection();
+
+        $count_per_committee = function (string $committee) use ($conn, $opportunity): array {
+            $rows = $conn->fetchAllAssociative(
+                "SELECT valuer_user_id, COUNT(*) AS total FROM evaluations WHERE opportunity_id = :opportunity_id AND valuer_committee = :committee GROUP BY valuer_user_id",
+                ['opportunity_id' => $opportunity->id, 'committee' => $committee]
+            );
+
+            $values = array_map(fn($row) => (int) $row['total'], $rows);
+            sort($values);
+
+            return $values;
+        };
+
+        $this->assertSame(
+            [2, 2],
+            $count_per_committee('committee 1'),
+            'A comissão 1 deve distribuir as 4 inscrições igualmente entre seus 2 avaliadores'
+        );
+
+        $this->assertSame(
+            [2, 2],
+            $count_per_committee('committee 2'),
+            'A comissão 2 deve distribuir as 4 inscrições igualmente entre seus 2 avaliadores, sem interferência da carga acumulada na comissão 1 pelo avaliador compartilhado'
+        );
+    }
+
+    function testCustomComparatorDoesNotBypassMaxRegistrationsPerValuerLimit()
+    {
+        $admin = $this->userDirector->createUser('admin');
+        $this->login($admin);
+
+        $max_registrations_valuerA = 2;
+
+        $opportunity = $this->opportunityBuilder
+            ->reset(owner: $admin->profile, owner_entity: $admin->profile)
+            ->fillRequiredProperties()
+            ->firstPhase()
+                ->setRegistrationPeriod(new Open)
+                ->done()
+            ->save()
+            ->createSentRegistrations(5)
+            ->addEvaluationPhase(EvaluationMethods::simple)
+                ->setEvaluationPeriod(new ConcurrentEndingAfter)
+                ->setCommitteeValuersPerRegistration('committee 1', 1)
+                ->save()
+                ->addValuer('committee 1', name: 'valuerA')
+                    ->maxRegistrations($max_registrations_valuerA)
+                    ->done()
+                ->addValuer('committee 1', name: 'valuerB')
+                    ->done()
+                ->done()
+            ->getInstance();
+
+        $emc = $opportunity->evaluationMethodConfiguration;
+        $valuerA_user_id = $emc->agentRelations[0]->agent->user->id;
+        $valuerB_user_id = $emc->agentRelations[1]->agent->user->id;
+
+        $target_opportunity_id = $opportunity->id;
+        $this->app->hook('evaluationMethod.distributionComparator', function (&$comparator, Opportunity $hook_opportunity) use ($target_opportunity_id, $valuerA_user_id) {
+            if ($hook_opportunity->id !== $target_opportunity_id) {
+                return;
+            }
+
+            // Comparador deliberadamente "trapaceiro": sempre tenta priorizar o avaliador A,
+            // ignorando a carga pendente, para provar que o limite (maxRegistrations) é
+            // aplicado de forma independente do critério de ordenação do comparador.
+            $comparator = function (object $v1, object $v2, string $committee, array $pending) use ($valuerA_user_id): ?int {
+                if ($v1->id === $valuerA_user_id) {
+                    return -1;
+                }
+                if ($v2->id === $valuerA_user_id) {
+                    return 1;
+                }
+                return 0;
+            };
+        });
+
+        $emc->redistributeCommitteeRegistrations();
+
+        /** @var Connection */
+        $conn = $this->app->em->getConnection();
+        $count = fn(int $user_id): int => (int) $conn->fetchScalar(
+            "SELECT COUNT(*) FROM evaluations WHERE opportunity_id = :opportunity_id AND valuer_user_id = :user_id",
+            ['opportunity_id' => $opportunity->id, 'user_id' => $user_id]
+        );
+
+        $this->assertEquals(
+            $max_registrations_valuerA,
+            $count($valuerA_user_id),
+            'Mesmo com o comparador sempre priorizando o avaliador A, o limite de maxRegistrations deve ser respeitado'
+        );
+
+        $this->assertEquals(
+            5 - $max_registrations_valuerA,
+            $count($valuerB_user_id),
+            'As inscrições que excedem o limite do avaliador A devem ser redirecionadas para o avaliador B'
+        );
+    }
+
+    private function buildDistributionComparatorContractScenario(): Opportunity
+    {
+        $admin = $this->userDirector->createUser('admin');
+        $this->login($admin);
+
+        $opportunity = $this->opportunityBuilder
+            ->reset(owner: $admin->profile, owner_entity: $admin->profile)
+            ->fillRequiredProperties()
+            ->firstPhase()
+                ->setRegistrationPeriod(new Open)
+                ->done()
+            ->save()
+            ->addEvaluationPhase(EvaluationMethods::simple)
+                ->setEvaluationPeriod(new ConcurrentEndingAfter)
+                ->setCommitteeValuersPerRegistration('committee 1', 1)
+                ->save()
+                ->addValuer('committee 1', name: 'valuerA')->done()
+                ->addValuer('committee 1', name: 'valuerB')->done()
+                ->done()
+            ->getInstance();
+
+        $this->registrationDirector->createSentRegistrations(
+            $opportunity,
+            number_of_registrations: 5
+        );
+
+        $emc = $opportunity->evaluationMethodConfiguration;
+        $valuerA = $emc->agentRelations[0]->agent->user;
+
+        $registrations = $this->app->repo('Registration')->findBy(
+            ['opportunity' => $opportunity],
+            ['id' => 'ASC']
+        );
+
+        // Cria 3 avaliações já concluídas do avaliador A, deixando-o à frente na contagem
+        // o suficiente para que as 2 pendências restantes nunca empatem com o avaliador B
+        // (evita depender do desempate não especificado do fallback por contagem do core).
+        $this->app->disableAccessControl();
+        try {
+            foreach (array_slice($registrations, 0, 3) as $registration) {
+                $evaluation = new RegistrationEvaluation();
+                $evaluation->registration = $registration;
+                $evaluation->user = $valuerA;
+                $evaluation->committee = 'committee 1';
+                $evaluation->evaluationData = ['status' => null];
+                $evaluation->status = RegistrationEvaluation::STATUS_EVALUATED;
+                $evaluation->save(true);
+            }
+        } finally {
+            $this->app->enableAccessControl();
+        }
+
+        return $opportunity;
+    }
+
+    function testDistributionComparatorNullFallsThroughToQuotaFallback()
+    {
+        $opportunity = $this->buildDistributionComparatorContractScenario();
+
+        $target_opportunity_id = $opportunity->id;
+        $this->app->hook('evaluationMethod.distributionComparator', function (&$comparator, Opportunity $hook_opportunity) use ($target_opportunity_id) {
+            if ($hook_opportunity->id !== $target_opportunity_id) {
+                return;
+            }
+
+            // Nunca opina: sempre delega ao critério padrão do core (contagem/quotas).
+            $comparator = fn(object $v1, object $v2, string $committee, array $pending): ?int => null;
+        });
+
+        $opportunity->evaluationMethodConfiguration->redistributeCommitteeRegistrations();
+
+        $emc = $opportunity->evaluationMethodConfiguration->refreshed();
+        $valuerA_id = $emc->agentRelations[0]->agent->user->id;
+        $valuerB_id = $emc->agentRelations[1]->agent->user->id;
+
+        /** @var Connection */
+        $conn = $this->app->em->getConnection();
+        $count = fn(int $user_id): int => (int) $conn->fetchScalar(
+            "SELECT COUNT(*) FROM evaluations WHERE opportunity_id = :opportunity_id AND valuer_user_id = :user_id",
+            ['opportunity_id' => $opportunity->id, 'user_id' => $user_id]
+        );
+
+        $this->assertEquals(3, $count($valuerA_id), 'Retornando null, o core cai no fallback por contagem e o avaliador A (que já tinha 2) termina com 3');
+        $this->assertEquals(2, $count($valuerB_id), 'Retornando null, o core cai no fallback por contagem e o avaliador B (que tinha 0) termina com 2');
+    }
+
+    function testDistributionComparatorZeroShortCircuitsQuotaFallback()
+    {
+        $opportunity = $this->buildDistributionComparatorContractScenario();
+
+        $target_opportunity_id = $opportunity->id;
+        $this->app->hook('evaluationMethod.distributionComparator', function (&$comparator, Opportunity $hook_opportunity) use ($target_opportunity_id) {
+            if ($hook_opportunity->id !== $target_opportunity_id) {
+                return;
+            }
+
+            // Declara empate definitivo para todo par: o core não deve cair no fallback por contagem.
+            $comparator = fn(object $v1, object $v2, string $committee, array $pending): ?int => 0;
+        });
+
+        $opportunity->evaluationMethodConfiguration->redistributeCommitteeRegistrations();
+
+        $emc = $opportunity->evaluationMethodConfiguration->refreshed();
+        $valuerA_id = $emc->agentRelations[0]->agent->user->id;
+        $valuerB_id = $emc->agentRelations[1]->agent->user->id;
+
+        /** @var Connection */
+        $conn = $this->app->em->getConnection();
+        $count = fn(int $user_id): int => (int) $conn->fetchScalar(
+            "SELECT COUNT(*) FROM evaluations WHERE opportunity_id = :opportunity_id AND valuer_user_id = :user_id",
+            ['opportunity_id' => $opportunity->id, 'user_id' => $user_id]
+        );
+
+        $this->assertEquals(5, $count($valuerA_id), 'Retornando 0, o core não deve cair no fallback por contagem, então o avaliador A concentra todas as pendências');
+        $this->assertEquals(0, $count($valuerB_id), 'Retornando 0, o avaliador B não deve receber nenhuma pendência nova');
+    }
+
 }


### PR DESCRIPTION
## O que muda

Este PR adiciona um novo ponto de extensão ao core: o hook `evaluationMethod.distributionComparator`, disparado dentro do método `redistributeRegistrations()`, em `EvaluationMethod.php`.

Esse hook permite que um tema injete uma função de comparação customizada para definir a ordem de prioridade dos avaliadores durante a redistribuição de uma comissão, sem precisar duplicar ou reescrever toda a lógica de distribuição já existente no core.

A motivação para essa alteração é a necessidade do Cultura Viva de balancear uniformemente a carga pendente dos avaliadores quando a opção `ignoreStartedEvaluations` estiver ativada na comissão. Esse comportamento não pode ser implementado utilizando apenas o critério atual de cotas.

Em vez de criar uma versão própria da lógica de distribuição dentro do tema, este PR adiciona um ponto de extensão ao core.

## Como funciona

Caso nenhum listener seja registrado para o hook, o comportamento permanece inalterado: `$distribution_comparator` permanece como `null`, e o core utiliza a lógica padrão de prioridade por lista, cotas e contagem.

O retorno do comparador define como a ordenação deve continuar:

* `null`: delega a decisão à lógica padrão do core, baseada em cotas e contagem;
* um valor inteiro, inclusive `0`: utiliza o valor retornado na comparação. O retorno `0` representa um empate definitivo e impede a execução do fallback.

O contador `$pending_assignments_count` registra, por comissão, quantas inscrições cada avaliador recebeu durante a rodada atual de redistribuição, incluindo as atribuições manuais realizadas por meio de `valuers_exceptions_list->include`.

Esse contador é enviado ao comparador para permitir a implementação de estratégias de balanceamento.

O comparador influencia somente a ordem de prioridade dos avaliadores. Limites como `maxRegistrations`, cotas por comissão, listas de exclusão e permissões continuam sendo aplicados posteriormente pelo core e não podem ser sobrepostos pelo comparador.

## Como foi testado

Foram adicionados seis testes em `tests/src/EvaluationsDistributionTest.php`, cobrindo cenários que ainda não possuíam uma rede de segurança adequada:

* Balanceamento pela carga pendente, preservando as avaliações já realizadas.
* Contabilização das inclusões manuais feitas por meio de `valuers_exceptions_list->include` na carga pendente do comparador.
* Isolamento de `$pending_assignments_count` por comissão.
* Validação do contrato de retorno: `null` delega a decisão ao core, enquanto `0` representa um empate definitivo e impede a execução do fallback.
* Garantia de que `maxRegistrations` continue sendo respeitado, mesmo com um comparador tendencioso.

Também foi executado o arquivo completo de testes, além dos três testes de regressão já existentes, sem o registro do novo hook:

* `testConcurrentEvaluationPhaseDistribution`
* `testMaxRegistrationsPerValuerLimit`
* `testRedistributePreservesAllCompletedEvaluations`

Todos os testes foram concluídos com sucesso, sem regressões no comportamento padrão.

## Observações

### Implementação no tema Cultura Viva

A implementação que consome o hook, localizada em `CulturaViva/EvaluationDistribution.php`, será realizada no repositório do tema e não faz parte deste PR.

Este PR adiciona exclusivamente o ponto de extensão necessário no core.
