### PR TITLE
Corrige a persistência visual dos filtros individuais configurados para cada pessoa avaliadora na distribuição das avaliações

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ O formato é baseado no [Keep a Changelog](https://keepachangelog.com/pt-BR/1.0.
 e este projeto adere ao [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [UNRELEASED]
+### Correções
+- Mantém visíveis, após recarregar a página, os filtros individuais configurados para cada pessoa avaliadora na distribuição das avaliações
+
 ### Melhorias
 - Ajusta tamanho dos cards da seção "Em destaque" na página inicial
 

--- a/src/core/Controllers/EvaluationMethodConfiguration.php
+++ b/src/core/Controllers/EvaluationMethodConfiguration.php
@@ -423,6 +423,7 @@ class EvaluationMethodConfiguration extends Controller {
             $relation->setSelectionFields($this->data['selectionFields']);
         }
 
+        $relation->setFiltersStoredOnRelation(true);
         $relation->save(true);
         $this->json(true);
     }

--- a/src/core/Entities/EvaluationMethodConfigurationAgentRelation.php
+++ b/src/core/Entities/EvaluationMethodConfigurationAgentRelation.php
@@ -138,6 +138,7 @@ class EvaluationMethodConfigurationAgentRelation extends AgentRelation {
         $this->metadata->ranges = $this->metadata->ranges ?? null;
         $this->metadata->distribution = $this->metadata->distribution ?? null;
         $this->metadata->selectionFields = $this->metadata->selectionFields ?? null;
+        $this->metadata->filtersStoredOnRelation = $this->metadata->filtersStoredOnRelation ?? false;
         $this->metadata->committeeSequentialNumber = $this->metadata->committeeSequentialNumber ?? null;
 
         return $this->metadata;
@@ -282,6 +283,19 @@ class EvaluationMethodConfigurationAgentRelation extends AgentRelation {
     {
         $this->initializeMetadata();
         $this->metadata->selectionFields = $selection_fields ? (object) $selection_fields : null;
+        $this->metadata = (object) (array) $this->metadata;
+    }
+
+    public function getFiltersStoredOnRelation(): bool
+    {
+        $this->initializeMetadata();
+        return (bool) $this->metadata->filtersStoredOnRelation;
+    }
+
+    public function setFiltersStoredOnRelation(bool $stored): void
+    {
+        $this->initializeMetadata();
+        $this->metadata->filtersStoredOnRelation = $stored;
         $this->metadata = (object) (array) $this->metadata;
     }
 

--- a/src/modules/Opportunities/components/opportunity-evaluation-committee/script.js
+++ b/src/modules/Opportunities/components/opportunity-evaluation-committee/script.js
@@ -568,13 +568,35 @@ app.component('opportunity-evaluation-committee', {
                         }
                     }
 
-                    this.evaluatorDistributionRules[info.agentUserId] = this.getEvaluatorDistributionRule(info.agentUserId);
+                    this.evaluatorDistributionRules[info.agentUserId] = this.getEvaluatorDistributionRule(info);
                     info.default = (this.entity.fetch[info.agentUserId] || this.entity.fetchCategories[info.agentUserId].length > 0 || this.entity.fetchRanges[info.agentUserId].length > 0 || this.entity.fetchProponentTypes[info.agentUserId].length > 0) ? false : true;
                 });
             }
         },
 
