### PR TITLE
Fix/formulario fase recurso

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,10 @@ Todas as mudanças notáveis no projeto serão documentadas neste arquivo.
 O formato é baseado no [Keep a Changelog](https://keepachangelog.com/pt-BR/1.0.0/)
 e este projeto adere ao [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+### Correções
+- Corrige a configuração do formulário da fase de recurso para criar a etapa inicial automaticamente e exibir corretamente a obrigatoriedade de campos e anexos ao editá-los
+
 ## [7.8.2] - 2026-07-24
 ### Correções
 - O botão Voltar da tela de avaliação leva de volta à lista de onde a pessoa veio (lista completa da gestão ou lista do avaliador), mesmo depois de trocar de inscrição pelo menu lateral

--- a/src/core/Entities/RegistrationFieldConfiguration.php
+++ b/src/core/Entities/RegistrationFieldConfiguration.php
@@ -272,7 +272,7 @@ class RegistrationFieldConfiguration extends \MapasCulturais\Entity {
         'title' => $this->title,
         'description' => $this->description,
         'maxSize' => $this->maxSize,
-        'required' => $this->required,
+        'required' => filter_var($this->required, FILTER_VALIDATE_BOOLEAN),
         'fieldType' => $this->fieldType,
         'fieldOptions' => $this->fieldOptions,
         'config' => $this->config ?: [],

--- a/src/core/Entities/RegistrationFileConfiguration.php
+++ b/src/core/Entities/RegistrationFileConfiguration.php
@@ -227,7 +227,7 @@ class RegistrationFileConfiguration extends \MapasCulturais\Entity {
             'ownerId' => $this->owner->id,
             'title' => $this->title,
             'description' => $this->description,
-            'required' => $this->required,
+            'required' => filter_var($this->required, FILTER_VALIDATE_BOOLEAN),
             'template' => $this->getFile('registrationFileTemplate'),
             'groupName' => $this->fileGroupName,
             'categories' => $this->categories ?: [],

--- a/src/modules/OpportunityAppealPhase/Module.php
+++ b/src/modules/OpportunityAppealPhase/Module.php
@@ -8,6 +8,7 @@ use MapasCulturais\Entities\EvaluationMethodConfiguration;
 use MapasCulturais\Entities\Notification;
 use MapasCulturais\Entities\Opportunity;
 use MapasCulturais\Entities\Registration;
+use MapasCulturais\Entities\RegistrationStep;
 use MapasCulturais\i;
 
 class Module extends \MapasCulturais\Module {
@@ -78,6 +79,11 @@ class Module extends \MapasCulturais\Module {
             try {
                 $appeal_phase->save(true);
 
+                $step = new RegistrationStep();
+                $step->name = '';
+                $step->opportunity = $appeal_phase;
+                $step->save(true);
+
                 $opportunity->appealPhase = $appeal_phase;
                 $opportunity->save(true);
 
@@ -104,6 +110,7 @@ class Module extends \MapasCulturais\Module {
                     'owner' => $opportunity,
                     'key' => 'appealPhase',
                 ])) {
+                    $conn->delete('registration_step', ['opportunity_id' => $orphan->id]);
                     $orphan->delete(true);
                 }
 

--- a/tests/src/OpportunityPhasesTest.php
+++ b/tests/src/OpportunityPhasesTest.php
@@ -1305,6 +1305,55 @@ class OpportunityPhasesTest extends TestCase
 
 
     /**
+     * Garante que uma fase de recurso seja criada com a etapa inicial do formulário.
+     */
+    function testCreateAppealPhaseCreatesDefaultRegistrationStep(): void
+    {
+        $app = $this->app;
+        $admin = $this->userDirector->createUser('admin');
+        $this->login($admin);
+
+        /** @var Opportunity $opportunity */
+        $opportunity = $this->opportunityBuilder
+            ->reset(owner: $admin->profile, owner_entity: $admin->profile)
+            ->fillRequiredProperties()
+            ->firstPhase()
+                ->setRegistrationPeriod(new Open)
+                ->done()
+            ->save()
+            ->addEvaluationPhase(EvaluationMethods::simple)
+                ->setEvaluationPeriod(new ConcurrentEndingAfter)
+                ->save()
+                ->done()
+            ->refresh()
+            ->getInstance();
+
+        $opportunityId = $opportunity->id;
+        $app->request = $this->requestFactory->mapasPOST('opportunity', 'createAppealPhase', [$opportunityId], ['id' => $opportunityId]);
+        $app->response = new Response();
+
+        /** @var OpportunityController $controller */
+        $controller = $app->controller('opportunity');
+        $controller->setRequestData(['id' => $opportunityId]);
+
+        try {
+            $controller->callAction('POST', 'createAppealPhase', []);
+        } catch (Halt) {
+        }
+
+        $app->em->clear();
+
+        $opportunity = $app->repo('Opportunity')->find($opportunityId);
+        $appealPhase = $opportunity->appealPhase;
+        $steps = $app->repo('RegistrationStep')->findBy(['opportunity' => $appealPhase]);
+
+        $this->assertNotNull($appealPhase, 'Garantindo que a fase de recurso tenha sido criada');
+        $this->assertCount(1, $steps, 'Garantindo que a fase de recurso tenha uma etapa inicial');
+        $this->assertSame('', $steps[0]->name, 'Garantindo que a etapa inicial tenha nome vazio');
+        $this->assertSame(0, $steps[0]->displayOrder, 'Garantindo que a etapa inicial seja a primeira');
+    }
+
+    /**
      * Garante que uma falha durante a criação da fase de recurso não deixa
      * fase órfã no banco (sem metadado appealPhase).
      */
@@ -1331,6 +1380,9 @@ class OpportunityPhasesTest extends TestCase
             ->getInstance();
 
         $opportunityId = $opportunity->id;
+        $stepCountBefore = (int) $app->em->getConnection()->fetchOne(
+            'SELECT COUNT(*) FROM registration_step'
+        );
 
         // Adiciona um hook que simula uma falha (timeout/erro) durante o save
         // da oportunidade principal, APÓS a fase de recurso ser criada mas ANTES
@@ -1377,6 +1429,12 @@ class OpportunityPhasesTest extends TestCase
         ]);
 
         $this->assertNull($appealPhaseMeta, 'Garantindo que o metadado appealPhase não foi salvo parcialmente no edital');
+
+        $stepCountAfter = (int) $app->em->getConnection()->fetchOne(
+            'SELECT COUNT(*) FROM registration_step'
+        );
+
+        $this->assertSame($stepCountBefore, $stepCountAfter, 'Garantindo que nenhuma etapa órfã permaneça no banco após falha');
     }
 
 }

--- a/tests/src/RegistrationConfigurationSerializationTest.php
+++ b/tests/src/RegistrationConfigurationSerializationTest.php
@@ -1,0 +1,57 @@
+<?php
+
+namespace Test;
+
+use MapasCulturais\Entities\Opportunity;
+use MapasCulturais\Entities\RegistrationFieldConfiguration;
+use MapasCulturais\Entities\RegistrationFileConfiguration;
+use Tests\Abstract\TestCase;
+use Tests\Traits\OpportunityBuilder;
+use Tests\Traits\UserDirector;
+
+class RegistrationConfigurationSerializationTest extends TestCase
+{
+    use OpportunityBuilder,
+        UserDirector;
+
+    function testRequiredIsSerializedAsBooleanForFieldsAndFiles(): void
+    {
+        $admin = $this->userDirector->createUser('admin');
+        $this->login($admin);
+
+        /** @var Opportunity $opportunity */
+        $opportunity = $this->opportunityBuilder
+            ->reset(owner: $admin->profile, owner_entity: $admin->profile)
+            ->fillRequiredProperties()
+            ->save()
+            ->getInstance();
+
+        $field = new RegistrationFieldConfiguration();
+        $field->owner = $opportunity;
+        $field->title = 'Campo de teste';
+        $field->fieldType = 'text';
+        $field->save(true);
+
+        $file = new RegistrationFileConfiguration();
+        $file->owner = $opportunity;
+        $file->title = 'Anexo de teste';
+        $file->save(true);
+
+        $field->required = 1;
+        $file->required = 'true';
+
+        $fieldJson = $field->jsonSerialize();
+        $fileJson = $file->jsonSerialize();
+
+        $this->assertIsBool($fieldJson['required']);
+        $this->assertTrue($fieldJson['required']);
+        $this->assertIsBool($fileJson['required']);
+        $this->assertTrue($fileJson['required']);
+
+        $field->required = 'false';
+        $file->required = 'false';
+
+        $this->assertFalse($field->jsonSerialize()['required']);
+        $this->assertFalse($file->jsonSerialize()['required']);
+    }
+}


### PR DESCRIPTION
## Contexto

A configuração do formulário da fase de recurso apresentava comportamentos diferentes das fases normais:

- A fase era criada sem uma etapa inicial de formulário.
- Ao editar um campo ou anexo obrigatório, o checkbox de obrigatoriedade não aparecia marcado, embora a configuração continuasse obrigatória ao salvar.

## Alterações

- Cria automaticamente uma etapa inicial ao criar uma fase de recurso.
- Remove a etapa criada caso ocorra uma falha durante a criação da fase, evitando registros órfãos.
- Normaliza o atributo `required` como booleano na serialização de campos e anexos.

## Como validar manualmente

1. Criar uma fase de recurso.
2. Abrir a configuração do formulário da fase.
3. Confirmar que uma etapa inicial já está disponível.
4. Criar um campo ou anexo obrigatório.
5. Salvar e editar novamente.
6. Confirmar que o checkbox de obrigatoriedade permanece marcado.