### PR TITLE
Reenviar link de validação de E-mail

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ e este projeto adere ao [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 ### Novas Funcionalidades
 - **Avaliação automática por selos**: o gestor pode indicar, em uma fase de avaliação, quais selos validam o proponente. Se a pessoa já tiver esses selos válidos no perfil, a inscrição é **dispensada automaticamente** daquela fase (marcada como “Dispensada por selos”) e segue para a próxima etapa, sem precisar de avaliador
 - **Novos anexos no cadastro do agente** (também usáveis como campos `@` no formulário de inscrição): CPF, CNPJ, CNH, RG, passaporte, comprovante de residência, vínculo territorial, currículo, portfólio, certidões fiscal, trabalhista e de prestação de contas, além de comprovantes de raça/cor, pessoa com deficiência e comunidades tradicionais. Os arquivos ficam no perfil e acompanham a inscrição automaticamente
+- **Reenvio do link de validação de conta**: na tela de gestão de usuários, o administrador vê se a conta já confirmou o e-mail e pode reenviar o link para quem ficou pendente, sem depender de orientar a pessoa a redefinir a senha. O link reenviado é o mesmo de antes, então e-mails já recebidos continuam válidos (depende de implementação feita no plugin-MultipleLocalAuth)
 
 ### Melhorias nos selos validadores
 - Mostra o **status de cada campo** do selo (válido, prestes a vencer, vencido etc.) na ficha e no formulário de avaliação, para o avaliador entender o que está ok e o que precisa de atenção

--- a/src/core/AuthProvider.php
+++ b/src/core/AuthProvider.php
@@ -247,4 +247,47 @@ abstract class AuthProvider {
             setcookie('mapasculturais.adm', $user_is_adm, 0, '/');
         }
     }
+
+    /**
+     * Indica se o provedor de autenticação valida a conta do usuário por e-mail
+     *
+     * Provedores que enviam ao usuário um link para validar a conta devem
+     * sobrescrever este método retornando true. O padrão é false para que a
+     * funcionalidade seja opcional: instalações que usam outros provedores não
+     * exibem nem executam nada relacionado a ela.
+     *
+     * Por ser um método declarado, sobrescrever é a única forma de implementá-lo:
+     * hooks `AuthProvider::supportsAccountValidation` não são aplicados, porque
+     * métodos declarados têm precedência sobre o Traits\MagicCallers.
+     *
+     * @return bool
+     */
+    function supportsAccountValidation(){
+        return false;
+    }
+
+    /**
+     * Indica se a conta do usuário já está validada
+     *
+     * O padrão é true porque provedores que não validam a conta por e-mail não
+     * têm contas pendentes de validação.
+     *
+     * @param Entities\User $user
+     * @return bool
+     */
+    function isAccountValidated(Entities\User $user){
+        return true;
+    }
+
+    /**
+     * Reenvia ao usuário o e-mail com o link de validação de conta
+     *
+     * O padrão é false, indicando que nenhum e-mail foi enviado.
+     *
+     * @param Entities\User $user
+     * @return bool true se o e-mail foi enviado
+     */
+    function resendAccountValidationEmail(Entities\User $user){
+        return false;
+    }
 }

--- a/src/modules/UserManagement/Module.php
+++ b/src/modules/UserManagement/Module.php
@@ -125,6 +125,27 @@ class Module extends \MapasCulturais\Module {
         return $app->user->is('admin') || $app->user->is('superAdmin');
     }
 
