### PR TITLE
fix(i18n): envolve 30 strings hardcoded em funções de tradução

### DIFF
--- a/src/modules/Entities/components/entity-links/template.php
+++ b/src/modules/Entities/components/entity-links/template.php
@@ -51,7 +51,7 @@ $this->import('
         <div v-for="(link, index) in newLinks" class="entity-links__item">
             <div class="grid-12">
                 <div class="field col-6">
-                    <label for="">Título</label>
+                    <label for=""><?= i::__('Título') ?></label>
                     <input v-model="link.title" class="newLinkTitle" type="text" name="newLinkTitle" />
                 </div>
 

--- a/src/modules/OpportunityAccountability/EvaluationMethod.php
+++ b/src/modules/OpportunityAccountability/EvaluationMethod.php
@@ -57,8 +57,14 @@ class EvaluationMethod extends \MapasCulturais\EvaluationMethod {
 
         $app->view->enqueueScript('app', 'accountability-evaluation', 'js/ng.evaluationMethod.accountability.js', ['entity.module.opportunity']);
         $app->view->enqueueStyle('app', 'accountability-evaluation-method', 'css/accountability-evaluation-method.css');
-        
+
         $app->view->jsObject['angularAppDependencies'][] = 'ng.evaluationMethod.accountability';
+
+        $app->view->localizeScript('accountability', [
+            'confirmFinishTechnicalOpinion' => i::__("Você tem certeza que deseja finalizer o parecer técnico?\n\nApós a finalização não será mais possível modificar o parecer."),
+            'confirmReopenAccountability' => i::__("Você tem certeza que deseja reabrir a prestação de contas?\n\nA abertura dos campos para edição deverá ser feita manualmente."),
+            'confirmPublishResult' => i::__('ATENÇÃO, essa ação é irreversível! Você tem certeza que deseja publicar o resultado dessa inscrição?'),
+        ]);
     }
 
     public function _init() {

--- a/src/modules/OpportunityAccountability/assets/js/ng.evaluationMethod.accountability.js
+++ b/src/modules/OpportunityAccountability/assets/js/ng.evaluationMethod.accountability.js
@@ -270,7 +270,7 @@
         };
 
         $scope.sendEvaluation = function () {
-            if (!confirm("Você tem certeza que deseja finalizer o parecer técnico?\n\nApós a finalização não será mais possível modificar o parecer.")) {
+            if (!confirm(MapasCulturais.gettext.accountability['confirmFinishTechnicalOpinion'])) {
                 return;
             }
 
@@ -292,8 +292,7 @@
                 return;  
             }
 
-            // TODO: i18n
-            if (!confirm("Você tem certeza que deseja reabrir a prestação de contas?\n\nA abertura dos campos para edição deverá ser feita manualmente.")) {
+            if (!confirm(MapasCulturais.gettext.accountability['confirmReopenAccountability'])) {
                 return;
             }
             AccountabilityEvaluationService.reopen(registrationId, $scope.evaluationData, MapasCulturais.evaluation.user).success(function () {
@@ -386,7 +385,7 @@
         }
         
         $scope.publishedResult = function(registration){
-            if (!confirm("ATENÇÃO, essa ação é irreversível! Você tem certeza que deseja publicar o resultado dessa inscrição?")) {
+            if (!confirm(MapasCulturais.gettext.accountability['confirmPublishResult'])) {
                 return;
             }
 

--- a/src/modules/OpportunityWorkplan/components/opportunity-enable-workplan/template.php
+++ b/src/modules/OpportunityWorkplan/components/opportunity-enable-workplan/template.php
@@ -44,8 +44,8 @@ $this->import('
             </div>
 
             <template #actions="modal">
-                <button class="button" @click="modal.close()">Cancelar</button>
-                <button class="button button--primary" @click="changeLabels(modal)">Alterar</button>
+                <button class="button" @click="modal.close()"><?= i::__('Cancelar') ?></button>
+                <button class="button button--primary" @click="changeLabels(modal)"><?= i::__('Alterar') ?></button>
             </template>
 
             <template #button="modal">
@@ -95,8 +95,8 @@ $this->import('
                         </div>
 
                         <template #actions="modal">
-                            <button class="button" @click="modal.close()">Cancelar</button>
-                            <button class="button button--primary" @click="changeLabels(modal)">Alterar</button>
+                            <button class="button" @click="modal.close()"><?= i::__('Cancelar') ?></button>
+                            <button class="button button--primary" @click="changeLabels(modal)"><?= i::__('Alterar') ?></button>
                         </template>
 
                         <template #button="modal">
@@ -144,8 +144,8 @@ $this->import('
                         </div>
 
                         <template #actions="modal">
-                            <button class="button" @click="modal.close()">Cancelar</button>
-                            <button class="button button--primary" @click="changeLabels(modal)">Alterar</button>
+                            <button class="button" @click="modal.close()"><?= i::__('Cancelar') ?></button>
+                            <button class="button button--primary" @click="changeLabels(modal)"><?= i::__('Alterar') ?></button>
                         </template>
 
                         <template #button="modal">

--- a/src/modules/Reports/Module.php
+++ b/src/modules/Reports/Module.php
@@ -158,6 +158,10 @@ class Module extends \MapasCulturais\Module
         $app->view->enqueueStyle('app', 'reports', 'css/reports.css');
         $app->view->enqueueScript('app', 'reports', 'js/ng.reports.js', ['entity.module.opportunity']);
         $app->view->jsObject['angularAppDependencies'][] = 'ng.reports';
+
+        $app->view->localizeScript('reports', [
+            'confirmDeleteChart' => i::__('Você tem certeza que deseja deletar esse gráfico?'),
+        ]);
     }
 
     /**

--- a/src/modules/Reports/assets/js/ng.reports.js
+++ b/src/modules/Reports/assets/js/ng.reports.js
@@ -466,7 +466,7 @@
 
         $scope.deleteGraphic = function (id) {
             
-            if (!confirm("Você tem certeza que deseja deletar esse gráfico?")) {
+            if (!confirm(MapasCulturais.gettext.reports['confirmDeleteChart'])) {
                 return;
             }
 

--- a/src/modules/Seals/components/seal-relation-view/template.php
+++ b/src/modules/Seals/components/seal-relation-view/template.php
@@ -14,7 +14,7 @@ $this->import('
     <div class="seal-relation-view__main">
         <div id="print">
             <div class="seal-relation-view__backlink">
-                <mc-icon name="arrow-left" class="seal-relation-view__backlink--icon"></mc-icon><a href="#">Voltar</a>
+                <mc-icon name="arrow-left" class="seal-relation-view__backlink--icon"></mc-icon><a href="#"><?= \MapasCulturais\i::__('Voltar') ?></a>
             </div>
             <div class="seal-relation-view__content">
                 <div class="seal-relation-view__content--top">

--- a/src/modules/Support/Module.php
+++ b/src/modules/Support/Module.php
@@ -282,6 +282,10 @@ class Module extends \MapasCulturais\Module
         $app->view->enqueueStyle('app', 'support', 'css/support.css');
         $app->view->enqueueScript('app', 'support', 'js/ng.support.js', ['entity.module.opportunity']);
         $app->view->jsObject['angularAppDependencies'][] = 'ng.support';
+
+        $app->view->localizeScript('support', [
+            'confirmRemoveAgentRelation' => \MapasCulturais\i::__('Voce realmente deseja remover a relação deste agente?'),
+        ]);
     }
 
     public function isSupportUser($opportunity, $user)

--- a/src/modules/Support/assets/js/ng.support.js
+++ b/src/modules/Support/assets/js/ng.support.js
@@ -195,7 +195,7 @@
             };
 
           
-            if(confirm('Voce realmente deseja remover a relação deste agente?')){
+            if(confirm(MapasCulturais.gettext.support['confirmRemoveAgentRelation'])){
                 SupportService.deleteRelation(MapasCulturais.entity.id, data).success(function (data, status, headers) {
                     $scope.data.agentsRelations.forEach(function (item, index){
                         if(item.agent.id == agentId){

--- a/src/themes/BaseV1/Theme.php
+++ b/src/themes/BaseV1/Theme.php
@@ -1809,6 +1809,8 @@ class Theme extends MapasCulturais\Theme {
             'Cancelar'      => i::__('Cancelar'),
             'confirmRemoveEntity'  => i::__('Você deseja excluir a entidade?'),
             'confirmDestroyEntity'  => i::__('Você deseja excluir definitivamente a entidade? Esta operação não poderá ser desfeita.'),
+            'confirmPublishRegistrations'  => i::__('ATENÇÃO, Essa ação é uma ação irreversível. Caso a próxima fase seja uma prestação de contas, primeiro crie a fase de prestação de contas para só depois fazer a publicação.'),
+            'confirmRemoveItem'  => i::__('Deseja remover este item?'),
         ]);
         $locale_specific_js = file_exists(dirname(__FILE__)  . '/assets/js/locale-specific/' . i::get_locale() . '.js') ? 'js/locale-specific/' . i::get_locale() . '.js' : 'js/locale-specific/default.js' ;
         $this->enqueueScript('app', 'mapasculturais-locale-specific', $locale_specific_js, array('mapasculturais'));
@@ -1869,6 +1871,7 @@ class Theme extends MapasCulturais\Theme {
 
         $this->enqueueScript('app', 'editable', 'js/editable.js', array('mapasculturais'));
         $this->localizeScript('editable', [
+            'confirmDeleteMetalistItem'    => i::__('Tem Certeza de que deseja excluir este item?'),
             'cancel'    => i::__('Cancelar Alteração (Esc)'),
             'confirm'    => i::__('Confirmar Alteração (Enter)'),
             'confirmC'    => i::__('Confirmar Alteração (Ctrl+Enter)'),

--- a/src/themes/BaseV1/assets/js/editable.js
+++ b/src/themes/BaseV1/assets/js/editable.js
@@ -978,7 +978,7 @@ MapasCulturais.MetalistManager = {
 
         // Delete Button
         $('.js-metalist-form .js-metalist-item-delete').on('click', function(){
-            if(confirm('Tem Certeza de que deseja excluir este item?')){
+            if(confirm(MapasCulturais.gettext.editable['confirmDeleteMetalistItem'])){
                 $form = $(this).parent();
                 $form.find('input:hidden[name="metalist_action"]').val('delete');
                 $form.find('input:submit').click();

--- a/src/themes/BaseV1/assets/js/mapasculturais.js
+++ b/src/themes/BaseV1/assets/js/mapasculturais.js
@@ -41,9 +41,8 @@ function copyToClipboard(element) {
     }
 }
 
-/**@TODO Internacionalizar */
 function alertPublish(id){
-    MapasCulturais.confirm('ATENÇÃO, Essa ação é uma ação irreversível. Caso a próxima fase seja uma prestação de contas, primeiro crie a fase de prestação de contas para só depois fazer a publicação.', function () {
+    MapasCulturais.confirm(MapasCulturais.gettext.mapas['confirmPublishRegistrations'], function () {
         var url = MapasCulturais.createUrl('opportunity', 'publishRegistrations', [id]);
         $.get(url, function() {
             MapasCulturais.Messages.success('Resultado publicado');
@@ -813,7 +812,7 @@ MapasCulturais.Remove = {
         $('body').on('click', '.js-remove-item', function (e) {
             e.stopPropagation();
             var $this = $(this);
-            MapasCulturais.confirm('Deseja remover este item?', function () {
+            MapasCulturais.confirm(MapasCulturais.gettext.mapas['confirmRemoveItem'], function () {
                 var $target = $($this.data('target'));
                 var href = $this.data('href');
 

--- a/src/themes/BaseV1/assets/js/ng.entity.module.opportunity.js
+++ b/src/themes/BaseV1/assets/js/ng.entity.module.opportunity.js
@@ -2961,7 +2961,7 @@ module.controller('OpportunityController', ['$scope', '$rootScope', '$anchorScro
             };
 
             $scope.removeRegistrationRulesFile = function (id, $index) {
-                if(confirm('Deseja remover este anexo?')){
+                if(confirm(MapasCulturais.gettext.moduleOpportunity['confirmAttachmentRemoved'])){
                     let url = MapasCulturais.createUrl('file','single',{id:$scope.data.entity.registrationRulesFile.id});
                     $http.delete(url).success(function(response){
                         $scope.data.entity.registrationRulesFile = null;

--- a/src/themes/BaseV1/layouts/parts/panel-agent.php
+++ b/src/themes/BaseV1/layouts/parts/panel-agent.php
@@ -33,7 +33,7 @@ $_type = is_object($entity->type) ? $entity->type->name : "";
         <?php
         if(!$can_edit){
             ?>
-            <a href="http://culturaviva.gov.br/cadastrar" target="_blank" rel='noopener noreferrer'>Usuário criado na rede cultura viva</a>
+            <a href="http://culturaviva.gov.br/cadastrar" target="_blank" rel='noopener noreferrer'><?php \MapasCulturais\i::_e("Usuário criado na rede cultura viva");?></a>
             <?php
         }else{
         ?>

--- a/src/themes/BaseV1/layouts/parts/related-seals.php
+++ b/src/themes/BaseV1/layouts/parts/related-seals.php
@@ -37,7 +37,7 @@ $this->addRelatedSealsToJs($entity);
                     <div class="descricao-do-selo">
                         <h1><a ng-href="<?php echo $app->createUrl('seal','sealrelation',[$idRelation]);?>" class="ng-binding">{{relation.seal.name}}</a></h1>
                         <p>
-                            <span ng-if="relation.toExpire === 2"><b>Não expira</b></span>
+                            <span ng-if="relation.toExpire === 2"><b><?php \MapasCulturais\i::_e("Não expira");?></b></span>
                             <span ng-if="relation.toExpire === 1"><b>Expira em: {{relation.validateDate}}</b></span>
                             <span ng-if="relation.toExpire === 0"><b>Expirou em: {{relation.validateDate}}</b></span>
                         </p>

--- a/src/themes/BaseV1/layouts/parts/singles/header-image.php
+++ b/src/themes/BaseV1/layouts/parts/singles/header-image.php
@@ -23,7 +23,7 @@ if ($header = $entity->getFile('header')){
     <?php if($this->isEditable()): ?>
         <div id="remove-background-button" class="<?php echo $removeBackgroundButtonClass; ?>">            
             <a class="btn btn-default delete banner-delete button-position-delete" title="<?php \MapasCulturais\i::esc_attr_e("Excluir capa");?>" 
-                data-href="<?php echo $removeBackgroundButtonUrl; ?>">Excluir</a>
+                data-href="<?php echo $removeBackgroundButtonUrl; ?>"><?php \MapasCulturais\i::_e("Excluir");?></a>
         </div>
     <?php endif; ?>
 </div>

--- a/src/themes/BaseV1/layouts/parts/singles/list-entities.php
+++ b/src/themes/BaseV1/layouts/parts/singles/list-entities.php
@@ -1,7 +1,6 @@
 
     <?php if(is_array($entities) && count($entities) > 0): ?>
     <div class="widget">
-        <h3>Projetos</h3>
         <h3><?php $this->dict($title); ?></h3>
         <ul class="widget-list js-slimScroll">
             <?php foreach($entities as $entity): ?>

--- a/src/themes/BaseV1/layouts/parts/singles/opportunity-projects--tab-content.php
+++ b/src/themes/BaseV1/layouts/parts/singles/opportunity-projects--tab-content.php
@@ -45,7 +45,7 @@ $app = \MapasCulturais\App::i();
     </div><!-- /.card -->
 
     <footer>
-        <button ng-if="!(data.projectsAPIMetadata.numPages == data.projectsAPIMetadata.page)" ng-click="loadMore()">Carregar mais</button>
+        <button ng-if="!(data.projectsAPIMetadata.numPages == data.projectsAPIMetadata.page)" ng-click="loadMore()"><?php i::_e('Carregar mais'); ?></button>
     </footer>
 
 </div><!-- /ng-controller OpportunityProjects -->

--- a/src/themes/BaseV1/layouts/parts/singles/opportunity-registrations--tables--manager.php
+++ b/src/themes/BaseV1/layouts/parts/singles/opportunity-registrations--tables--manager.php
@@ -89,7 +89,7 @@ use MapasCulturais\i;
                 <?php i::_e("Avaliação");?>
             </th>
             <th ng-show="data.registrationTableColumns.status" class="registration-status-col">
-                <mc-select placeholder="Status" model="registrationsFilters['status']" data="data.registrationStatuses"></mc-select>
+                <mc-select placeholder="<?php i::esc_attr_e("Status");?>" model="registrationsFilters['status']" data="data.registrationStatuses"></mc-select>
             </th>
 
             <?php $this->applyTemplateHook('registration-list-header','end'); ?>

--- a/src/themes/BaseV1/layouts/parts/singles/registration-edit--spaces.php
+++ b/src/themes/BaseV1/layouts/parts/singles/registration-edit--spaces.php
@@ -7,7 +7,7 @@
     <div class="registration-fieldset">
         <h4 id="registration-space-title"><?php \MapasCulturais\i::_e("Espaço Vinculado"); ?>
         <span class="registration-label"></span></h4> 
-            <div class="registration-help">Selecione um espaço a ser vinculado à inscrição</div>
+            <div class="registration-help"><?php \MapasCulturais\i::_e("Selecione um espaço a ser vinculado à inscrição");?></div>
                 <div id="registration-space" class="registration-list-item registration-edit-mode ng-scope">
                     <p ng-if="data.entity.registrationSpace.status < 0" class="alert warning" 
                         style="display:block !important /* está oculto no scss */" ><?php \MapasCulturais\i::_e("Aguardando confirmação");?>

--- a/src/themes/BaseV1/layouts/parts/singles/subsite-filters.php
+++ b/src/themes/BaseV1/layouts/parts/singles/subsite-filters.php
@@ -48,7 +48,7 @@ function printSubsiteFilter($property){
 
     <?php $this->applyTemplateHook('subsite-filters-space','before'); ?>
     <section class="filter-section">
-        <header>Espaços</header>
+        <header><?php i::_e('Espaços'); ?></header>
         <?php $this->applyTemplateHook('subsite-filters-space','begin'); ?>
         <p>
           <span class="label <?php echo ($entity->isPropertyRequired($entity,"filtro_space_term_area") && $editEntity? 'required': '');?>"><?php i::_e('Área de Atuação do Espaço:'); ?> </span>
@@ -77,7 +77,7 @@ function printSubsiteFilter($property){
 
     <?php $this->applyTemplateHook('subsite-filters-event','before'); ?>
     <section class="filter-section">
-        <header>Eventos</header>
+        <header><?php i::_e('Eventos'); ?></header>
         <?php $this->applyTemplateHook('subsite-filters-event','begin'); ?>
         <p>
             <span class="label <?php echo ($entity->isPropertyRequired($entity,"filtro_event_term_linguagem") && $editEntity? 'required': '');?>"><?php i::_e('Linguagem:'); ?> </span>

--- a/src/themes/BaseV1/views/auth/fake-authentication.php
+++ b/src/themes/BaseV1/views/auth/fake-authentication.php
@@ -140,7 +140,7 @@
                         '<tr>',
                         '    <td colspan="5"',
                         '       style="text-align: center; color: #0000cc; background: #ddddff;">',
-                        '       <strong>Filtrando usuários</strong>',
+                        '       <strong><?php echo \MapasCulturais\i::__('Filtrando usuários'); ?></strong>',
                         '    </td>',
                         '</tr>'
                     ].join(''));
@@ -166,7 +166,7 @@
                             '<tr>',
                             '    <td colspan="5"',
                             '       style="text-align: center;color: #ee0000;background: #ffdddd;">',
-                            '       <strong>Nenhum registro encontrado</strong>',
+                            '       <strong><?php echo \MapasCulturais\i::__('Nenhum registro encontrado'); ?></strong>',
                             '    </td>',
                             '</tr>'
                         ].join(''));

--- a/src/themes/BaseV1/views/panel/seals.php
+++ b/src/themes/BaseV1/views/panel/seals.php
@@ -34,7 +34,7 @@ $arquivo_num = count($user->archivedSeals);
     </ul>
     <!-- #ativos-->
     <div id="ativos">
-        <p>Aqui estão listados todos os selos que você tem permissão de editar</p>
+        <p><?php i::_e('Aqui estão listados todos os selos que você tem permissão de editar'); ?></p>
         <?php foreach($seals as $entity): if($app->user->profile->equals($entity)) continue;?>
             <?php $this->part('panel-seal', array('entity' => $entity)); ?>
         <?php endforeach; ?>


### PR DESCRIPTION
Cobre os 4 padrões detectados na auditoria de i18n:

- Views/layouts do BaseV1 com texto puro em HTML sem i::_e()/i::__() (fake-authentication.php, seals.php, panel-agent.php, related-seals.php, header-image.php, opportunity-projects--tab-content.php, registration-edit--spaces.php, subsite-filters.php).
- Um placeholder hardcoded (opportunity-registrations--tables--manager.php).
- template.php de componentes Vue com texto solto fora da interpolação (entity-links, seal-relation-view, opportunity-enable-workplan x3 repetido).
- confirm()/alert() de JS clássico (não Vue) que nunca passavam pelo mecanismo localizeScript()/MapasCulturais.gettext: foram criados os grupos 'accountability' e 'reports'/'support' (antes inexistentes) e adicionadas chaves aos grupos 'editable' e 'mapas' já existentes no Theme.php. ng.entity.module.opportunity.js já tinha a chave pronta no Theme.php ('confirmAttachmentRemoved'), só faltava usá-la.

De quebra, list-entities.php tinha um <h3> duplicado (um hardcoded em português e o de ao lado já traduzido dinamicamente via $this->dict()) — removido o duplicado em vez de traduzi-lo, já que renderizava dois cabeçalhos.

Fora do escopo: __TemplateAngularModule__.js tem um alert() hardcoded, mas é um arquivo de scaffold sem nenhum enqueue real no projeto (não é usado em produção).