### PR TITLE
Adiciona ajuste de cards do painel ao changelog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ e este projeto adere ao [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 ## [UNRELEASED]
 ### Melhorias
 - Ajusta tamanho dos cards da seção "Em destaque" na página inicial
+- Ajusta tamanho dos cards da seção "Editados recentemente" no painel de controle
 
 ## [7.8.6] - 2026-08-13
 ### Correções


### PR DESCRIPTION
Adiciona entrada no CHANGELOG para o ajuste de tamanho dos cards da seção "Editados recentemente" no painel de controle, já integrado na branch v7.8.X via hacklabr/mapasculturais#23.

## Mudança
- Adiciona item na lista de melhorias do UNRELEASED:
  - Ajusta tamanho dos cards da seção "Editados recentemente" no painel de controle