+    /**
+     * Indica se o usuário logado pode reenviar o link de validação de conta de outro usuário.
+     * Usa o mesmo critério de acesso da tela de detalhe do usuário.
+     *
+     * @return bool
+     */
+    public static function canUserResendAccountValidationEmail(): bool
+    {
+        $app = App::i();
+
+        if ($app->user->is('guest')) {
+            return false;
+        }
+
+        $can = $app->user->is('admin');
+
+        $app->applyHook('module(UserManagement).canResendAccountValidationEmail', [&$can]);
+
+        return $can;
+    }
+
     private static function getGlobalAccountDeletionEmailFromFile(): ?string
     {
         $file = self::getGlobalEmailConfigFilePath();
@@ -456,6 +477,58 @@ class Module extends \MapasCulturais\Module {
             }
 
             $this->json(['success' => true, 'email' => $email, 'scope' => 'global']);
+        });
+
+        /**
+         * Reenvia ao usuário o e-mail com o link de validação de conta.
+         *
+         * O core apenas orquestra: quem sabe gerar o link e montar o e-mail é o
+         * provedor de autenticação (\MapasCulturais\AuthProvider).
+         *
+         * A permissão é verificada antes de buscar o usuário para que quem não
+         * administra não consiga descobrir se um id existe pela diferença entre 403 e 404.
+         */
+        $app->hook('POST(panel.resendAccountValidationEmail)', function () use ($app) {
+            /** @var \MapasCulturais\Controllers\Panel $this */
+            $this->requireAuthentication();
+
+            if (!self::canUserResendAccountValidationEmail()) {
+                $this->errorJson(i::__('Permissão negada.'), 403);
+                return;
+            }
+
+            if (!$app->auth->supportsAccountValidation()) {
+                $this->errorJson(i::__('O provedor de autenticação não utiliza validação de conta por e-mail.'), 400);
+                return;
+            }
+
+            $user = $app->repo('User')->find($this->data['userId'] ?? -1);
+            if (!$user) {
+                $this->errorJson(i::__('Usuário não encontrado.'), 404);
+                return;
+            }
+
+            if ($app->auth->isAccountValidated($user)) {
+                $this->errorJson(i::__('Esta conta já está validada.'), 400);
+                return;
+            }
+
+            $send_error = i::__('Não foi possível reenviar o link de validação. Tente novamente mais tarde.');
+
+            try {
+                if (!$app->auth->resendAccountValidationEmail($user)) {
+                    $this->errorJson($send_error, 500);
+                    return;
+                }
+            } catch (Halt $e) {
+                throw $e;
+            } catch (\Throwable $e) {
+                $app->log->error($e->getMessage());
+                $this->errorJson($send_error, 500);
+                return;
+            }
+
+            $this->json(['success' => true, 'message' => i::__('Link de validação reenviado com sucesso.')]);
         });
 
         /**

--- a/src/modules/UserManagement/Module.php
+++ b/src/modules/UserManagement/Module.php
@@ -619,6 +619,17 @@ class Module extends \MapasCulturais\Module {
                 throw new PermissionDenied($app->user, null, i::__('Gerenciar Usuários'));
             }
 
+            // O estado da validação vem do provedor de autenticação, não do metadado:
+            // a ApiQuery só devolve metadados existentes, e um usuário anterior à
+            // validação por e-mail chegaria ao front sem a chave.
+            $supports_validation = $app->auth->supportsAccountValidation();
+
+            $app->view->jsObject['accountValidation'] = [
+                'supported' => $supports_validation,
+                'validated' => $supports_validation ? $app->auth->isAccountValidated($user) : true,
+                'canResend' => self::canUserResendAccountValidationEmail(),
+            ];
+
             $app->view->addRequestedEntityToJs(User::class, $this->data['id']);
             $this->render('user-detail');
         });

--- a/src/modules/UserManagement/components/user-mail/template.php
+++ b/src/modules/UserManagement/components/user-mail/template.php
@@ -9,6 +9,7 @@ use MapasCulturais\i;
 $this->import('
     entity-field
     mc-icon
+    user-management--resend-account-validation
 ');
 ?>
 <?php $this->applyTemplateHook('user-mail', 'before'); ?>
@@ -28,6 +29,7 @@ $this->import('
                 <mc-icon name="edit"></mc-icon>
                 <?php i::_e('Alterar email') ?>
             </a>
+            <user-management--resend-account-validation :entity="entity"></user-management--resend-account-validation>
         </div>
     </div>
 

--- a/src/modules/UserManagement/components/user-management--resend-account-validation/script.js
+++ b/src/modules/UserManagement/components/user-management--resend-account-validation/script.js
@@ -1,0 +1,85 @@
+app.component('user-management--resend-account-validation', {
+    template: $TEMPLATES['user-management--resend-account-validation'],
+
+    setup() {
+        const text = Utils.getTexts('user-management--resend-account-validation');
+        const messages = useMessages();
+        return { text, messages };
+    },
+
+    props: {
+        entity: {
+            type: Entity,
+            required: true
+        }
+    },
+
+    data() {
+        const config = $MAPAS.accountValidation || {};
+
+        return {
+            // Ausência da chave significa validada, espelhando o padrão do backend:
+            // provedor sem validação de conta não tem conta pendente.
+            supported: config.supported || false,
+            validated: config.validated !== false,
+            canResend: config.canResend || false,
+            sending: false,
+            sent: false,
+        };
+    },
+
+    computed: {
+        showButton() {
+            return this.supported && this.canResend && !this.validated;
+        }
+    },
+
+    methods: {
+        parseApiError(error) {
+            if (!error) {
+                return '';
+            }
+            if (typeof error.data === 'string') {
+                return error.data;
+            }
+            if (error.message) {
+                return error.message;
+            }
+            return '';
+        },
+
+        async resend() {
+            if (this.sending) {
+                return;
+            }
+
+            this.sending = true;
+
+            try {
+                const url = Utils.createUrl('panel', 'resendAccountValidationEmail');
+                const res = await fetch(url, {
+                    method: 'POST',
+                    headers: { 'Content-Type': 'application/json' },
+                    body: JSON.stringify({ userId: this.entity.id })
+                });
+
+                const data = await res.json().catch(() => ({}));
+
+                if (res.ok && !data.error) {
+                    this.sent = true;
+                    this.sendMessage(data.message || this.text('successMessage'), 'success');
+                } else {
+                    this.sendMessage(this.parseApiError(data) || this.text('errorMessage'), 'error');
+                }
+            } catch (e) {
+                this.sendMessage(this.text('errorMessage'), 'error');
+            } finally {
+                this.sending = false;
+            }
+        },
+
+        sendMessage(message, type = 'success') {
+            this.messages[type](message);
+        }
+    }
+});

--- a/src/modules/UserManagement/components/user-management--resend-account-validation/template.php
+++ b/src/modules/UserManagement/components/user-management--resend-account-validation/template.php
@@ -1,0 +1,38 @@
+<?php
+/**
+ * @var MapasCulturais\App $app
+ * @var MapasCulturais\Themes\BaseV2\Theme $this
+ */
+
+use MapasCulturais\i;
+
+$this->import('
+    mc-icon
+');
+?>
+<?php $this->applyTemplateHook('resend-account-validation', 'before'); ?>
+
+<span class="user-management-resend-account-validation" v-if="supported">
+    <?php $this->applyTemplateHook('resend-account-validation', 'begin'); ?>
+
+    <span class="user-management-resend-account-validation__status user-management-resend-account-validation__status--ok" v-if="validated">
+        <mc-icon name="check"></mc-icon>
+        <?php i::_e('Conta validada') ?>
+    </span>
+
+    <a class="user-management-resend-account-validation__action" v-else-if="showButton" :class="{'user-management-resend-account-validation__action--sending': sending}"
+       :title="sent ? text('sentHelp') : text('pendingHelp')" @click="resend">
+        <mc-icon name="send"></mc-icon>
+        <span v-if="sending"><?php i::_e('Enviando...') ?></span>
+        <span v-else><?php i::_e('Reenviar E-mail de validação') ?></span>
+    </a>
+
+    <span class="user-management-resend-account-validation__status user-management-resend-account-validation__status--pending" v-else>
+        <mc-icon name="email"></mc-icon>
+        <?php i::_e('Aguardando validação') ?>
+    </span>
+
+    <?php $this->applyTemplateHook('resend-account-validation', 'end'); ?>
+</span>
+
+<?php $this->applyTemplateHook('resend-account-validation', 'after'); ?>

--- a/src/modules/UserManagement/components/user-management--resend-account-validation/texts.php
+++ b/src/modules/UserManagement/components/user-management--resend-account-validation/texts.php
@@ -1,0 +1,10 @@
+<?php
+use MapasCulturais\i;
+
+return [
+    // Exibidos como tooltip da ação, não como texto na tela.
+    'pendingHelp' => i::__('Reenvia o e-mail com o link de validação para o endereço cadastrado nesta conta.'),
+    'sentHelp' => i::__('Link já reenviado. Peça ao usuário que verifique a caixa de entrada e a pasta de spam.'),
+    'successMessage' => i::__('Link de validação reenviado com sucesso.'),
+    'errorMessage' => i::__('Não foi possível reenviar o link de validação. Tente novamente mais tarde.'),
+];

--- a/src/themes/BaseV2/assets-src/sass/2.components/_user-management-resend-account-validation.scss
+++ b/src/themes/BaseV2/assets-src/sass/2.components/_user-management-resend-account-validation.scss
@@ -1,0 +1,35 @@
+@use '../0.settings/mixins' as *;
+
+.user-management-resend-account-validation {
+    // Alinha à direita da linha do e-mail sem alterar o layout do container,
+    // que não tem estilo próprio e é compartilhado com a tela de conta do usuário.
+    float: right;
+
+    &__status,
+    &__action {
+        align-items: center;
+        display: inline-flex;
+        gap: size(12);
+    }
+
+    &__status {
+        color: var(--mc-gray-500);
+    }
+
+    &__action {
+        cursor: pointer;
+
+        &--sending {
+            opacity: 0.6;
+            pointer-events: none;
+        }
+    }
+
+    // Em tela estreita o float encavalaria o endereço de e-mail. A ação passa para
+    // a linha de baixo em vez de ser escondida — é a única forma de reenviar o link.
+    @media (max-width: size(800)) {
+        display: block;
+        float: none;
+        margin-top: size(8);
+    }
+}

--- a/src/themes/BaseV2/assets-src/sass/theme-BaseV2.scss
+++ b/src/themes/BaseV2/assets-src/sass/theme-BaseV2.scss
@@ -215,6 +215,7 @@
 @import '2.components/user-accepted-terms';
 @import '2.components/user-mail';
 @import '2.components/user-management';
+@import '2.components/user-management-resend-account-validation';
 @import '2.components/_fields-visible-evaluators';
 
 

--- a/tests/src/AccountValidationResendTest.php
+++ b/tests/src/AccountValidationResendTest.php
@@ -1,0 +1,167 @@
+<?php
+
+namespace Tests;
+
+use MapasCulturais\App;
+use MapasCulturais\AuthProvider;
+use MapasCulturais\Entities\User;
+use Tests\Abstract\TestCase;
+use Tests\Doubles\ResendAccountValidationAuthProvider;
+use Tests\Traits\RequestFactory;
+use Tests\Traits\UserDirector;
+use UserManagement\Module as UserManagementModule;
+
+/**
+ * Cobre o endpoint de reenvio do link de validação de conta e o controle de acesso.
+ */
+class AccountValidationResendTest extends TestCase
+{
+    use RequestFactory, UserDirector;
+
+    protected AuthProvider $originalAuth;
+    protected ResendAccountValidationAuthProvider $provider;
+    protected User $admin;
+    protected User $target;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        // App::reset() não recria o provedor, então o double sobrevive ao reset do login().
+        $this->originalAuth = $this->app->auth;
+        $this->provider = new ResendAccountValidationAuthProvider($this->app->config['auth.config'] ?? []);
+        $this->app->auth = $this->provider;
+
+        $this->admin = $this->userDirector->createUser(['admin']);
+        $this->target = $this->userDirector->createUser();
+    }
+
+    protected function tearDown(): void
+    {
+        App::i()->auth = $this->originalAuth;
+
+        parent::tearDown();
+    }
+
+    private function resendRequest(?int $user_id = null)
+    {
+        return $this->requestFactory->POST('panel', 'resendAccountValidationEmail', payload: [
+            'userId' => $user_id ?? $this->target->id,
+        ]);
+    }
+
+    function testAdministradorReenviaOLink()
+    {
+        $this->login($this->admin);
+
+        $this->assertStatus200($this->resendRequest());
+        $this->assertSame([$this->target->id], $this->provider->resendCalls);
+    }
+
+    function testUsuarioNaoAutenticadoRecebe401()
+    {
+        $this->assertStatus401($this->resendRequest());
+        $this->assertEmpty($this->provider->resendCalls);
+    }
+
+    function testUsuarioSemPermissaoRecebe403()
+    {
+        $this->login($this->target);
+
+        $this->assertStatus403($this->resendRequest());
+        $this->assertEmpty($this->provider->resendCalls);
+    }
+
+    function testProvedorSemSuporteRecebe400()
+    {
+        $this->provider->supports = false;
+        $this->login($this->admin);
+
+        $this->assertStatus400($this->resendRequest());
+        $this->assertEmpty($this->provider->resendCalls);
+    }
+
+    function testUsuarioInexistenteRecebe404()
+    {
+        $this->login($this->admin);
+
+        $this->assertStatus404($this->resendRequest(999999999));
+        $this->assertEmpty($this->provider->resendCalls);
+    }
+
+    function testContaJaValidadaRecebe400()
+    {
+        $this->provider->validated = true;
+        $this->login($this->admin);
+
+        $this->assertStatus400($this->resendRequest());
+        $this->assertEmpty($this->provider->resendCalls);
+    }
+
+    function testFalhaNoEnvioRecebe500()
+    {
+        $this->provider->sendResult = false;
+        $this->login($this->admin);
+
+        $this->assertHttpStatusCode($this->resendRequest(), 500);
+    }
+
+    /**
+     * Garante que o catch de Throwable cobre o erro e que o catch de Halt anterior
+     * não engole a resposta.
+     */
+    function testExcecaoNoEnvioRecebe500()
+    {
+        $this->provider->throwOnSend = new \RuntimeException('falha no envio');
+        $this->login($this->admin);
+
+        $this->assertHttpStatusCode($this->resendRequest(), 500);
+    }
+
+    /**
+     * Um provedor que responda pela própria requisição interrompe o fluxo com Halt.
+     * O catch específico repassa a exceção para que a resposta dele prevaleça; sem ele,
+     * o catch de Throwable converteria tudo no erro genérico de envio.
+     */
+    function testRespostaDoProvedorNaoViraErroDeEnvio()
+    {
+        $this->provider->haltWithStatus = 202;
+        $this->login($this->admin);
+
+        $this->assertHttpStatusCode($this->resendRequest(), 202);
+    }
+
+    function testAdministradorPodeReenviar()
+    {
+        $this->login($this->admin);
+
+        $this->assertTrue(UserManagementModule::canUserResendAccountValidationEmail());
+    }
+
+    function testHookPodeConcederPermissaoAOutroPapel()
+    {
+        $this->login($this->target);
+
+        $this->app->hook('module(UserManagement).canResendAccountValidationEmail', function (&$can) {
+            $can = true;
+        });
+
+        $this->assertTrue(UserManagementModule::canUserResendAccountValidationEmail());
+
+        $this->app->clearHooks('module(UserManagement).canResendAccountValidationEmail');
+    }
+
+    function testUsuarioComumNaoPodeReenviar()
+    {
+        $this->login($this->target);
+
+        $this->assertFalse(UserManagementModule::canUserResendAccountValidationEmail());
+    }
+
+    function testVisitanteNaoPodeReenviar()
+    {
+        $this->logout();
+
+        $this->assertFalse(UserManagementModule::canUserResendAccountValidationEmail());
+    }
+}

