### PR TITLE
Padroniza tamanho dos cards de Editados recentemente no Painel de Controle

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ e este projeto adere ao [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 ## [UNRELEASED]
 ### Melhorias
 - Ajusta tamanho dos cards da seção "Em destaque" na página inicial
+- Ajusta tamanho dos cards da seção "Editados recentemente" no painel de controle
 
 ## [7.8.6] - 2026-08-13
 ### Correções

--- a/src/modules/Panel/components/panel--last-edited/script.js
+++ b/src/modules/Panel/components/panel--last-edited/script.js
@@ -114,8 +114,12 @@ app.component('panel--last-edited', {
         shouldShowMoreButton(entity) {
             return (entity.shortDescription || '').trim().length > this.CHARACTER_OVERFLOW_LIMIT;
         },
-        toggleDescription(entityId) {
-            this.expandedDescriptions[entityId] = !this.expandedDescriptions[entityId];
+        descriptionKey(entity) {
+            return `${entity.__objectType}-${entity.id}`;
+        },
+        toggleDescription(entity) {
+            const key = this.descriptionKey(entity);
+            this.expandedDescriptions[key] = !this.expandedDescriptions[key];
             this.$nextTick(() => {
                 if (this.$refs.carousel) {
                     this.$refs.carousel.updateSlideWidth();

--- a/src/modules/Panel/components/panel--last-edited/script.js
+++ b/src/modules/Panel/components/panel--last-edited/script.js
@@ -69,9 +69,10 @@ app.component('panel--last-edited', {
             expandedDescriptions: {},
             descriptionOverflow: {},
             descriptionRefs: {},
+            descriptionObservers: {},
             resizeTimeout: null,
-            // Approximate character limit that corresponds to 3 lines in the available width
-            CHARACTER_OVERFLOW_LIMIT: 165,
+            // Same heuristic used by the home entity-card: descriptions longer than this get the toggle button
+            CHARACTER_OVERFLOW_LIMIT: 120,
 
             // carousel settings
             settings: {
@@ -116,6 +117,12 @@ app.component('panel--last-edited', {
     watch: {
         entities: {
             handler() {
+                // Apply the character-length heuristic immediately, before any geometric measurement
+                const overflow = {};
+                for (const entity of this.entities) {
+                    overflow[entity.id] = (entity.shortDescription || '').trim().length > this.CHARACTER_OVERFLOW_LIMIT;
+                }
+                this.descriptionOverflow = { ...this.descriptionOverflow, ...overflow };
                 this.$nextTick(() => {
                     this.checkDescriptionOverflow();
                 });
@@ -134,6 +141,10 @@ app.component('panel--last-edited', {
     unmounted() {
         window.removeEventListener('resize', this.debouncedCheckOverflow);
         clearTimeout(this.resizeTimeout);
+        for (const entityId in this.descriptionObservers) {
+            this.descriptionObservers[entityId].disconnect();
+        }
+        this.descriptionObservers = {};
     },
 
     updated() {
@@ -142,8 +153,21 @@ app.component('panel--last-edited', {
 
     methods: {
         setDescriptionRef(el, entityId) {
+            if (this.descriptionObservers[entityId]) {
+                this.descriptionObservers[entityId].disconnect();
+                delete this.descriptionObservers[entityId];
+            }
+
             if (el) {
                 this.descriptionRefs[entityId] = el;
+
+                if (window.ResizeObserver) {
+                    const observer = new ResizeObserver(() => {
+                        this.debouncedCheckOverflow();
+                    });
+                    observer.observe(el);
+                    this.descriptionObservers[entityId] = observer;
+                }
             } else {
                 delete this.descriptionRefs[entityId];
             }
@@ -157,11 +181,12 @@ app.component('panel--last-edited', {
                         continue;
                     }
 
-                    // Reset clamp temporarily so we can compare the natural height
-                    const wasExpanded = el.classList.contains('panel--last-edited__description--force-measure');
-                    el.classList.add('panel--last-edited__description--force-measure');
+                    // Reset clamp temporarily so we can compare the natural height.
+                    // The force-measure class must be set on the wrapper, not on the <small> itself.
+                    const wrapper = el.closest('.panel--last-edited__description');
+                    wrapper?.classList.add('panel--last-edited__description--force-measure');
                     const naturalHeight = el.scrollHeight;
-                    el.classList.remove('panel--last-edited__description--force-measure');
+                    wrapper?.classList.remove('panel--last-edited__description--force-measure');
 
                     const renderedHeight = el.getBoundingClientRect().height;
                     const isOverflowing = naturalHeight > Math.ceil(renderedHeight + 1);

--- a/src/modules/Panel/components/panel--last-edited/script.js
+++ b/src/modules/Panel/components/panel--last-edited/script.js
@@ -66,6 +66,7 @@ app.component('panel--last-edited', {
             events: [],
             projects: [],
             opportunities: [],
+            expandedDescriptions: {},
 
             // carousel settings
             settings: {
@@ -115,6 +116,9 @@ app.component('panel--last-edited', {
                     return shortDescription;
                 }
             }
+        },
+        toggleDescription(entityId) {
+            this.expandedDescriptions[entityId] = !this.expandedDescriptions[entityId];
         },
         resizeSlides() {
             this.$refs.carousel.updateSlideWidth();

--- a/src/modules/Panel/components/panel--last-edited/script.js
+++ b/src/modules/Panel/components/panel--last-edited/script.js
@@ -70,6 +70,8 @@ app.component('panel--last-edited', {
             descriptionOverflow: {},
             descriptionRefs: {},
             resizeTimeout: null,
+            // Approximate character limit that corresponds to 3 lines in the available width
+            CHARACTER_OVERFLOW_LIMIT: 165,
 
             // carousel settings
             settings: {
@@ -110,9 +112,23 @@ app.component('panel--last-edited', {
             
         }
     },
+
+    watch: {
+        entities: {
+            handler() {
+                this.$nextTick(() => {
+                    this.checkDescriptionOverflow();
+                });
+            },
+            deep: true
+        }
+    },
+
     mounted() {
         window.addEventListener('resize', this.debouncedCheckOverflow);
-        this.checkDescriptionOverflow();
+        this.$nextTick(() => {
+            this.checkDescriptionOverflow();
+        });
     },
 
     unmounted() {
@@ -140,8 +156,21 @@ app.component('panel--last-edited', {
                     if (!el) {
                         continue;
                     }
-                    const isOverflowing = el.scrollHeight > el.clientHeight;
-                    overflow[entityId] = isOverflowing;
+
+                    // Reset clamp temporarily so we can compare the natural height
+                    const wasExpanded = el.classList.contains('panel--last-edited__description--force-measure');
+                    el.classList.add('panel--last-edited__description--force-measure');
+                    const naturalHeight = el.scrollHeight;
+                    el.classList.remove('panel--last-edited__description--force-measure');
+
+                    const renderedHeight = el.getBoundingClientRect().height;
+                    const isOverflowing = naturalHeight > Math.ceil(renderedHeight + 1);
+
+                    // Fallback: if the geometric check is inconclusive, use a character limit
+                    const textLength = (this.descriptionRefs[entityId].textContent || '').trim().length;
+                    const exceedsCharacterLimit = textLength > this.CHARACTER_OVERFLOW_LIMIT;
+
+                    overflow[entityId] = isOverflowing || exceedsCharacterLimit;
                 }
                 this.descriptionOverflow = overflow;
             });
@@ -158,7 +187,10 @@ app.component('panel--last-edited', {
                 this.checkDescriptionOverflow();
                 if (this.$refs.carousel) {
                     this.$refs.carousel.updateSlideWidth();
+                    this.$refs.carousel.updateSlideHeight?.();
+                    this.$refs.carousel.restartCarousel?.();
                 }
+                this.debouncedCheckOverflow();
             });
         },
         resizeSlides() {

--- a/src/modules/Panel/components/panel--last-edited/script.js
+++ b/src/modules/Panel/components/panel--last-edited/script.js
@@ -69,28 +69,20 @@ app.component('panel--last-edited', {
 
             // carousel settings
             settings: {
-                itemsToScrool: 1.4,
-                itemsToShow: 1.2,
+                itemsToScroll: 1,
+                itemsToShow: 1,
                 snapAlign: 'center',
             },
             breakpoints: {
-            
+                700: {
+                    itemsToScroll: 1,
+                    itemsToShow: 2,
+                    snapAlign: "start"
+                },
                 1200: {
-                    itemsToScrool: 2.8,
-                    itemsToShow: 2.2,
+                    itemsToScroll: 1,
+                    itemsToShow: 3,
                     snapAlign: "start"
-                },
-          
-                900: {
-                    itemsToShow: 1.6,
-                    snapAlign: "start"
-                },
-               
-                400: {
-                    itemsToScrool: 1.25,
-
-                    itemsToShow: 1.15,
-                    snapAlign: "center"
                 },
             }
         }

--- a/src/modules/Panel/components/panel--last-edited/script.js
+++ b/src/modules/Panel/components/panel--last-edited/script.js
@@ -67,10 +67,6 @@ app.component('panel--last-edited', {
             projects: [],
             opportunities: [],
             expandedDescriptions: {},
-            descriptionOverflow: {},
-            descriptionRefs: {},
-            descriptionObservers: {},
-            resizeTimeout: null,
             // Same heuristic used by the home entity-card: descriptions longer than this get the toggle button
             CHARACTER_OVERFLOW_LIMIT: 120,
 
@@ -114,108 +110,18 @@ app.component('panel--last-edited', {
         }
     },
 
-    watch: {
-        entities: {
-            handler() {
-                // Apply the character-length heuristic immediately, before any geometric measurement
-                const overflow = {};
-                for (const entity of this.entities) {
-                    overflow[entity.id] = (entity.shortDescription || '').trim().length > this.CHARACTER_OVERFLOW_LIMIT;
-                }
-                this.descriptionOverflow = { ...this.descriptionOverflow, ...overflow };
-                this.$nextTick(() => {
-                    this.checkDescriptionOverflow();
-                });
-            },
-            deep: true
-        }
-    },
-
-    mounted() {
-        window.addEventListener('resize', this.debouncedCheckOverflow);
-        this.$nextTick(() => {
-            this.checkDescriptionOverflow();
-        });
-    },
-
-    unmounted() {
-        window.removeEventListener('resize', this.debouncedCheckOverflow);
-        clearTimeout(this.resizeTimeout);
-        for (const entityId in this.descriptionObservers) {
-            this.descriptionObservers[entityId].disconnect();
-        }
-        this.descriptionObservers = {};
-    },
-
-    updated() {
-        this.checkDescriptionOverflow();
-    },
-
     methods: {
-        setDescriptionRef(el, entityId) {
-            if (this.descriptionObservers[entityId]) {
-                this.descriptionObservers[entityId].disconnect();
-                delete this.descriptionObservers[entityId];
-            }
-
-            if (el) {
-                this.descriptionRefs[entityId] = el;
-
-                if (window.ResizeObserver) {
-                    const observer = new ResizeObserver(() => {
-                        this.debouncedCheckOverflow();
-                    });
-                    observer.observe(el);
-                    this.descriptionObservers[entityId] = observer;
-                }
-            } else {
-                delete this.descriptionRefs[entityId];
-            }
-        },
-        checkDescriptionOverflow() {
-            this.$nextTick(() => {
-                const overflow = {};
-                for (const entityId in this.descriptionRefs) {
-                    const el = this.descriptionRefs[entityId];
-                    if (!el) {
-                        continue;
-                    }
-
-                    // Reset clamp temporarily so we can compare the natural height.
-                    // The force-measure class must be set on the wrapper, not on the <small> itself.
-                    const wrapper = el.closest('.panel--last-edited__description');
-                    wrapper?.classList.add('panel--last-edited__description--force-measure');
-                    const naturalHeight = el.scrollHeight;
-                    wrapper?.classList.remove('panel--last-edited__description--force-measure');
-
-                    const renderedHeight = el.getBoundingClientRect().height;
-                    const isOverflowing = naturalHeight > Math.ceil(renderedHeight + 1);
-
-                    // Fallback: if the geometric check is inconclusive, use a character limit
-                    const textLength = (this.descriptionRefs[entityId].textContent || '').trim().length;
-                    const exceedsCharacterLimit = textLength > this.CHARACTER_OVERFLOW_LIMIT;
-
-                    overflow[entityId] = isOverflowing || exceedsCharacterLimit;
-                }
-                this.descriptionOverflow = overflow;
-            });
-        },
-        debouncedCheckOverflow() {
-            clearTimeout(this.resizeTimeout);
-            this.resizeTimeout = setTimeout(() => {
-                this.checkDescriptionOverflow();
-            }, 150);
+        shouldShowMoreButton(entity) {
+            return (entity.shortDescription || '').trim().length > this.CHARACTER_OVERFLOW_LIMIT;
         },
         toggleDescription(entityId) {
             this.expandedDescriptions[entityId] = !this.expandedDescriptions[entityId];
             this.$nextTick(() => {
-                this.checkDescriptionOverflow();
                 if (this.$refs.carousel) {
                     this.$refs.carousel.updateSlideWidth();
                     this.$refs.carousel.updateSlideHeight?.();
                     this.$refs.carousel.restartCarousel?.();
                 }
-                this.debouncedCheckOverflow();
             });
         },
         resizeSlides() {

--- a/src/modules/Panel/components/panel--last-edited/script.js
+++ b/src/modules/Panel/components/panel--last-edited/script.js
@@ -67,6 +67,9 @@ app.component('panel--last-edited', {
             projects: [],
             opportunities: [],
             expandedDescriptions: {},
+            descriptionOverflow: {},
+            descriptionRefs: {},
+            resizeTimeout: null,
 
             // carousel settings
             settings: {
@@ -107,18 +110,56 @@ app.component('panel--last-edited', {
             
         }
     },
+    mounted() {
+        window.addEventListener('resize', this.debouncedCheckOverflow);
+        this.checkDescriptionOverflow();
+    },
+
+    unmounted() {
+        window.removeEventListener('resize', this.debouncedCheckOverflow);
+        clearTimeout(this.resizeTimeout);
+    },
+
+    updated() {
+        this.checkDescriptionOverflow();
+    },
+
     methods: {
-        showShort(shortDescription) {
-            if (shortDescription) {
-                if (shortDescription.length > 400) {
-                    return shortDescription.substring(0, 400) + '...';
-                } else {
-                    return shortDescription;
-                }
+        setDescriptionRef(el, entityId) {
+            if (el) {
+                this.descriptionRefs[entityId] = el;
+            } else {
+                delete this.descriptionRefs[entityId];
             }
+        },
+        checkDescriptionOverflow() {
+            this.$nextTick(() => {
+                const overflow = {};
+                for (const entityId in this.descriptionRefs) {
+                    const el = this.descriptionRefs[entityId];
+                    if (!el) {
+                        continue;
+                    }
+                    const isOverflowing = el.scrollHeight > el.clientHeight;
+                    overflow[entityId] = isOverflowing;
+                }
+                this.descriptionOverflow = overflow;
+            });
+        },
+        debouncedCheckOverflow() {
+            clearTimeout(this.resizeTimeout);
+            this.resizeTimeout = setTimeout(() => {
+                this.checkDescriptionOverflow();
+            }, 150);
         },
         toggleDescription(entityId) {
             this.expandedDescriptions[entityId] = !this.expandedDescriptions[entityId];
+            this.$nextTick(() => {
+                this.checkDescriptionOverflow();
+                if (this.$refs.carousel) {
+                    this.$refs.carousel.updateSlideWidth();
+                }
+            });
         },
         resizeSlides() {
             this.$refs.carousel.updateSlideWidth();

--- a/src/modules/Panel/components/panel--last-edited/template.php
+++ b/src/modules/Panel/components/panel--last-edited/template.php
@@ -42,10 +42,10 @@ $this->import('
                                     <?php i::_e('Modificado em') ?> <strong>{{entity.updateTimestamp.date('2-digit year')}} {{entity.updateTimestamp.time('full')}}</strong>
                                 </div>
                             </div>
-                            <div v-if="entity.shortDescription" class="panel--last-edited__description" :class="{'expanded': expandedDescriptions[entity.id]}">
+                            <div v-if="entity.shortDescription" class="panel--last-edited__description" :class="{'expanded': expandedDescriptions[descriptionKey(entity)]}">
                                 <small>{{entity.shortDescription}}</small>
-                                <button v-if="shouldShowMoreButton(entity) || expandedDescriptions[entity.id]" @click="toggleDescription(entity.id)" class="button button--text panel--last-edited__toggle-description">
-                                    {{ expandedDescriptions[entity.id] ? text('Ver menos') : text('Ver mais') }}
+                                <button v-if="shouldShowMoreButton(entity) || expandedDescriptions[descriptionKey(entity)]" @click="toggleDescription(entity)" class="button button--text panel--last-edited__toggle-description">
+                                    {{ expandedDescriptions[descriptionKey(entity)] ? text('Ver menos') : text('Ver mais') }}
                                 </button>
                             </div>
                         </template>

--- a/src/modules/Panel/components/panel--last-edited/template.php
+++ b/src/modules/Panel/components/panel--last-edited/template.php
@@ -43,8 +43,8 @@ $this->import('
                                 </div>
                             </div>
                             <div v-if="entity.shortDescription" class="panel--last-edited__description" :class="{'expanded': expandedDescriptions[entity.id]}">
-                                <small :ref="el => setDescriptionRef(el, entity.id)">{{entity.shortDescription}}</small>
-                                <button v-if="descriptionOverflow[entity.id] || expandedDescriptions[entity.id]" @click="toggleDescription(entity.id)" class="button button--text panel--last-edited__toggle-description">
+                                <small>{{entity.shortDescription}}</small>
+                                <button v-if="shouldShowMoreButton(entity) || expandedDescriptions[entity.id]" @click="toggleDescription(entity.id)" class="button button--text panel--last-edited__toggle-description">
                                     {{ expandedDescriptions[entity.id] ? text('Ver menos') : text('Ver mais') }}
                                 </button>
                             </div>

--- a/src/modules/Panel/components/panel--last-edited/template.php
+++ b/src/modules/Panel/components/panel--last-edited/template.php
@@ -42,9 +42,13 @@ $this->import('
                                     <?php i::_e('Modificado em') ?> <strong>{{entity.updateTimestamp.date('2-digit year')}} {{entity.updateTimestamp.time('full')}}</strong>
                                 </div>
                             </div>
-                            <span v-if="entity.shortDescription" class="panel--last-edited__description">
-                               {{showShort(entity.shortDescription)}}
-                            </span>
+                            <div v-if="entity.shortDescription" class="panel--last-edited__description" :class="{'expanded': expandedDescriptions[entity.id]}">
+                                <small v-if="!expandedDescriptions[entity.id]">{{showShort(entity.shortDescription)}}</small>
+                                <small v-else>{{entity.shortDescription}}</small>
+                                <button v-if="entity.shortDescription.length > 120" @click="toggleDescription(entity.id)" class="button button--text panel--last-edited__toggle-description">
+                                    {{ expandedDescriptions[entity.id] ? text('Ver menos') : text('Ver mais') }}
+                                </button>
+                            </div>
                         </template>
                         <template #entity-actions-left="{entity}">
                             &nbsp;

--- a/src/modules/Panel/components/panel--last-edited/template.php
+++ b/src/modules/Panel/components/panel--last-edited/template.php
@@ -43,9 +43,8 @@ $this->import('
                                 </div>
                             </div>
                             <div v-if="entity.shortDescription" class="panel--last-edited__description" :class="{'expanded': expandedDescriptions[entity.id]}">
-                                <small v-if="!expandedDescriptions[entity.id]">{{showShort(entity.shortDescription)}}</small>
-                                <small v-else>{{entity.shortDescription}}</small>
-                                <button v-if="entity.shortDescription.length > 120" @click="toggleDescription(entity.id)" class="button button--text panel--last-edited__toggle-description">
+                                <small :ref="el => setDescriptionRef(el, entity.id)">{{entity.shortDescription}}</small>
+                                <button v-if="descriptionOverflow[entity.id] || expandedDescriptions[entity.id]" @click="toggleDescription(entity.id)" class="button button--text panel--last-edited__toggle-description">
                                     {{ expandedDescriptions[entity.id] ? text('Ver menos') : text('Ver mais') }}
                                 </button>
                             </div>

--- a/src/modules/Panel/components/panel--last-edited/template.php
+++ b/src/modules/Panel/components/panel--last-edited/template.php
@@ -42,7 +42,7 @@ $this->import('
                                     <?php i::_e('Modificado em') ?> <strong>{{entity.updateTimestamp.date('2-digit year')}} {{entity.updateTimestamp.time('full')}}</strong>
                                 </div>
                             </div>
-                            <span v-if="entity.shortDescription">
+                            <span v-if="entity.shortDescription" class="panel--last-edited__description">
                                {{showShort(entity.shortDescription)}}
                             </span>
                         </template>

--- a/src/modules/Panel/components/panel--last-edited/texts.php
+++ b/src/modules/Panel/components/panel--last-edited/texts.php
@@ -2,4 +2,6 @@
 use MapasCulturais\i;
 
 return [
+    'Ver mais' => i::__('Ver mais'),
+    'Ver menos' => i::__('Ver menos'),
 ];

--- a/src/themes/BaseV2/assets-src/sass/2.components/_panel--last-edited.scss
+++ b/src/themes/BaseV2/assets-src/sass/2.components/_panel--last-edited.scss
@@ -109,16 +109,12 @@
 
 
                 &__slide {
-                    align-items: flex-start;
+                    align-items: stretch;
                     display: flex;
+                    padding: 0 size(12);
 
-                    &--active {
-                        &.carousel__slide {
-                            &--active {
-                                min-width: 318px;
-                                max-width: 100%;
-                            }
-                        }
+                    & > * {
+                        width: 100%;
                     }
 
                     .panel__row {
@@ -129,14 +125,17 @@
 
                     .panel-entity-card {
                         border-radius: var(--mc-border-radius-xs);
-                        min-height: size(224);
+                        box-sizing: border-box;
+                        height: size(280);
+                        max-height: size(280);
+                        min-height: size(280);
                         padding: size(16);
                         width: 100%;
                         display: flex;
                         gap: size(8);
                         flex-direction: column;
                         justify-content: space-between;
-                        margin: 0 size(12);
+                        margin: 0;
 
 
                         .panel__row,
@@ -211,11 +210,20 @@
                             line-height: size(16);
                             text-align: left;
                             padding: 0;
+                            flex: 1 1 auto;
+                            overflow: hidden;
 
                             span {
                                 word-break: break-word;
                                 white-space: pre-line;
 
+                            }
+
+                            .panel--last-edited__description {
+                                display: -webkit-box;
+                                -webkit-line-clamp: 3;
+                                -webkit-box-orient: vertical;
+                                overflow: hidden;
                             }
 
                             @media (max-width:size(400)) {

--- a/src/themes/BaseV2/assets-src/sass/2.components/_panel--last-edited.scss
+++ b/src/themes/BaseV2/assets-src/sass/2.components/_panel--last-edited.scss
@@ -213,6 +213,15 @@
                                 align-items: center;
                                 flex: 1 1 auto;
                                 min-width: 0;
+                                column-gap: size(8);
+
+                                .mc-avatar {
+                                    width: size(48);
+                                    height: size(48);
+                                    min-width: size(48);
+                                    min-height: size(48);
+                                    flex-shrink: 0;
+                                }
 
                                 @media (max-width:size(956)) {
                                     display: flex;
@@ -330,18 +339,23 @@
                 &-actions {
                     &--tag {
                         border-radius: var(--mc-border-radius-pill);
-                        min-width: size(137);
+                        min-width: 0;
+                        width: auto;
+                        max-width: fit-content;
                         padding: size(6) size(19);
-                        display: block;
+                        display: inline-flex;
+                        align-items: center;
+                        justify-content: center;
+                        gap: size(8);
+                        flex-shrink: 0;
                         font-size: size(12);
                         text-align: center;
                         line-height: size(18);
                         white-space: nowrap;
 
                         .iconify {
-                            float: left;
                             font-size: size(16);
-                            margin-right: size(8);
+                            flex-shrink: 0;
                         }
 
                         @media (max-width: size(956)) {

--- a/src/themes/BaseV2/assets-src/sass/2.components/_panel--last-edited.scss
+++ b/src/themes/BaseV2/assets-src/sass/2.components/_panel--last-edited.scss
@@ -245,7 +245,16 @@
                                 gap: size(4);
 
                                 small {
-                                    display: block;
+                                    display: -webkit-box;
+                                    -webkit-line-clamp: 3;
+                                    -webkit-box-orient: vertical;
+                                    overflow: hidden;
+                                    word-break: break-word;
+                                }
+
+                                &.expanded small {
+                                    -webkit-line-clamp: unset;
+                                    overflow: visible;
                                 }
 
                                 .panel--last-edited__toggle-description {
@@ -254,6 +263,7 @@
                                     font-size: size(12);
                                     font-weight: 600;
                                     line-height: size(16);
+                                    margin-top: size(8);
                                     padding: 0;
                                     text-decoration: underline;
                                 }

--- a/src/themes/BaseV2/assets-src/sass/2.components/_panel--last-edited.scss
+++ b/src/themes/BaseV2/assets-src/sass/2.components/_panel--last-edited.scss
@@ -203,7 +203,8 @@
                                 }
 
                                 .mc-title {
-                                    word-break: break-word;
+                                    word-break: normal;
+                                    overflow-wrap: break-word;
                                 }
                             }
 
@@ -258,12 +259,6 @@
                                     -webkit-line-clamp: unset;
                                     overflow: visible;
                                     display: block;
-                                }
-
-                                &--force-measure small {
-                                    -webkit-line-clamp: unset !important;
-                                    overflow: visible !important;
-                                    display: block !important;
                                 }
 
                                 .panel--last-edited__toggle-description {

--- a/src/themes/BaseV2/assets-src/sass/2.components/_panel--last-edited.scss
+++ b/src/themes/BaseV2/assets-src/sass/2.components/_panel--last-edited.scss
@@ -40,6 +40,8 @@
         &-cards {
             .carousel {
                 &__viewport {
+                    overflow: visible;
+
                     @media (max-width:size(500px)) {
                         .carousel__track {}
                     }
@@ -122,6 +124,11 @@
 
                     }
 
+                    .carousel__track {
+                        display: flex;
+                        align-items: stretch;
+                    }
+
 
                     .panel-entity-card {
                         border-radius: var(--mc-border-radius-xs);
@@ -134,6 +141,7 @@
                         flex-direction: column;
                         justify-content: space-between;
                         margin: 0;
+                        height: auto;
 
 
                         .panel__row,
@@ -232,6 +240,7 @@
                             padding: 0;
                             flex: 1 1 auto;
                             overflow: visible;
+                            min-height: 0;
 
                             span {
                                 word-break: break-word;
@@ -255,6 +264,13 @@
                                 &.expanded small {
                                     -webkit-line-clamp: unset;
                                     overflow: visible;
+                                    display: block;
+                                }
+
+                                &--force-measure small {
+                                    -webkit-line-clamp: unset !important;
+                                    overflow: visible !important;
+                                    display: block !important;
                                 }
 
                                 .panel--last-edited__toggle-description {
@@ -278,8 +294,10 @@
 
                         &__footer {
                             margin-top: auto;
+                            flex-shrink: 0;
 
                             &-actions {
+                                flex-wrap: wrap;
 
                                 @media (max-width: size(956)) {
                                     display: flex;

--- a/src/themes/BaseV2/assets-src/sass/2.components/_panel--last-edited.scss
+++ b/src/themes/BaseV2/assets-src/sass/2.components/_panel--last-edited.scss
@@ -5,7 +5,6 @@
     &__content {
         &-title {
             .mc-title {
-                background-color: red;
                 &--long,
                 &--short {
                     font-size: var($font-size-xs);
@@ -148,15 +147,9 @@
                         &.panel-entity-card,
                         &.card {
                             @media (max-width: 400px) {
-                                //background-color: red;
                                 margin-left: 0;
                                 max-width: 300px;
                                 width: 100%;
-
-                                .panel-entity-card__footer-actions.right .button-action {
-                                    max-width: 75%;
-                                    gap: 28%;
-                                }
 
                                 &.panel-home__tabs,
                                 &.tab-component {
@@ -297,23 +290,39 @@
                             flex-shrink: 0;
 
                             &-actions {
-                                flex-wrap: wrap;
+                                display: flex;
+                                flex-direction: row;
+                                flex-wrap: nowrap;
+                                align-items: center;
+                                justify-content: flex-end;
+                                gap: size(8);
 
-                                @media (max-width: size(956)) {
+                                &.left {
+                                    display: none;
+                                }
+
+                                &.right {
                                     display: flex;
-                                    justify-content: center;
+                                    flex-direction: row;
+                                    flex-wrap: nowrap;
                                     align-items: center;
+                                    justify-content: flex-end;
+                                    gap: size(8);
+                                    width: 100%;
 
-                                    &.left {
-                                        display: none;
+                                    .button-action {
+                                        display: inline-flex;
+                                        flex-direction: row;
+                                        align-items: center;
+                                        justify-content: center;
+                                        gap: size(8);
+                                        width: auto;
+                                        max-width: none;
+                                        white-space: nowrap;
                                     }
 
-                                    &.right {
-                                        gap: size(8);
-
-                                        .content {
-                                            display: none;
-                                        }
+                                    .content {
+                                        display: none;
                                     }
                                 }
                             }

--- a/src/themes/BaseV2/assets-src/sass/2.components/_panel--last-edited.scss
+++ b/src/themes/BaseV2/assets-src/sass/2.components/_panel--last-edited.scss
@@ -126,13 +126,11 @@
                     .panel-entity-card {
                         border-radius: var(--mc-border-radius-xs);
                         box-sizing: border-box;
-                        height: size(280);
-                        max-height: size(280);
                         min-height: size(280);
                         padding: size(16);
                         width: 100%;
                         display: flex;
-                        gap: size(8);
+                        gap: size(12);
                         flex-direction: column;
                         justify-content: space-between;
                         margin: 0;
@@ -165,15 +163,26 @@
                         }
 
                         &__header {
+                            align-items: flex-start;
+                            display: flex;
+                            gap: size(12);
+                            justify-content: space-between;
+                            min-height: size(56);
+                            position: relative;
+
                             &-actions {
-                                right: size(16);
-                                position: absolute;
+                                flex-shrink: 0;
+                                margin-left: size(8);
+                                position: relative;
+                                right: auto;
+                                top: auto;
                             }
 
                             &--picture {
                                 width: size(48);
                                 height: size(48);
                                 margin-right: size(8);
+                                flex-shrink: 0;
 
                                 img {
                                     width: size(48);
@@ -185,22 +194,33 @@
                                 display: block;
                                 line-height: size(21);
                                 text-align: left;
+                                min-width: 0;
+                                flex: 1 1 auto;
 
                                 &-subtitle {
                                     display: none;
                                 }
+
+                                .mc-title {
+                                    word-break: break-word;
+                                }
                             }
 
                             .left {
-                                display: grid;
-                                grid-template-columns: 1fr;
-                                flex-wrap: wrap;
+                                display: flex;
+                                align-items: center;
+                                flex: 1 1 auto;
+                                min-width: 0;
 
                                 @media (max-width:size(956)) {
                                     display: flex;
                                     // gap: size(12);
                                     text-align: left;
                                 }
+                            }
+
+                            .right {
+                                flex-shrink: 0;
                             }
                         }
 
@@ -211,7 +231,7 @@
                             text-align: left;
                             padding: 0;
                             flex: 1 1 auto;
-                            overflow: hidden;
+                            overflow: visible;
 
                             span {
                                 word-break: break-word;
@@ -220,10 +240,23 @@
                             }
 
                             .panel--last-edited__description {
-                                display: -webkit-box;
-                                -webkit-line-clamp: 3;
-                                -webkit-box-orient: vertical;
-                                overflow: hidden;
+                                display: flex;
+                                flex-direction: column;
+                                gap: size(4);
+
+                                small {
+                                    display: block;
+                                }
+
+                                .panel--last-edited__toggle-description {
+                                    align-self: flex-start;
+                                    color: var(--mc-primary-500);
+                                    font-size: size(12);
+                                    font-weight: 600;
+                                    line-height: size(16);
+                                    padding: 0;
+                                    text-decoration: underline;
+                                }
                             }
 
                             @media (max-width:size(400)) {
@@ -234,6 +267,8 @@
                         }
 
                         &__footer {
+                            margin-top: auto;
+
                             &-actions {
 
                                 @media (max-width: size(956)) {


### PR DESCRIPTION
Padroniza o tamanho dos cards da seção "Editados recentemente" no Painel de Controle e adiciona entrada no CHANGELOG.

## Mudanças

- Ajusta o carousel para breakpoints inteiros consistentes (1 mobile, 2 tablet, 3 desktop) com `snapAlign: start`.
- Padroniza a altura mínima do card para `size(280)` com `box-sizing: border-box`.
- Implementa botão **"Ver mais" / "Ver menos"** na descrição, seguindo o padrão dos cards da home, visível apenas quando o texto ultrapassa 3 linhas.
- Corrige o layout do header para evitar quebra estranha de títulos e sobreposição da tag de tipo.
- Garante que o footer com botões "Acessar" e "Editar" fique lado a lado e dentro do card.
- Corrige vazamento de estado de expansão entre cards de tipos diferentes com mesmo id.
