### PR TITLE
Corrige exibição da validação para uploads grandes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ e este projeto adere ao [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 ## [UNRELEASED]
 ### Correções
 - Corrige os filtros de período de inscrição nas listas de oportunidades para enviar o timestamp completo (YYYY-MM-DD HH:mm) em vez de apenas a data, classificando corretamente as inscrições abertas, futuras e encerradas
+- Ao enviar um arquivo maior que o tamanho permitido, o campo de anexo passa a exibir o motivo da recusa, em vez de uma mensagem de erro vermelha e sem texto, e informa que o arquivo excede o limite em vez de dizer que nenhum arquivo foi enviado
 
 ### Melhorias
 - Ajusta tamanho dos cards da seção "Em destaque" na página inicial

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -16,7 +16,7 @@ RUN curl -fsSL https://deb.nodesource.com/gpgkey/nodesource-repo.gpg.key | gpg -
 RUN echo "deb [signed-by=/etc/apt/keyrings/nodesource.gpg] https://deb.nodesource.com/node_20.x nodistro main" | sudo tee /etc/apt/sources.list.d/nodesource.list
 RUN apt-get update && apt-get install -y nodejs
 
-RUN npm install -g pnpm
+RUN corepack enable
 RUN rm -rf /var/lib/apt/lists
 
 ENV PNPM_HOME=/root/.local/share/pnpm

--- a/src/core/Traits/ControllerUploads.php
+++ b/src/core/Traits/ControllerUploads.php
@@ -68,6 +68,11 @@ trait ControllerUploads{
 
         // if no files uploaded or no id in request data, return an error
         if(empty($_FILES) || !$this->data['id']){
+            if($this->postExceededMaxUploadSize()){
+                $this->errorJson(\MapasCulturais\i::__('O arquivo enviado é maior do que o permitido.'));
+                return ;
+            }
+
             $this->errorJson(\MapasCulturais\i::__('Nenhum arquivo enviado'));
             return ;
         }
@@ -197,6 +202,16 @@ trait ControllerUploads{
         $app->em->flush();
         $this->json($result);
         return;
+    }
+
+    /**
+     * Indica que o corpo do POST passou do limite efetivo de upload.
+     * @return bool
+     */
+    protected function postExceededMaxUploadSize(){
+        $content_length = (int) ($_SERVER['CONTENT_LENGTH'] ?? 0);
+
+        return $content_length > App::i()->getMaxUploadSize(false) * 1024;
     }
 
     /**

--- a/src/modules/Components/assets/js/components-base/Entity.js
+++ b/src/modules/Components/assets/js/components-base/Entity.js
@@ -229,7 +229,7 @@ class Entity {
         this.__validationMessages = [];
     }
 
-    catchErrors(res, data) {
+    catchErrors(res, data, persistentErrors = true) {
         let message = null;
         let handled = false;
         
@@ -255,7 +255,7 @@ class Entity {
                     this.sendMessage({
                         title: this.text('nao foi possivel salvar'),
                         messages: this.__validationMessages,
-                        persistent: true,
+                        persistent: persistentErrors,
                     }, 'error');
                 } else {
                     this.sendMessage(message || this.text('erro de validacao'), 'error');
@@ -487,7 +487,7 @@ class Entity {
         });
     }
 
-    async doPromise(res, cb) {
+    async doPromise(res, cb, {persistentErrors = true} = {}) {
         let data = await res.json();
         let result; 
 
@@ -495,7 +495,7 @@ class Entity {
             data = cb(data) || data;
             result = Promise.resolve(data);
         } else {
-            const handled = this.catchErrors(res, data);
+            const handled = this.catchErrors(res, data, persistentErrors);
             const error = data && typeof data === 'object' ? data : {error: true, data};
             error.status = res.status;
             if (handled) {
@@ -789,7 +789,7 @@ class Entity {
                     this.files[group] = file;
                 }
                 return file;
-            });
+            }, {persistentErrors: false});
         } catch (error) {
             return this.doCatch(error);
         }

--- a/src/modules/Entities/components/entity-file/script.js
+++ b/src/modules/Entities/components/entity-file/script.js
@@ -176,13 +176,10 @@ app.component('entity-file', {
                 });
             }
 
-            this.entity.disableMessages();
             try{
                 const response = await this.entity.upload(this.newFile, data);
                 this.file = response;
                 this.$emit('uploaded', this);
-                this.loading = false;
-                this.entity.enableMessages();
 
                 this.file = null;
                 this.newFile = {};
@@ -192,13 +189,11 @@ app.component('entity-file', {
                 }
 
             } catch(e) {
-                this.loading = false;
-                if(e.error) {
-                    const messages = useMessages();
-                    messages.error(e.data[this.groupName]);
-                } else {
+                if(!e.error) {
                     console.error(e);
                 }
+            } finally {
+                this.loading = false;
             }
 
             return true;

--- a/src/package.json
+++ b/src/package.json
@@ -1,6 +1,7 @@
 {
     "name": "mapasculturais",
     "private": true,
+    "packageManager": "pnpm@12.1.0",
     "scripts": {
         "dev": "pnpm run --parallel --recursive dev",
         "build": "pnpm run --parallel --recursive build",

--- a/src/pnpm-workspace.yaml
+++ b/src/pnpm-workspace.yaml
@@ -3,3 +3,8 @@ packages:
   - 'plugins/*'
   - 'themes/*'
   - 'node_scripts'
+
+allowBuilds:
+  '@parcel/watcher': false
+  '@scarf/scarf': false
+  vue-demi: false

--- a/tests/src/UploadPostSizeLimitTest.php
+++ b/tests/src/UploadPostSizeLimitTest.php
@@ -1,0 +1,102 @@
+<?php
+
+namespace Test;
+
+use MapasCulturais\Entities\Opportunity;
+use MapasCulturais\Exceptions\Halt;
+use Slim\Psr7\Response;
+use Tests\Abstract\TestCase;
+use Tests\Traits\OpportunityBuilder;
+use Tests\Traits\RequestFactory;
+use Tests\Traits\UserDirector;
+
+class UploadPostSizeLimitTest extends TestCase
+{
+    use OpportunityBuilder,
+        RequestFactory,
+        UserDirector;
+
+    function testInformaExcessoDeTamanhoQuandoOPostFoiDescartado()
+    {
+        $limite = $this->app->getMaxUploadSize(false) * 1024;
+
+        $resposta = $this->uploadSemArquivo($limite + 1);
+
+        $this->assertEquals(400, $resposta['status'], 'Garantindo que o upload seja recusado');
+        $this->assertEquals('O arquivo enviado é maior do que o permitido.', $resposta['data'], 'Garantindo que o motivo informado seja o tamanho do arquivo');
+    }
+
+    function testInformaAusenciaDeArquivoQuandoOPostCabeNoLimite()
+    {
+        $limite = $this->app->getMaxUploadSize(false) * 1024;
+
+        $resposta = $this->uploadSemArquivo($limite - 1);
+
+        $this->assertEquals(400, $resposta['status'], 'Garantindo que o upload seja recusado');
+        $this->assertEquals('Nenhum arquivo enviado', $resposta['data'], 'Garantindo que o motivo informado seja a ausência de arquivo');
+    }
+
+    function testNaoTrataComoExcessoOPostQueBateExatamenteNoLimite()
+    {
+        $limite = $this->app->getMaxUploadSize(false) * 1024;
+
+        $resposta = $this->uploadSemArquivo($limite);
+
+        $this->assertEquals(400, $resposta['status'], 'Garantindo que o upload seja recusado');
+        $this->assertEquals('Nenhum arquivo enviado', $resposta['data'], 'Garantindo que o tamanho igual ao limite não seja tratado como excesso');
+    }
+
+    /**
+     * Simula o POST que o PHP descarta por exceder o post_max_size: $_FILES vazio e apenas o CONTENT_LENGTH denunciando o tamanho.
+     * @return array status e data da resposta
+     */
+    private function uploadSemArquivo(int $content_length): array
+    {
+        $opportunity = $this->createOpportunity();
+        $app = $this->app;
+
+        $app->request = $this->requestFactory->mapasPOST('opportunity', 'upload', [$opportunity->id]);
+        $app->response = new Response();
+
+        $files = $_FILES;
+        $length = $_SERVER['CONTENT_LENGTH'] ?? null;
+        $_FILES = [];
+        $_SERVER['CONTENT_LENGTH'] = $content_length;
+
+        try {
+            $controller = $app->controller('opportunity');
+            $controller->setRequestData(['id' => $opportunity->id]);
+            $controller->callAction('POST', 'upload', []);
+            $this->fail('Garantindo que o upload sem arquivo encerre com Halt após responder em JSON');
+        } catch (Halt) {
+        } finally {
+            $_FILES = $files;
+            if ($length === null) {
+                unset($_SERVER['CONTENT_LENGTH']);
+            } else {
+                $_SERVER['CONTENT_LENGTH'] = $length;
+            }
+        }
+
+        $body = $app->response->getBody();
+        $body->rewind();
+
+        return [
+            'status' => $app->response->getStatusCode(),
+            'data' => json_decode($body->getContents(), true)['data'] ?? null,
+        ];
+    }
+
+    private function createOpportunity(): Opportunity
+    {
+        $admin = $this->userDirector->createUser('admin');
+        $this->login($admin);
+
+        $this->opportunityBuilder
+            ->reset(owner: $admin->profile, owner_entity: $admin->profile)
+            ->fillRequiredProperties()
+            ->save();
+
+        return $this->opportunityBuilder->getInstance();
+    }
+}


### PR DESCRIPTION
## Do cenário

Quem tentava anexar um arquivo maior que o tamanho permitido via apenas uma faixa vermelha **sem nenhum texto** dentro. O sistema recusava o arquivo corretamente, mas não dizia por quê.

Havia um segundo efeito, menos visível: depois de um envio recusado, aquela tela parava de mostrar **qualquer** aviso. A pessoa salvava a oportunidade e não recebia a confirmação de que salvou.

## Da Solução

O sistema já sabia explicar o erro — a explicação vinha pronta do servidor e era descartada antes de chegar à tela. A correção foi deixá-la passar.

O que muda na prática:

- A faixa vermelha agora mostra o motivo: **"O arquivo enviado é maior do que o permitido."**
- Antes, quando o arquivo era muito grande, o sistema respondia que "nenhum arquivo foi enviado" — verdadeiro do ponto de vista do servidor, confuso para quem acabara de escolher um arquivo. Agora a mensagem diz o que de fato aconteceu.
- Os avisos da tela voltam a funcionar normalmente depois de um envio recusado.

Envios válidos seguem funcionando como antes: o arquivo é anexado, a janela fecha sozinha e o nome aparece na tela.

O comportamento foi conferido no navegador em quatro situações: 
- Arquivo muito acima do limite
- Arquivo pouco acima do limite
- Arquivo válido
- Envio bem-sucedido logo após uma recusa. 

## Dos Prints

### Antes
<img width="1280" height="600" alt="image" src="https://github.com/user-attachments/assets/6e68d174-23ed-46ce-990f-c6ec4e1f9103" />

### Depois
<img width="680" height="677" alt="image" src="https://github.com/user-attachments/assets/018fa04d-9944-489f-abee-009a05fe70b2" />