--- a/tests/src/AccountValidationStateTest.php
+++ b/tests/src/AccountValidationStateTest.php
@@ -1,0 +1,82 @@
+<?php
+
+namespace Tests;
+
+use MapasCulturais\App;
+use MapasCulturais\AuthProvider;
+use Tests\Abstract\TestCase;
+use Tests\Doubles\ResendAccountValidationAuthProvider;
+use Tests\Traits\RequestFactory;
+use Tests\Traits\UserDirector;
+
+/**
+ * Cobre o estado de validação de conta que a tela de gestão publica para o front.
+ *
+ * O componente lê esses booleanos em vez do metadado do usuário, porque a ApiQuery
+ * só devolve metadados existentes e uma conta anterior à validação por e-mail
+ * chegaria sem a chave.
+ */
+class AccountValidationStateTest extends TestCase
+{
+    use RequestFactory, UserDirector;
+
+    protected AuthProvider $originalAuth;
+    protected ResendAccountValidationAuthProvider $provider;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->originalAuth = $this->app->auth;
+        $this->provider = new ResendAccountValidationAuthProvider($this->app->config['auth.config'] ?? []);
+        $this->app->auth = $this->provider;
+    }
+
+    protected function tearDown(): void
+    {
+        App::i()->auth = $this->originalAuth;
+
+        parent::tearDown();
+    }
+
+    private function openUserDetail(): array
+    {
+        $admin = $this->userDirector->createUser(['admin']);
+        $target = $this->userDirector->createUser();
+
+        $this->login($admin);
+        $this->assertStatus200($this->requestFactory->GET('panel', 'user-detail', [$target->id]));
+
+        return App::i()->view->jsObject['accountValidation'];
+    }
+
+    function testTelaPublicaContaPendenteDeValidacao()
+    {
+        $state = $this->openUserDetail();
+
+        $this->assertTrue($state['supported']);
+        $this->assertFalse($state['validated']);
+        $this->assertTrue($state['canResend']);
+    }
+
+    function testTelaPublicaContaJaValidada()
+    {
+        $this->provider->validated = true;
+
+        $this->assertTrue($this->openUserDetail()['validated']);
+    }
+
+    /**
+     * Sem suporte do provedor o estado é validado sem consultá-lo, para que a tela
+     * não ofereça uma ação que ninguém sabe executar.
+     */
+    function testProvedorSemSuporteNaoEConsultado()
+    {
+        $this->provider->supports = false;
+
+        $state = $this->openUserDetail();
+
+        $this->assertFalse($state['supported']);
+        $this->assertTrue($state['validated']);
+    }
+}