-        getEvaluatorDistributionRule(agentUserId) {
+        getEvaluatorDistributionRule(infoReviewer) {
+            const agentUserId = infoReviewer.agentUserId;
+            const metadata = infoReviewer.metadata || {};
+            const hasRelationFilters = metadata.filtersStoredOnRelation === true ||
+                (Array.isArray(metadata.categories) && metadata.categories.length > 0) ||
+                (Array.isArray(metadata.proponentTypes) && metadata.proponentTypes.length > 0) ||
+                (Array.isArray(metadata.ranges) && metadata.ranges.length > 0) ||
+                (typeof metadata.distribution === 'string' && metadata.distribution.length > 0) ||
+                (metadata.selectionFields && typeof metadata.selectionFields === 'object' && Object.keys(metadata.selectionFields).length > 0);
+
+            if (hasRelationFilters) {
+                return {
+                    categories: Array.isArray(metadata.categories) ? [...metadata.categories] : [],
+                    proponentTypes: Array.isArray(metadata.proponentTypes) ? [...metadata.proponentTypes] : [],
+                    ranges: Array.isArray(metadata.ranges) ? [...metadata.ranges] : [],
+                    distribution: typeof metadata.distribution === 'string' ? metadata.distribution : '',
+                    sentTimestamp: { from: '', to: '' },
+                    fields: metadata.selectionFields && typeof metadata.selectionFields === 'object'
+                        ? { ...metadata.selectionFields }
+                        : {}
+                };
+            }
+
             return {
                 categories: Array.isArray(this.entity.fetchCategories?.[agentUserId]) ? [...this.entity.fetchCategories[agentUserId]] : [],
                 proponentTypes: Array.isArray(this.entity.fetchProponentTypes?.[agentUserId]) ? [...this.entity.fetchProponentTypes[agentUserId]] : [],

--- a/src/modules/Opportunities/components/registration-distribution-rule/script.js
+++ b/src/modules/Opportunities/components/registration-distribution-rule/script.js
@@ -403,7 +403,11 @@ app.component('registration-distribution-rule', {
                 }
             }
 
-            if (this.parentFilters && this.parentFilters.fields && typeof this.parentFilters.fields === 'object') {
+            const hasParentFieldRestrictions = this.parentFilters?.fields &&
+                typeof this.parentFilters.fields === 'object' &&
+                Object.values(this.parentFilters.fields).some(values => Array.isArray(values) && values.length > 0);
+
+            if (hasParentFieldRestrictions) {
                 const nextFields = {};
                 const disabledFields = disabled.fields || {};
 

--- a/tests/src/ValuerFiltersPersistenceTest.php
+++ b/tests/src/ValuerFiltersPersistenceTest.php
@@ -1,0 +1,65 @@
+<?php
+
+namespace Tests;
+
+use MapasCulturais\App;
+use Tests\Abstract\TestCase;
+use Tests\Builders\PhasePeriods\ConcurrentEndingAfter;
+use Tests\Builders\PhasePeriods\Open;
+use Tests\Enums\EvaluationMethods;
+use Tests\Traits\OpportunityBuilder;
+use Tests\Traits\RequestFactory;
+use Tests\Traits\UserDirector;
+
+class ValuerFiltersPersistenceTest extends TestCase
+{
+    use OpportunityBuilder;
+    use RequestFactory;
+    use UserDirector;
+
+    public function testSetValuerFiltersMarksRelationStorageEvenWhenAllFiltersAreRemoved(): void
+    {
+        $admin = $this->userDirector->createUser('admin');
+        $this->login($admin);
+
+        $opportunity = $this->opportunityBuilder
+            ->reset(owner: $admin->profile, owner_entity: $admin->profile)
+            ->fillRequiredProperties()
+            ->firstPhase()
+                ->setRegistrationPeriod(new Open())
+                ->done()
+            ->save()
+            ->addEvaluationPhase(EvaluationMethods::simple)
+                ->setEvaluationPeriod(new ConcurrentEndingAfter())
+                ->setCommitteeValuersPerRegistration('Comissão', 1)
+                ->save()
+                ->done()
+            ->getInstance();
+
+        $emc = $opportunity->evaluationMethodConfiguration->refreshed();
+        $valuer = $this->userDirector->createUser();
+        $relation = $emc->createAgentRelation($valuer->profile, 'Comissão', true, true, true);
+
+        $response = $this->requestFactory->POST(
+            'evaluationMethodConfiguration',
+            'setValuerFilters',
+            [$emc->id],
+            [
+                'relationId' => $relation->id,
+                'categories' => null,
+                'proponentTypes' => null,
+                'ranges' => null,
+                'distribution' => null,
+                'selectionFields' => null,
+            ]
+        );
+
+        $this->assertStatus200($response);
+
+        $persistedRelation = App::i()
+            ->repo('EvaluationMethodConfigurationAgentRelation')
+            ->find($relation->id);
+
+        $this->assertTrue($persistedRelation->getFiltersStoredOnRelation());
+    }
+}


### PR DESCRIPTION
## Descrição

Corrige a persistência visual dos filtros individuais configurados para cada pessoa avaliadora na distribuição das avaliações.

Anteriormente, após recarregar a página, os filtros continuavam salvos, mas deixavam de aparecer na interface. Isso impedia identificar ou remover facilmente os filtros aplicados.

<img width="989" height="626" alt="image" src="https://github.com/user-attachments/assets/9b9412e9-5137-492a-a4c7-0549ccb1e37f" />

<img width="988" height="631" alt="image" src="https://github.com/user-attachments/assets/70a7fa3b-0a2b-446c-a0a0-e8b035409664" />

## Alterações realizadas

- Carrega os filtros individuais a partir dos metadados da relação com a pessoa avaliadora.
- Mantém compatibilidade com filtros salvos no formato anterior.
- Registra quando os filtros foram explicitamente salvos na relação.
- Impede que filtros antigos reapareçam após a remoção de todos os filtros.
- Adiciona teste de regressão para a persistência dos filtros.

## Como testar

1. Acesse uma oportunidade com fase de avaliação.
2. Abra a distribuição das avaliações na comissão.
3. Configure um filtro para uma pessoa avaliadora, como:
   - tipo de proponente;
   - categoria;
   - faixa;
   - campo da inscrição.
4. Recarregue a página.
5. Verifique que o filtro continua visível na pessoa avaliadora.
6. Remova todos os filtros e recarregue novamente.
7. Verifique que os filtros removidos não reaparecem.
