### PR TITLE
feat: cobre aplicação de resultados por inscrição

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,9 @@ e este projeto adere ao [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 - **Avaliação automática por selos**: o gestor pode indicar, em uma fase de avaliação, quais selos validam o proponente. Se a pessoa já tiver esses selos válidos no perfil, a inscrição é **dispensada automaticamente** daquela fase (marcada como “Dispensada por selos”) e segue para a próxima etapa, sem precisar de avaliador
 - **Novos anexos no cadastro do agente** (também usáveis como campos `@` no formulário de inscrição): CPF, CNPJ, CNH, RG, passaporte, comprovante de residência, vínculo territorial, currículo, portfólio, certidões fiscal, trabalhista e de prestação de contas, além de comprovantes de raça/cor, pessoa com deficiência e comunidades tradicionais. Os arquivos ficam no perfil e acompanham a inscrição automaticamente
 
+### Melhorias
+- Permite aplicar um status do resultado da avaliação técnica a uma lista específica de inscrições informada por seus números
+
 ### Melhorias nos selos validadores
 - Mostra o **status de cada campo** do selo (válido, prestes a vencer, vencido etc.) na ficha e no formulário de avaliação, para o avaliador entender o que está ok e o que precisa de atenção
 - Permite **concessão parcial do selo** na avaliação documental: o selo pode ser aplicado só aos campos que passaram, conforme os invalidadores configurados

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,7 @@ e este projeto adere ao [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 - **Novos anexos no cadastro do agente** (também usáveis como campos `@` no formulário de inscrição): CPF, CNPJ, CNH, RG, passaporte, comprovante de residência, vínculo territorial, currículo, portfólio, certidões fiscal, trabalhista e de prestação de contas, além de comprovantes de raça/cor, pessoa com deficiência e comunidades tradicionais. Os arquivos ficam no perfil e acompanham a inscrição automaticamente
 
 ### Melhorias
-- Permite aplicar um status do resultado da avaliação técnica a uma lista específica de inscrições informada por seus números
+- Permite aplicar um status do resultado da avaliação a uma lista específica de inscrições, nos métodos técnico, simplificado, documental e contínuo
 
 ### Melhorias nos selos validadores
 - Mostra o **status de cada campo** do selo (válido, prestes a vencer, vencido etc.) na ficha e no formulário de avaliação, para o avaliador entender o que está ok e o que precisa de atenção

--- a/src/core/EvaluationMethod.php
+++ b/src/core/EvaluationMethod.php
@@ -94,6 +94,48 @@ abstract class EvaluationMethod extends Module implements \JsonSerializable{
     }
 
     /**
+     * Retorna os IDs das inscrições aptas a receber a aplicação de um resultado.
+     *
+     * A busca considera apenas inscrições da oportunidade informada, com os números
+     * solicitados, em status válidos e com status diferente do que será aplicado.
+     *
+     * @param Opportunity $opportunity Oportunidade à qual as inscrições pertencem
+     * @param string[] $registration_numbers Números das inscrições a serem filtradas
+     * @param int $new_status Status que será aplicado às inscrições encontradas
+     * @return int[] IDs das inscrições aptas
+     */
+    public function findRegistrationIdsForResultApplication(
+        Opportunity $opportunity,
+        array $registration_numbers,
+        int $new_status
+    ): array {
+        $registration_numbers = array_values(array_unique(array_filter(array_map(
+            fn ($number) => is_string($number) ? trim($number) : '',
+            $registration_numbers
+        ))));
+
+        if (!$registration_numbers) {
+            return [];
+        }
+
+        $status_in = API::IN([
+            Registration::STATUS_SENT,
+            Registration::STATUS_NOTAPPROVED,
+            Registration::STATUS_WAITLIST,
+            Registration::STATUS_APPROVED,
+        ]);
+        $status_not_equal = API::NOT_EQ($new_status);
+        $query = new ApiQuery(Registration::class, [
+            '@select' => 'id',
+            'opportunity' => API::EQ($opportunity->id),
+            'number' => API::IN($registration_numbers),
+            'status' => "AND($status_not_equal, $status_in)",
+        ]);
+
+        return $query->findIds();
+    }
+
+    /**
      * Exporta as configurações do método para array
      * 
      * @param EvaluationMethodConfiguration $evaluation_method_configuration

--- a/src/modules/EvaluationMethodContinuous/Module.php
+++ b/src/modules/EvaluationMethodContinuous/Module.php
@@ -236,7 +236,7 @@ class Module extends \MapasCulturais\EvaluationMethod
             $sections = $result;
         });
 
-        $app->hook('POST(opportunity.applyEvaluationsContinuous)', function() {
+        $app->hook('POST(opportunity.applyEvaluationsContinuous)', function() use ($self) {
             $this->requireAuthentication();
 
             set_time_limit(0);
@@ -261,37 +261,36 @@ class Module extends \MapasCulturais\EvaluationMethod
 
             $new_status = intval($this->data['to']);
             
-            $apply_status = $this->data['status'] ?? false;
-            if ($apply_status == 'all') {
-                $status = 'r.status > 0';
-            } else {
-                $status = 'r.status = 1';
-            }
-    
             $opp->checkPermission('@control');
-            
-            // pesquise todas as registrations da opportunity que esta vindo na request
-            $dql = "
-            SELECT 
-                r.id
-            FROM
-                MapasCulturais\Entities\Registration r
-            WHERE 
-                r.opportunity = :opportunity_id AND
-                r.consolidatedResult = :consolidated_result AND
-                r.status <> $new_status AND
-                $status 
-            ";
-            $query = $app->em->createQuery($dql);
-        
-            $params = [
-                'opportunity_id' => $opp->id,
-                'consolidated_result' => $this->data['from']
-            ];
-    
-            $query->setParameters($params);
-    
-            $registrations = $query->getScalarResult();
+
+            if (($this->data['tabSelected'] ?? 'result') === 'registration') {
+                $registrations = $self->findRegistrationIdsForResultApplication(
+                    $opp,
+                    $this->data['registrationNumbers'] ?? [],
+                    $new_status
+                );
+            } else {
+                $apply_status = $this->data['status'] ?? false;
+                $status = $apply_status == 'all' ? 'r.status > 0' : 'r.status = 1';
+
+                $dql = "
+                SELECT
+                    r.id
+                FROM
+                    MapasCulturais\Entities\Registration r
+                WHERE
+                    r.opportunity = :opportunity_id AND
+                    r.consolidatedResult = :consolidated_result AND
+                    r.status <> $new_status AND
+                    $status
+                ";
+                $query = $app->em->createQuery($dql);
+                $query->setParameters([
+                    'opportunity_id' => $opp->id,
+                    'consolidated_result' => $this->data['from']
+                ]);
+                $registrations = $query->getScalarResult();
+            }
             
             $count = 0;
             $total = count($registrations);
@@ -303,7 +302,8 @@ class Module extends \MapasCulturais\EvaluationMethod
             // faça um foreach em cada registration e pegue as suas avaliações
             foreach ($registrations as $reg) {
                 $count++;
-                $registration = $app->repo('Registration')->find($reg['id']);
+                $registration_id = is_array($reg) ? $reg['id'] : $reg;
+                $registration = $app->repo('Registration')->find($registration_id);
                 $registration->__skipQueuingPCacheRecreation = true;
 
                 $app->log->debug("{$count}/{$total} Alterando status da inscrição {$registration->number} para {$new_status}");

--- a/src/modules/EvaluationMethodContinuous/components/evaluation-method-continuous--apply/script.js
+++ b/src/modules/EvaluationMethodContinuous/components/evaluation-method-continuous--apply/script.js
@@ -20,12 +20,12 @@ app.component('evaluation-method-continuous--apply', {
     },
 
     data() {
-        applyAll = false;
-        applyData = {};
         return {
-            applyData,
-            applyAll
-        }
+            applyData: {},
+            applyAll: false,
+            registrationListText: '',
+            tabSelected: 'result'
+        };
     },
 
     computed: {
@@ -41,7 +41,7 @@ app.component('evaluation-method-continuous--apply', {
         apply(modal) {
             const messages = useMessages();
 
-            this.applyData.status = this.applyAll ? 'all' : 'pending';
+            this.prepareApplyData();
             this.entity.disableMessages();
             
             this.entity.POST('applyEvaluationsContinuous', {
@@ -54,6 +54,41 @@ app.component('evaluation-method-continuous--apply', {
             }).catch((data) => {
                 messages.error(data.data)
             });
+        },
+        changed(event) {
+            this.tabSelected = event.tab.slug;
+        },
+        modalClose() {
+            this.resetApplyData();
+        },
+        parseRegistrationList(text) {
+            if (!text || !text.trim()) {
+                return [];
+            }
+
+            return text
+                .split(/[,;\s\n\r]+/)
+                .map(number => number.trim())
+                .filter(number => number.length > 0);
+        },
+        prepareApplyData() {
+            this.applyData.tabSelected = this.tabSelected;
+
+            if (this.tabSelected === 'registration') {
+                this.applyData.registrationNumbers = this.parseRegistrationList(this.registrationListText);
+                delete this.applyData.from;
+                delete this.applyData.status;
+                return;
+            }
+
+            this.applyData.status = this.applyAll ? 'all' : 'pending';
+            delete this.applyData.registrationNumbers;
+        },
+        resetApplyData() {
+            this.applyData = {};
+            this.applyAll = false;
+            this.registrationListText = '';
+            this.tabSelected = 'result';
         },
         valueToString(value) {
             switch (value) {

--- a/src/modules/EvaluationMethodContinuous/components/evaluation-method-continuous--apply/template.php
+++ b/src/modules/EvaluationMethodContinuous/components/evaluation-method-continuous--apply/template.php
@@ -9,10 +9,12 @@ use MapasCulturais\i;
 
 $this->import('
     mc-modal
+    mc-tab
+    mc-tabs
 ');
 ?>
 
-<mc-modal title="<?php \MapasCulturais\i::esc_attr_e('Aplicar resultados das avaliações'); ?>" classes="apply-evaluations">
+<mc-modal title="<?php i::esc_attr_e('Aplicar resultados das avaliações'); ?>" classes="apply-evaluations" @close="modalClose()">
 
     <template #button="modal">
         <button class="button button--primary button--icon" @click="modal.open()">
@@ -22,35 +24,57 @@ $this->import('
     </template>
 
     <template #default>
-        <div class="grid-12">
-            <div class="field col-12">
-                <label><?php i::_e('Selecione as avaliações') ?></label>
-                <select v-model="applyData.from">
-                    <option value="all"><?php i::_e('Todos') ?></option>
-                    <option v-for="item in consolidatedResults" :value="item.evaluation">{{valueToString(item.evaluation)}} ({{item.num}} <?php i::_e('Inscrições') ?>)</option>
-                </select>
-            </div>
+        <mc-tabs @changed="changed($event)">
+            <mc-tab label="<?= i::esc_attr__('Por resultado') ?>" slug="result">
+                <div class="grid-12 classification__panel">
+                    <div class="field col-12">
+                        <label for="evaluation-continuous-result"><?php i::_e('Selecione as avaliações') ?></label>
+                        <select id="evaluation-continuous-result" v-model="applyData.from">
+                            <option value="all"><?php i::_e('Todos') ?></option>
+                            <option v-for="item in consolidatedResults" :value="item.evaluation">{{valueToString(item.evaluation)}} ({{item.num}} <?php i::_e('Inscrições') ?>)</option>
+                        </select>
+                    </div>
 
-            <div class="field col-12">
-                <label><?php i::_e('Selecione o status que deseja aplicar') ?></label>
-                <select v-model="applyData.to">
-                    <option v-for="item in statusList" :value="item.status">{{item.label}}</option>
-                </select>
-            </div>
+                    <div class="field col-12">
+                        <label for="evaluation-continuous-result-status"><?php i::_e('Selecione o status que deseja aplicar') ?></label>
+                        <select id="evaluation-continuous-result-status" v-model="applyData.to">
+                            <option v-for="item in statusList" :value="item.status">{{item.label}}</option>
+                        </select>
+                    </div>
 
-            <div class="apply-evaluations__apply-all col-12">
-                <h5> 
-                    <?= i::__("Se você preferir não marcar a caixa abaixo, as avaliações serão aplicadas somente ") ?> <span class="semibold"><?=i::__("nas inscrições que com o status 'Pendente'.")?></span> 
-                </h5>
+                    <div class="apply-evaluations__apply-all col-12">
+                        <h5>
+                            <?= i::__("Se você preferir não marcar a caixa abaixo, as avaliações serão aplicadas somente ") ?> <span class="semibold"><?=i::__("nas inscrições que com o status 'Pendente'.")?></span>
+                        </h5>
 
-                <div class="field">
-                    <label>
-                        <input type="checkbox" v-model="applyAll">
-                        <?php i::_e('Aplicar para todas as inscrições enviadas') ?>
-                    </label>
+                        <div class="field">
+                            <label>
+                                <input type="checkbox" v-model="applyAll">
+                                <?php i::_e('Aplicar para todas as inscrições enviadas') ?>
+                            </label>
+                        </div>
+                    </div>
                 </div>
-            </div>
-        </div>
+            </mc-tab>
+
+            <mc-tab label="<?= i::esc_attr__('Por inscrição') ?>" slug="registration">
+                <div class="grid-12 classification__panel">
+                    <div class="field col-12">
+                        <label for="evaluation-continuous-registration-list"><?php i::_e('Lista de inscrições') ?></label>
+                        <div class="field opportunity-evaluation-committee__registration-list-textarea">
+                            <textarea id="evaluation-continuous-registration-list" v-model="registrationListText" placeholder="<?= i::esc_attr__('Preencha com os números das inscrições em que deseja aplicar o resultado das avaliações, separados por vírgula.') ?>" rows="4"></textarea>
+                        </div>
+                    </div>
+
+                    <div class="field col-12">
+                        <label for="evaluation-continuous-registration-status"><?php i::_e('Selecione o status que deseja aplicar') ?></label>
+                        <select id="evaluation-continuous-registration-status" v-model="applyData.to">
+                            <option v-for="item in statusList" :value="item.status">{{item.label}}</option>
+                        </select>
+                    </div>
+                </div>
+            </mc-tab>
+        </mc-tabs>
     </template>
 
     <template #actions="modal">

--- a/src/modules/EvaluationMethodDocumentary/Module.php
+++ b/src/modules/EvaluationMethodDocumentary/Module.php
@@ -190,7 +190,7 @@ class Module extends \MapasCulturais\EvaluationMethod
             $sections = $result;
         });
 
-        $app->hook('POST(opportunity.applyEvaluationsDocumentary)', function() {
+        $app->hook('POST(opportunity.applyEvaluationsDocumentary)', function() use ($self) {
             $this->requireAuthentication();
 
             set_time_limit(0);
@@ -214,37 +214,36 @@ class Module extends \MapasCulturais\EvaluationMethod
             }
             $new_status = intval($this->data['to']);
             
-            $apply_status = $this->data['status'] ?? false;
-            if ($apply_status == 'all') {
-                $status = 'r.status > 0';
-            } else {
-                $status = 'r.status = 1';
-            }
-    
             $opp->checkPermission('@control');
 
-            // pesquise todas as registrations da opportunity que esta vindo na request
-            $dql = "
-            SELECT 
-                r.id
-            FROM
-                MapasCulturais\Entities\Registration r
-            WHERE 
-                r.opportunity = :opportunity_id AND
-                r.consolidatedResult = :consolidated_result AND
-                r.status <> $new_status AND
-                $status
-            ";
-            $query = $app->em->createQuery($dql);
-        
-            $params = [
-                'opportunity_id' => $opp->id,
-                'consolidated_result' => $this->data['from']
-            ];
-    
-            $query->setParameters($params);
-    
-            $registrations = $query->getScalarResult();
+            if (($this->data['tabSelected'] ?? 'result') === 'registration') {
+                $registrations = $self->findRegistrationIdsForResultApplication(
+                    $opp,
+                    $this->data['registrationNumbers'] ?? [],
+                    $new_status
+                );
+            } else {
+                $apply_status = $this->data['status'] ?? false;
+                $status = $apply_status == 'all' ? 'r.status > 0' : 'r.status = 1';
+
+                $dql = "
+                SELECT
+                    r.id
+                FROM
+                    MapasCulturais\Entities\Registration r
+                WHERE
+                    r.opportunity = :opportunity_id AND
+                    r.consolidatedResult = :consolidated_result AND
+                    r.status <> $new_status AND
+                    $status
+                ";
+                $query = $app->em->createQuery($dql);
+                $query->setParameters([
+                    'opportunity_id' => $opp->id,
+                    'consolidated_result' => $this->data['from']
+                ]);
+                $registrations = $query->getScalarResult();
+            }
 
             $count = 0;
             $total = count($registrations);
@@ -253,7 +252,8 @@ class Module extends \MapasCulturais\EvaluationMethod
             foreach ($registrations as $reg) {
                 $count++;
                 /** @var Registration $registration */
-                $registration = $app->repo('Registration')->find($reg['id']);
+                $registration_id = is_array($reg) ? $reg['id'] : $reg;
+                $registration = $app->repo('Registration')->find($registration_id);
                 $registration->skipSync = true;
                 $registration->__skipQueuingPCacheRecreation = true;
 

--- a/src/modules/EvaluationMethodDocumentary/components/evaluation-method-documentary--apply/script.js
+++ b/src/modules/EvaluationMethodDocumentary/components/evaluation-method-documentary--apply/script.js
@@ -20,12 +20,12 @@ app.component('evaluation-method-documentary--apply', {
     },
 
     data() {
-        applyAll = false;
-        applyData = {};
         return {
-            applyData,
-            applyAll
-        }
+            applyData: {},
+            applyAll: false,
+            registrationListText: '',
+            tabSelected: 'result'
+        };
     },
 
     computed: {
@@ -41,7 +41,7 @@ app.component('evaluation-method-documentary--apply', {
         apply(modal) {
             const messages = useMessages();
 
-            this.applyData.status = this.applyAll ? 'all' : 'pending';
+            this.prepareApplyData();
             this.entity.disableMessages();
             
             this.entity.POST('applyEvaluationsDocumentary', {
@@ -54,6 +54,41 @@ app.component('evaluation-method-documentary--apply', {
             }).catch((data) => {
                 messages.error(data.data)
             });
+        },
+        changed(event) {
+            this.tabSelected = event.tab.slug;
+        },
+        modalClose() {
+            this.resetApplyData();
+        },
+        parseRegistrationList(text) {
+            if (!text || !text.trim()) {
+                return [];
+            }
+
+            return text
+                .split(/[,;\s\n\r]+/)
+                .map(number => number.trim())
+                .filter(number => number.length > 0);
+        },
+        prepareApplyData() {
+            this.applyData.tabSelected = this.tabSelected;
+
+            if (this.tabSelected === 'registration') {
+                this.applyData.registrationNumbers = this.parseRegistrationList(this.registrationListText);
+                delete this.applyData.from;
+                delete this.applyData.status;
+                return;
+            }
+
+            this.applyData.status = this.applyAll ? 'all' : 'pending';
+            delete this.applyData.registrationNumbers;
+        },
+        resetApplyData() {
+            this.applyData = {};
+            this.applyAll = false;
+            this.registrationListText = '';
+            this.tabSelected = 'result';
         },
         valueToString(value) {
             switch (value) {

--- a/src/modules/EvaluationMethodDocumentary/components/evaluation-method-documentary--apply/template.php
+++ b/src/modules/EvaluationMethodDocumentary/components/evaluation-method-documentary--apply/template.php
@@ -9,10 +9,12 @@ use MapasCulturais\i;
 
 $this->import('
     mc-modal
+    mc-tab
+    mc-tabs
 ');
 ?>
 
-<mc-modal title="<?= \MapasCulturais\i::__('Aplicar resultados das avaliações') ?>" classes="apply-evaluations">
+<mc-modal title="<?= i::esc_attr__('Aplicar resultados das avaliações') ?>" classes="apply-evaluations" @close="modalClose()">
     <template #button="modal">
         <button class="button button--primary button--icon" @click="modal.open()">
             <mc-icon name="add"></mc-icon>
@@ -21,35 +23,57 @@ $this->import('
     </template> 
 
     <template #default>
-        <div class="grid-12">
-            <div class="field col-12">
-                <label><?php i::_e('Selecione as avaliações') ?></label>
-                <select v-model="applyData.from">
-                    <option value="all"><?php i::_e('Todos') ?></option>
-                    <option v-for="item in consolidatedResults" :value="item.evaluation">{{valueToString(item.evaluation)}} ({{item.num}} <?php i::_e('Inscrições') ?>)</option>
-                </select>
-            </div>
+        <mc-tabs @changed="changed($event)">
+            <mc-tab label="<?= i::esc_attr__('Por resultado') ?>" slug="result">
+                <div class="grid-12 classification__panel">
+                    <div class="field col-12">
+                        <label for="evaluation-documentary-result"><?php i::_e('Selecione as avaliações') ?></label>
+                        <select id="evaluation-documentary-result" v-model="applyData.from">
+                            <option value="all"><?php i::_e('Todos') ?></option>
+                            <option v-for="item in consolidatedResults" :value="item.evaluation">{{valueToString(item.evaluation)}} ({{item.num}} <?php i::_e('Inscrições') ?>)</option>
+                        </select>
+                    </div>
 
-            <div class="field col-12">
-                <label><?php i::_e('Selecione o status que deseja aplicar') ?></label>
-                <select v-model="applyData.to">
-                    <option v-for="item in statusList" :value="item.status">{{item.label}}</option>
-                </select>
-            </div>
+                    <div class="field col-12">
+                        <label for="evaluation-documentary-result-status"><?php i::_e('Selecione o status que deseja aplicar') ?></label>
+                        <select id="evaluation-documentary-result-status" v-model="applyData.to">
+                            <option v-for="item in statusList" :value="item.status">{{item.label}}</option>
+                        </select>
+                    </div>
 
-            <div class="apply-evaluations__apply-all col-12">
-                <h5> 
-                    <?= i::__("Se você preferir não marcar a caixa abaixo, as avaliações serão aplicadas somente ") ?> <span class="semibold"><?=i::__("nas inscrições que com o status 'Pendente'.")?></span> 
-                </h5>
+                    <div class="apply-evaluations__apply-all col-12">
+                        <h5>
+                            <?= i::__("Se você preferir não marcar a caixa abaixo, as avaliações serão aplicadas somente ") ?> <span class="semibold"><?=i::__("nas inscrições que com o status 'Pendente'.")?></span>
+                        </h5>
 
-                <div class="field">
-                    <label>
-                        <input type="checkbox" v-model="applyAll">
-                        <?php i::_e('Aplicar para todas as inscrições enviadas') ?>
-                    </label>
+                        <div class="field">
+                            <label>
+                                <input type="checkbox" v-model="applyAll">
+                                <?php i::_e('Aplicar para todas as inscrições enviadas') ?>
+                            </label>
+                        </div>
+                    </div>
                 </div>
-            </div>
-        </div>        
+            </mc-tab>
+
+            <mc-tab label="<?= i::esc_attr__('Por inscrição') ?>" slug="registration">
+                <div class="grid-12 classification__panel">
+                    <div class="field col-12">
+                        <label for="evaluation-documentary-registration-list"><?php i::_e('Lista de inscrições') ?></label>
+                        <div class="field opportunity-evaluation-committee__registration-list-textarea">
+                            <textarea id="evaluation-documentary-registration-list" v-model="registrationListText" placeholder="<?= i::esc_attr__('Preencha com os números das inscrições em que deseja aplicar o resultado das avaliações, separados por vírgula.') ?>" rows="4"></textarea>
+                        </div>
+                    </div>
+
+                    <div class="field col-12">
+                        <label for="evaluation-documentary-registration-status"><?php i::_e('Selecione o status que deseja aplicar') ?></label>
+                        <select id="evaluation-documentary-registration-status" v-model="applyData.to">
+                            <option v-for="item in statusList" :value="item.status">{{item.label}}</option>
+                        </select>
+                    </div>
+                </div>
+            </mc-tab>
+        </mc-tabs>
     </template>
 
     <template #actions="modal">

--- a/src/modules/EvaluationMethodSimple/Module.php
+++ b/src/modules/EvaluationMethodSimple/Module.php
@@ -165,7 +165,7 @@ class Module extends \MapasCulturais\EvaluationMethod
             $sections = $result;
         });
 
-        $app->hook('POST(opportunity.applyEvaluationsSimple)', function() {
+        $app->hook('POST(opportunity.applyEvaluationsSimple)', function() use ($self) {
             $this->requireAuthentication();
 
             set_time_limit(0);
@@ -190,37 +190,36 @@ class Module extends \MapasCulturais\EvaluationMethod
 
             $new_status = intval($this->data['to']);
             
-            $apply_status = $this->data['status'] ?? false;
-            if ($apply_status == 'all') {
-                $status = 'r.status > 0';
-            } else {
-                $status = 'r.status = 1';
-            }
-    
             $opp->checkPermission('@control');
-            
-            // pesquise todas as registrations da opportunity que esta vindo na request
-            $dql = "
-            SELECT 
-                r.id
-            FROM
-                MapasCulturais\Entities\Registration r
-            WHERE 
-                r.opportunity = :opportunity_id AND
-                r.consolidatedResult = :consolidated_result AND
-                r.status <> $new_status AND
-                $status 
-            ";
-            $query = $app->em->createQuery($dql);
-        
-            $params = [
-                'opportunity_id' => $opp->id,
-                'consolidated_result' => $this->data['from']
-            ];
-    
-            $query->setParameters($params);
-    
-            $registrations = $query->getScalarResult();
+
+            if (($this->data['tabSelected'] ?? 'result') === 'registration') {
+                $registrations = $self->findRegistrationIdsForResultApplication(
+                    $opp,
+                    $this->data['registrationNumbers'] ?? [],
+                    $new_status
+                );
+            } else {
+                $apply_status = $this->data['status'] ?? false;
+                $status = $apply_status == 'all' ? 'r.status > 0' : 'r.status = 1';
+
+                $dql = "
+                SELECT
+                    r.id
+                FROM
+                    MapasCulturais\Entities\Registration r
+                WHERE
+                    r.opportunity = :opportunity_id AND
+                    r.consolidatedResult = :consolidated_result AND
+                    r.status <> $new_status AND
+                    $status
+                ";
+                $query = $app->em->createQuery($dql);
+                $query->setParameters([
+                    'opportunity_id' => $opp->id,
+                    'consolidated_result' => $this->data['from']
+                ]);
+                $registrations = $query->getScalarResult();
+            }
             
             $count = 0;
             $total = count($registrations);
@@ -232,7 +231,8 @@ class Module extends \MapasCulturais\EvaluationMethod
             // faça um foreach em cada registration e pegue as suas avaliações
             foreach ($registrations as $reg) {
                 $count++;
-                $registration = $app->repo('Registration')->find($reg['id']);
+                $registration_id = is_array($reg) ? $reg['id'] : $reg;
+                $registration = $app->repo('Registration')->find($registration_id);
                 $registration->__skipQueuingPCacheRecreation = true;
 
                 $app->log->debug("{$count}/{$total} Alterando status da inscrição {$registration->number} para {$new_status}");

--- a/src/modules/EvaluationMethodSimple/components/evaluation-method-simple--apply/script.js
+++ b/src/modules/EvaluationMethodSimple/components/evaluation-method-simple--apply/script.js
@@ -20,12 +20,12 @@ app.component('evaluation-method-simple--apply', {
     },
 
     data() {
-        applyAll = false;
-        applyData = {};
         return {
-            applyData,
-            applyAll
-        }
+            applyData: {},
+            applyAll: false,
+            registrationListText: '',
+            tabSelected: 'result'
+        };
     },
 
     computed: {
@@ -41,7 +41,7 @@ app.component('evaluation-method-simple--apply', {
         apply(modal) {
             const messages = useMessages();
 
-            this.applyData.status = this.applyAll ? 'all' : 'pending';
+            this.prepareApplyData();
             this.entity.disableMessages();
             
             this.entity.POST('applyEvaluationsSimple', {
@@ -54,6 +54,41 @@ app.component('evaluation-method-simple--apply', {
             }).catch((data) => {
                 messages.error(data.data)
             });
+        },
+        changed(event) {
+            this.tabSelected = event.tab.slug;
+        },
+        modalClose() {
+            this.resetApplyData();
+        },
+        parseRegistrationList(text) {
+            if (!text || !text.trim()) {
+                return [];
+            }
+
+            return text
+                .split(/[,;\s\n\r]+/)
+                .map(number => number.trim())
+                .filter(number => number.length > 0);
+        },
+        prepareApplyData() {
+            this.applyData.tabSelected = this.tabSelected;
+
+            if (this.tabSelected === 'registration') {
+                this.applyData.registrationNumbers = this.parseRegistrationList(this.registrationListText);
+                delete this.applyData.from;
+                delete this.applyData.status;
+                return;
+            }
+
+            this.applyData.status = this.applyAll ? 'all' : 'pending';
+            delete this.applyData.registrationNumbers;
+        },
+        resetApplyData() {
+            this.applyData = {};
+            this.applyAll = false;
+            this.registrationListText = '';
+            this.tabSelected = 'result';
         },
         valueToString(value) {
             switch (value) {

--- a/src/modules/EvaluationMethodSimple/components/evaluation-method-simple--apply/template.php
+++ b/src/modules/EvaluationMethodSimple/components/evaluation-method-simple--apply/template.php
@@ -9,10 +9,12 @@ use MapasCulturais\i;
 
 $this->import('
     mc-modal
+    mc-tab
+    mc-tabs
 ');
 ?>
 
-<mc-modal title="<?= \MapasCulturais\i::__('Aplicar resultados das avaliações') ?>" classes="apply-evaluations">
+<mc-modal title="<?= i::esc_attr__('Aplicar resultados das avaliações') ?>" classes="apply-evaluations" @close="modalClose()">
 
     <template #button="modal">
         <button class="button button--primary button--icon" @click="modal.open()">
@@ -22,35 +24,57 @@ $this->import('
     </template>
 
     <template #default>
-        <div class="grid-12">
-            <div class="field col-12">
-                <label><?php i::_e('Selecione as avaliações') ?></label>
-                <select v-model="applyData.from">
-                    <option value="all"><?php i::_e('Todos') ?></option>
-                    <option v-for="item in consolidatedResults" :value="item.evaluation">{{valueToString(item.evaluation)}} ({{item.num}} <?php i::_e('Inscrições') ?>)</option>
-                </select>
-            </div>
+        <mc-tabs @changed="changed($event)">
+            <mc-tab label="<?= i::esc_attr__('Por resultado') ?>" slug="result">
+                <div class="grid-12 classification__panel">
+                    <div class="field col-12">
+                        <label for="evaluation-simple-result"><?php i::_e('Selecione as avaliações') ?></label>
+                        <select id="evaluation-simple-result" v-model="applyData.from">
+                            <option value="all"><?php i::_e('Todos') ?></option>
+                            <option v-for="item in consolidatedResults" :value="item.evaluation">{{valueToString(item.evaluation)}} ({{item.num}} <?php i::_e('Inscrições') ?>)</option>
+                        </select>
+                    </div>
 
-            <div class="field col-12">
-                <label><?php i::_e('Selecione o status que deseja aplicar') ?></label>
-                <select v-model="applyData.to">
-                    <option v-for="item in statusList" :value="item.status">{{item.label}}</option>
-                </select>
-            </div>
+                    <div class="field col-12">
+                        <label for="evaluation-simple-result-status"><?php i::_e('Selecione o status que deseja aplicar') ?></label>
+                        <select id="evaluation-simple-result-status" v-model="applyData.to">
+                            <option v-for="item in statusList" :value="item.status">{{item.label}}</option>
+                        </select>
+                    </div>
 
-            <div class="apply-evaluations__apply-all col-12">
-                <h5> 
-                    <?= i::__("Se você preferir não marcar a caixa abaixo, as avaliações serão aplicadas somente ") ?> <span class="semibold"><?=i::__("nas inscrições que com o status 'Pendente'.")?></span> 
-                </h5>
+                    <div class="apply-evaluations__apply-all col-12">
+                        <h5>
+                            <?= i::__("Se você preferir não marcar a caixa abaixo, as avaliações serão aplicadas somente ") ?> <span class="semibold"><?=i::__("nas inscrições que com o status 'Pendente'.")?></span>
+                        </h5>
 
-                <div class="field">
-                    <label>
-                        <input type="checkbox" v-model="applyAll">
-                        <?php i::_e('Aplicar para todas as inscrições enviadas') ?>
-                    </label>
+                        <div class="field">
+                            <label>
+                                <input type="checkbox" v-model="applyAll">
+                                <?php i::_e('Aplicar para todas as inscrições enviadas') ?>
+                            </label>
+                        </div>
+                    </div>
                 </div>
-            </div>
-        </div>
+            </mc-tab>
+
+            <mc-tab label="<?= i::esc_attr__('Por inscrição') ?>" slug="registration">
+                <div class="grid-12 classification__panel">
+                    <div class="field col-12">
+                        <label for="evaluation-simple-registration-list"><?php i::_e('Lista de inscrições') ?></label>
+                        <div class="field opportunity-evaluation-committee__registration-list-textarea">
+                            <textarea id="evaluation-simple-registration-list" v-model="registrationListText" placeholder="<?= i::esc_attr__('Preencha com os números das inscrições em que deseja aplicar o resultado das avaliações, separados por vírgula.') ?>" rows="4"></textarea>
+                        </div>
+                    </div>
+
+                    <div class="field col-12">
+                        <label for="evaluation-simple-registration-status"><?php i::_e('Selecione o status que deseja aplicar') ?></label>
+                        <select id="evaluation-simple-registration-status" v-model="applyData.to">
+                            <option v-for="item in statusList" :value="item.status">{{item.label}}</option>
+                        </select>
+                    </div>
+                </div>
+            </mc-tab>
+        </mc-tabs>
     </template>
 
     <template #actions="modal">

--- a/src/modules/EvaluationMethodTechnical/Module.php
+++ b/src/modules/EvaluationMethodTechnical/Module.php
@@ -101,6 +101,29 @@ class Module extends \MapasCulturais\EvaluationMethod
         return i::__('Consiste em avaliação por critérios e cotas.');
     }
 
+    public function findRegistrationIdsForResultApplication(Opportunity $opportunity, array $registration_numbers, int $new_status): array
+    {
+        $registration_numbers = array_values(array_unique(array_filter(array_map(
+            fn ($number) => is_string($number) ? trim($number) : '',
+            $registration_numbers
+        ))));
+
+        if (!$registration_numbers) {
+            return [];
+        }
+
+        $status_in = API::IN([1, 3, 8, 10]);
+        $status_not_equal = API::NOT_EQ($new_status);
+        $query = new ApiQuery(Registration::class, [
+            '@select' => 'id',
+            'opportunity' => API::EQ($opportunity->id),
+            'number' => API::IN($registration_numbers),
+            'status' => "AND($status_not_equal, $status_in)",
+        ]);
+
+        return $query->findIds();
+    }
+
     public function filterEvaluationsSummary(array $data) {
         $items = array_filter(array_keys($data), function($item) {
             return is_numeric($item) ? $item : null;            
@@ -683,8 +706,10 @@ class Module extends \MapasCulturais\EvaluationMethod
                 '@order' => 'score DESC'
             ];
 
-            // TAB POR PONTUAÇÃO
-            if($this->data['tabSelected'] === 'score') {
+            $tab_selected = $this->data['tabSelected'] ?? null;
+            $applies_single_status = in_array($tab_selected, ['score', 'registration'], true);
+
+            if($applies_single_status) {
                 if(!isset($this->data['setStatusTo'])) {
                     $this->errorJson(i::__('Por favor selecione um status para ser aplicado.'), 400);
                 }
@@ -695,6 +720,10 @@ class Module extends \MapasCulturais\EvaluationMethod
                 }
 
                 $new_status = intval($this->data['setStatusTo']);
+            }
+
+            // TAB POR PONTUAÇÃO
+            if($tab_selected === 'score') {
                 $statusNotEqual =  API::NOT_EQ($new_status);
                 $min = $this->data['from'][0];
                 $max = $this->data['from'][1];
@@ -704,6 +733,18 @@ class Module extends \MapasCulturais\EvaluationMethod
 
                 $query = new ApiQuery(Registration::class, $query_params);
                 $registrations = $query->findIds();
+            }
+
+            // TAB POR INSCRIÇÃO
+            if($tab_selected === 'registration') {
+                $registrations = $self->findRegistrationIdsForResultApplication(
+                    $opp,
+                    $this->data['registrationNumbers'] ?? [],
+                    $new_status
+                );
+            }
+
+            if($applies_single_status) {
                 $total = count($registrations);
 
                 foreach($registrations as $i => $reg) {
@@ -742,7 +783,7 @@ class Module extends \MapasCulturais\EvaluationMethod
             }
 
             // TAB POR CLASSIFICAÇÃO
-            if($this->data['tabSelected'] === 'classification') {
+            if($tab_selected === 'classification') {
                 $early_registrations = $this->data['earlyRegistrations'];
                 $wait_list = $this->data['waitList'];
                 $invalidate_registrations = $this->data['invalidateRegistrations'];

--- a/src/modules/EvaluationMethodTechnical/Module.php
+++ b/src/modules/EvaluationMethodTechnical/Module.php
@@ -101,29 +101,6 @@ class Module extends \MapasCulturais\EvaluationMethod
         return i::__('Consiste em avaliação por critérios e cotas.');
     }
 
-    public function findRegistrationIdsForResultApplication(Opportunity $opportunity, array $registration_numbers, int $new_status): array
-    {
-        $registration_numbers = array_values(array_unique(array_filter(array_map(
-            fn ($number) => is_string($number) ? trim($number) : '',
-            $registration_numbers
-        ))));
-
-        if (!$registration_numbers) {
-            return [];
-        }
-
-        $status_in = API::IN([1, 3, 8, 10]);
-        $status_not_equal = API::NOT_EQ($new_status);
-        $query = new ApiQuery(Registration::class, [
-            '@select' => 'id',
-            'opportunity' => API::EQ($opportunity->id),
-            'number' => API::IN($registration_numbers),
-            'status' => "AND($status_not_equal, $status_in)",
-        ]);
-
-        return $query->findIds();
-    }
-
     public function filterEvaluationsSummary(array $data) {
         $items = array_filter(array_keys($data), function($item) {
             return is_numeric($item) ? $item : null;            

--- a/src/modules/EvaluationMethodTechnical/components/evaluation-method-technical--apply/script.js
+++ b/src/modules/EvaluationMethodTechnical/components/evaluation-method-technical--apply/script.js
@@ -19,9 +19,11 @@ app.component('evaluation-method-technical--apply', {
         return {
             processing: false,
             vacancies: this.entity.parent?.vacancies || this.entity.vacancies,
+            registrationListText: '',
             applyData: {
                 from: [0, max],
                 setStatusTo: '',
+                registrationNumbers: [],
                 cutoffScore: 0,
                 earlyRegistrations: false,
                 waitList: false,
@@ -93,6 +95,17 @@ app.component('evaluation-method-technical--apply', {
             this.tabSelected = event.tab.slug;
         },
 
+        parseRegistrationList(text) {
+            if (!text || !text.trim()) {
+                return [];
+            }
+
+            return text
+                .split(/[,;\s\n\r]+/)
+                .map(number => number.trim())
+                .filter(number => number.length > 0);
+        },
+
         setTabClassification() {
             this.applyData.cutoffScore = this.cutoffScore;
             this.applyData.earlyRegistrations = this.selectionType.includes('earlyRegistrations') ? true : false;
@@ -102,16 +115,29 @@ app.component('evaluation-method-technical--apply', {
             this.applyData.quantityVacancies = this.vacancies;
             delete this.applyData.from;
             delete this.applyData.setStatusTo;
+            delete this.applyData.registrationNumbers;
         },
 
         setTabScore() {
-            const propertiesToRemove = ['cutoffScore', 'earlyRegistrations', 'waitList', 'invalidateRegistrations', 'considerQuotas'];
+            const propertiesToRemove = ['cutoffScore', 'earlyRegistrations', 'waitList', 'invalidateRegistrations', 'considerQuotas', 'registrationNumbers'];
 
             for (const prop of propertiesToRemove) {
                 if (this.applyData.hasOwnProperty(prop)) {
                     delete this.applyData[prop];
                 }
             }
+        },
+
+        setTabRegistration() {
+            const propertiesToRemove = ['from', 'cutoffScore', 'earlyRegistrations', 'waitList', 'invalidateRegistrations', 'considerQuotas', 'quantityVacancies'];
+
+            for (const prop of propertiesToRemove) {
+                if (this.applyData.hasOwnProperty(prop)) {
+                    delete this.applyData[prop];
+                }
+            }
+
+            this.applyData.registrationNumbers = this.parseRegistrationList(this.registrationListText);
         },
 
         infosApplyData() {
@@ -123,6 +149,10 @@ app.component('evaluation-method-technical--apply', {
                 this.setTabScore();
             }
 
+            if (this.tabSelected === 'registration') {
+                this.setTabRegistration();
+            }
+
             this.applyData.tabSelected = this.tabSelected;
         },
 
@@ -131,6 +161,7 @@ app.component('evaluation-method-technical--apply', {
             this.applyData = {
                 from: [0, max],
                 setStatusTo: '',
+                registrationNumbers: [],
                 cutoffScore: 0,
                 earlyRegistrations: false,
                 waitList: false,
@@ -138,6 +169,7 @@ app.component('evaluation-method-technical--apply', {
                 considerQuotas: true,
                 quantityVacancies: this.vacancies
             };
+            this.registrationListText = '';
             this.selectionType = [];
             this.tabSelected = 'score';
             this.cutoffScore = this.entity.evaluationMethodConfiguration?.cutoffScore ?? 0;

--- a/src/modules/EvaluationMethodTechnical/components/evaluation-method-technical--apply/template.php
+++ b/src/modules/EvaluationMethodTechnical/components/evaluation-method-technical--apply/template.php
@@ -97,15 +97,13 @@ $this->import('
             <mc-tab label="<?= i::esc_attr__('Por inscrição') ?>" slug='registration'>
                 <div class="grid-12 classification__panel">
                     <div class="field col-12">
-                        <label>
-                            <?php i::_e('Lista de inscrições') ?>
-                            <div class="field opportunity-evaluation-committee__registration-list-textarea">
-                                <textarea
-                                    v-model="registrationListText"
-                                    placeholder="<?= i::esc_attr__('Preencha com os números de inscrição que o avaliador deve avaliar, separados por vírgula.') ?>"
-                                    rows="4"></textarea>
-                            </div>
-                        </label>
+                        <label><?php i::_e('Lista de inscrições') ?></label>
+                        <div class="field opportunity-evaluation-committee__registration-list-textarea">
+                            <textarea
+                                v-model="registrationListText"
+                                placeholder="<?= i::esc_attr__('Preencha com os números das inscrições em que deseja aplicar o resultado das avaliações, separados por vírgula.') ?>"
+                                rows="4"></textarea>
+                        </div>
                     </div>
 
                     <div class="field col-12">

--- a/src/modules/EvaluationMethodTechnical/components/evaluation-method-technical--apply/template.php
+++ b/src/modules/EvaluationMethodTechnical/components/evaluation-method-technical--apply/template.php
@@ -93,6 +93,29 @@ $this->import('
                     </div>
                 </div>
             </mc-tab>
+
+            <mc-tab label="<?= i::esc_attr__('Por inscrição') ?>" slug='registration'>
+                <div class="grid-12 classification__panel">
+                    <div class="field col-12">
+                        <label>
+                            <?php i::_e('Lista de inscrições') ?>
+                            <div class="field opportunity-evaluation-committee__registration-list-textarea">
+                                <textarea
+                                    v-model="registrationListText"
+                                    placeholder="<?= i::esc_attr__('Preencha com os números de inscrição que o avaliador deve avaliar, separados por vírgula.') ?>"
+                                    rows="4"></textarea>
+                            </div>
+                        </label>
+                    </div>
+
+                    <div class="field col-12">
+                        <label><?php i::_e('Selecione o status que deseja aplicar') ?></label>
+                        <select v-model="applyData.setStatusTo">
+                            <option v-for="item in statusList" :value="item.status">{{item.label}}</option>
+                        </select>
+                    </div>
+                </div>
+            </mc-tab>
         </mc-tabs>
     </template>
 

--- a/src/modules/EvaluationMethodTechnical/components/evaluation-method-technical--apply/template.php
+++ b/src/modules/EvaluationMethodTechnical/components/evaluation-method-technical--apply/template.php
@@ -97,9 +97,10 @@ $this->import('
             <mc-tab label="<?= i::esc_attr__('Por inscrição') ?>" slug='registration'>
                 <div class="grid-12 classification__panel">
                     <div class="field col-12">
-                        <label><?php i::_e('Lista de inscrições') ?></label>
+                        <label for="evaluation-technical-registration-list"><?php i::_e('Lista de inscrições') ?></label>
                         <div class="field opportunity-evaluation-committee__registration-list-textarea">
                             <textarea
+                                id="evaluation-technical-registration-list"
                                 v-model="registrationListText"
                                 placeholder="<?= i::esc_attr__('Preencha com os números das inscrições em que deseja aplicar o resultado das avaliações, separados por vírgula.') ?>"
                                 rows="4"></textarea>
@@ -107,8 +108,8 @@ $this->import('
                     </div>
 
                     <div class="field col-12">
-                        <label><?php i::_e('Selecione o status que deseja aplicar') ?></label>
-                        <select v-model="applyData.setStatusTo">
+                        <label for="evaluation-technical-registration-status"><?php i::_e('Selecione o status que deseja aplicar') ?></label>
+                        <select id="evaluation-technical-registration-status" v-model="applyData.setStatusTo">
                             <option v-for="item in statusList" :value="item.status">{{item.label}}</option>
                         </select>
                     </div>

--- a/tests/src/EvaluationMethodApplyResultsByRegistrationTest.php
+++ b/tests/src/EvaluationMethodApplyResultsByRegistrationTest.php
@@ -1,0 +1,77 @@
+<?php
+
+namespace Tests;
+
+use MapasCulturais\Entities\Registration;
+use PHPUnit\Framework\Attributes\DataProvider;
+use Tests\Abstract\TestCase;
+use Tests\Builders\PhasePeriods\ConcurrentEndingAfter;
+use Tests\Builders\PhasePeriods\Open;
+use Tests\Enums\EvaluationMethods;
+use Tests\Traits\OpportunityBuilder;
+use Tests\Traits\RegistrationDirector;
+use Tests\Traits\RequestFactory;
+use Tests\Traits\UserDirector;
+
+class EvaluationMethodApplyResultsByRegistrationTest extends TestCase
+{
+    use OpportunityBuilder,
+        RegistrationDirector,
+        RequestFactory,
+        UserDirector;
+
+    public static function evaluationMethods(): array
+    {
+        return [
+            'simplificada' => [EvaluationMethods::simple, 'simple', 'applyEvaluationsSimple'],
+            'documental' => [EvaluationMethods::documentary, 'documentary', 'applyEvaluationsDocumentary'],
+            'contínua' => [EvaluationMethods::simple, 'continuous', 'applyEvaluationsContinuous'],
+        ];
+    }
+
+    #[DataProvider('evaluationMethods')]
+    public function testApplyResultsByRegistration(
+        EvaluationMethods $evaluation_method,
+        string $type,
+        string $action
+    ): void {
+        $admin = $this->userDirector->createUser('admin');
+        $this->login($admin);
+
+        $opportunity = $this->opportunityBuilder
+            ->reset(owner: $admin->profile, owner_entity: $admin->profile)
+            ->fillRequiredProperties()
+            ->firstPhase()
+                ->setRegistrationPeriod(new Open)
+                ->done()
+            ->save()
+            ->addEvaluationPhase($evaluation_method)
+                ->setEvaluationPeriod(new ConcurrentEndingAfter)
+                ->save()
+                ->done()
+            ->getInstance();
+
+        if ($type === 'continuous') {
+            $opportunity->evaluationMethodConfiguration->type = $type;
+            $opportunity->evaluationMethodConfiguration->save(true);
+        }
+
+        $selected = $this->registrationDirector->createSentRegistration($opportunity, data: []);
+        $not_selected = $this->registrationDirector->createSentRegistration($opportunity, data: []);
+
+        $request = $this->requestFactory->POST(
+            controller_id: 'opportunity',
+            action: $action,
+            url_params: [$opportunity->id],
+            payload: [
+                'tabSelected' => 'registration',
+                'registrationNumbers' => [$selected->number, 'numero-inexistente'],
+                'to' => Registration::STATUS_APPROVED,
+            ]
+        );
+
+        $this->assertStatus200($request);
+        $this->assertSame(Registration::STATUS_APPROVED, $selected->refreshed()->status);
+        $this->assertSame(Registration::STATUS_SENT, $not_selected->refreshed()->status);
+    }
+}

--- a/tests/src/EvaluationMethodTechnicalTest.php
+++ b/tests/src/EvaluationMethodTechnicalTest.php
@@ -3273,15 +3273,23 @@ class EvaluationMethodTechnicalTest extends TestCase
 
         $selected_registrations = array_slice($eligible_registrations, 0, 2);
         $registration_numbers = array_column($selected_registrations, 'number');
+        $registration_numbers[] = $selected_registrations[0]['number'];
         $registration_numbers[] = 'numero-inexistente';
 
-        $found_ids = \EvaluationMethodTechnical\Module::i()->findRegistrationIdsForResultApplication(
+        $simple_method = $app->getRegisteredEvaluationMethodBySlug('simple')->evaluationMethod;
+
+        $found_ids = $simple_method->findRegistrationIdsForResultApplication(
             $technical_phase,
             $registration_numbers,
             Registration::STATUS_APPROVED
         );
 
         $this->assertEqualsCanonicalizing(array_column($selected_registrations, 'id'), $found_ids);
+        $this->assertSame([], $simple_method->findRegistrationIdsForResultApplication(
+            $technical_phase,
+            [],
+            Registration::STATUS_APPROVED
+        ));
     }
 
     public function testApplyResultsByScore()

--- a/tests/src/EvaluationMethodTechnicalTest.php
+++ b/tests/src/EvaluationMethodTechnicalTest.php
@@ -3247,6 +3247,43 @@ class EvaluationMethodTechnicalTest extends TestCase
         $this->assertGreaterThanOrEqual($cutoff_score, $lowest_score, "[PAGINAÇÃO] A menor nota deve ser >= {$cutoff_score} (nota de corte)");
     }
 
+    public function testFindRegistrationIdsForResultApplication()
+    {
+        $admin = $this->userDirector->createUser('admin');
+        $this->login($admin);
+
+        $opportunity = $this->createOpportunityWithQuotas($admin);
+        $technical_phase = $this->getTechnicalEvaluationOpportunity($opportunity);
+        $registrations = $this->quotaRegistrationDirector->idealQuotasScenario($opportunity);
+        $this->prepareTechnicalScenarioRegistrations($technical_phase, $registrations);
+
+        $app = App::i();
+        /** @var OpportunityController $opportunity_controller */
+        $opportunity_controller = $app->controller('opportunity');
+        $query_result = $opportunity_controller->apiFindRegistrations($technical_phase, [
+            '@select' => 'id,number,status',
+            '@order' => 'id ASC',
+        ], true);
+
+        $eligible_registrations = array_values(array_filter(
+            $query_result->registrations,
+            fn (array $registration) => in_array($registration['status'], [1, 3, 8, 10], true)
+        ));
+        $this->assertGreaterThanOrEqual(3, count($eligible_registrations));
+
+        $selected_registrations = array_slice($eligible_registrations, 0, 2);
+        $registration_numbers = array_column($selected_registrations, 'number');
+        $registration_numbers[] = 'numero-inexistente';
+
+        $found_ids = \EvaluationMethodTechnical\Module::i()->findRegistrationIdsForResultApplication(
+            $technical_phase,
+            $registration_numbers,
+            Registration::STATUS_APPROVED
+        );
+
+        $this->assertEqualsCanonicalizing(array_column($selected_registrations, 'id'), $found_ids);
+    }
+
     public function testApplyResultsByScore()
     {
         $admin = $this->userDirector->createUser('admin');


### PR DESCRIPTION
## Contexto

Em alguns editais, os gestores realizam a classificação, a seleção e a aplicação das cotas fora da plataforma, utilizando planilhas ou outras ferramentas. Depois desse processo, é necessário atualizar manualmente o status das inscrições no Mapas Culturais.

## Alterações

Este PR adiciona a aba **Por inscrição** ao modal **Aplicar resultados das avaliações** dos seguintes métodos de avaliação:

- técnica;
- simplificada;
- documental;
- contínua.

A nova aba permite:

- informar uma lista de números de inscrição;
- separar os números por vírgula, ponto e vírgula, espaço ou quebra de linha;
- selecionar o status que será aplicado;
- atualizar somente as inscrições válidas pertencentes à oportunidade e à fase atual;
- ignorar números duplicados, inexistentes ou inválidos sem interromper o processamento.

A seleção das inscrições foi centralizada na classe base dos métodos de avaliação, enquanto cada método continua utilizando seu próprio endpoint e preservando suas regras de status e demais efeitos do processamento.

Também foram realizados ajustes no layout, nos textos e na associação dos rótulos aos campos, mantendo a nova aba consistente e acessível nos diferentes modais.

<img width="582" height="471" alt="Aba Por inscrição no modal Aplicar resultados das avaliações" src="https://github.com/user-attachments/assets/7bab399d-c874-43a0-be0d-c652858519d1" />

## Benefício

A alteração facilita o dia a dia dos gestores que fazem a classificação, a seleção e o processamento das cotas fora da plataforma. Após concluir esse trabalho, eles podem copiar a lista de inscrições e aplicar o status correspondente em uma única operação, evitando alterações manuais inscrição por inscrição.

## Testes

Foram adicionados testes automatizados para:

- validar a seleção compartilhada das inscrições pelos números informados;
- garantir que somente inscrições válidas da oportunidade sejam selecionadas;
- verificar a aplicação do status nos métodos simplificado, documental e contínuo;
- preservar o funcionamento da aplicação de resultados na avaliação técnica.