--- a/tests/src/AuthProviderAccountValidationTest.php
+++ b/tests/src/AuthProviderAccountValidationTest.php
@@ -1,0 +1,37 @@
+<?php
+
+namespace Tests;
+
+use MapasCulturais\App;
+use Tests\Abstract\TestCase;
+use Tests\Traits\UserDirector;
+
+/**
+ * Trava os valores padrão do contrato de validação de conta do AuthProvider.
+ *
+ * Provedores que não validam a conta por e-mail não devem oferecer nem executar
+ * o reenvio do link de validação.
+ */
+class AuthProviderAccountValidationTest extends TestCase
+{
+    use UserDirector;
+
+    function testProvedorNaoSuportaValidacaoDeContaPorPadrao()
+    {
+        $this->assertFalse(App::i()->auth->supportsAccountValidation());
+    }
+
+    function testContaEConsideradaValidadaPorPadrao()
+    {
+        $user = $this->userDirector->createUser();
+
+        $this->assertTrue(App::i()->auth->isAccountValidated($user));
+    }
+
+    function testReenvioNaoEnviaEmailPorPadrao()
+    {
+        $user = $this->userDirector->createUser();
+
+        $this->assertFalse(App::i()->auth->resendAccountValidationEmail($user));
+    }
+}

--- a/tests/src/AuthProviderAccountValidationTest.php
+++ b/tests/src/AuthProviderAccountValidationTest.php
@@ -3,6 +3,7 @@
 namespace Tests;
 
 use MapasCulturais\App;
+use MapasCulturais\AuthProviders\Test as TestAuthProvider;
 use Tests\Abstract\TestCase;
 use Tests\Traits\UserDirector;
 
@@ -11,27 +12,36 @@ use Tests\Traits\UserDirector;
  *
  * Provedores que não validam a conta por e-mail não devem oferecer nem executar
  * o reenvio do link de validação.
+ *
+ * A verificação é feita sobre uma instância de AuthProviders\Test, que não
+ * sobrescreve o contrato, e não sobre $app->auth — o provedor ativo varia
+ * conforme a suíte e passaria a testar uma implementação em vez do padrão.
  */
 class AuthProviderAccountValidationTest extends TestCase
 {
     use UserDirector;
 
+    private function provider(): TestAuthProvider
+    {
+        return new TestAuthProvider(App::i()->config['auth.config'] ?? []);
+    }
+
     function testProvedorNaoSuportaValidacaoDeContaPorPadrao()
     {
-        $this->assertFalse(App::i()->auth->supportsAccountValidation());
+        $this->assertFalse($this->provider()->supportsAccountValidation());
     }
 
     function testContaEConsideradaValidadaPorPadrao()
     {
         $user = $this->userDirector->createUser();
 
-        $this->assertTrue(App::i()->auth->isAccountValidated($user));
+        $this->assertTrue($this->provider()->isAccountValidated($user));
     }
 
     function testReenvioNaoEnviaEmailPorPadrao()
     {
         $user = $this->userDirector->createUser();
 
-        $this->assertFalse(App::i()->auth->resendAccountValidationEmail($user));
+        $this->assertFalse($this->provider()->resendAccountValidationEmail($user));
     }
 }

--- a/tests/src/Doubles/ResendAccountValidationAuthProvider.php
+++ b/tests/src/Doubles/ResendAccountValidationAuthProvider.php
@@ -1,0 +1,50 @@
+<?php
+
+namespace Tests\Doubles;
+
+use MapasCulturais\App;
+use MapasCulturais\AuthProviders\Test as TestAuthProvider;
+use MapasCulturais\Entities\User;
+
+/**
+ * Provedor que implementa o contrato de validação de conta e registra as chamadas
+ * recebidas, para que o endpoint de reenvio possa ser exercitado sem depender de
+ * um plugin.
+ *
+ * Cada propriedade pública controla um desfecho do reenvio: sucesso, falha por
+ * retorno falso, falha por exceção e resposta emitida pelo próprio provedor.
+ */
+class ResendAccountValidationAuthProvider extends TestAuthProvider
+{
+    public bool $supports = true;
+    public bool $validated = false;
+    public bool $sendResult = true;
+    public ?\Throwable $throwOnSend = null;
+    public ?int $haltWithStatus = null;
+    public array $resendCalls = [];
+
+    function supportsAccountValidation()
+    {
+        return $this->supports;
+    }
+
+    function isAccountValidated(User $user)
+    {
+        return $this->validated;
+    }
+
+    function resendAccountValidationEmail(User $user)
+    {
+        $this->resendCalls[] = $user->id;
+
+        if ($this->haltWithStatus) {
+            App::i()->halt($this->haltWithStatus);
+        }
+
+        if ($this->throwOnSend) {
+            throw $this->throwOnSend;
+        }
+
+        return $this->sendResult;
+    }
+}


### PR DESCRIPTION
# Contexto

Usuário admin pode reenviar link de validação do e-mail na tela de gestão de usuários.

<img width="1098" height="505" alt="image" src="https://github.com/user-attachments/assets/320366d3-c437-4401-80f0-466484c9b3d7" />

# plugin-MultipleLocalAuth

Essa implementação possui dependência direta do https://github.com/mapasculturais/plugin-MultipleLocalAuth/pull/87, não podendo subir de forma separada