### PR TITLE
Restaura o build da imagem Docker quebrado pelo pnpm 12

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ e este projeto adere ao [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 ## [UNRELEASED]
 ### Correções
 - Corrige os filtros de período de inscrição nas listas de oportunidades para enviar o timestamp completo (YYYY-MM-DD HH:mm) em vez de apenas a data, classificando corretamente as inscrições abertas, futuras e encerradas
+- Corrige a falha no build da imagem Docker introduzida pelo pnpm 12, fixando a versão do gerenciador de pacotes e declarando as dependências que não executam scripts de instalação
 
 ### Melhorias
 - Ajusta tamanho dos cards da seção "Em destaque" na página inicial

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -16,7 +16,7 @@ RUN curl -fsSL https://deb.nodesource.com/gpgkey/nodesource-repo.gpg.key | gpg -
 RUN echo "deb [signed-by=/etc/apt/keyrings/nodesource.gpg] https://deb.nodesource.com/node_20.x nodistro main" | sudo tee /etc/apt/sources.list.d/nodesource.list
 RUN apt-get update && apt-get install -y nodejs
 
-RUN npm install -g pnpm
+RUN corepack enable
 RUN rm -rf /var/lib/apt/lists
 
 ENV PNPM_HOME=/root/.local/share/pnpm

--- a/src/package.json
+++ b/src/package.json
@@ -1,6 +1,7 @@
 {
     "name": "mapasculturais",
     "private": true,
+    "packageManager": "pnpm@12.1.0",
     "scripts": {
         "dev": "pnpm run --parallel --recursive dev",
         "build": "pnpm run --parallel --recursive build",

--- a/src/pnpm-workspace.yaml
+++ b/src/pnpm-workspace.yaml
@@ -3,3 +3,8 @@ packages:
   - 'plugins/*'
   - 'themes/*'
   - 'node_scripts'
+
+allowBuilds:
+  '@parcel/watcher': false
+  '@scarf/scarf': false
+  vue-demi: false


### PR DESCRIPTION
## Do cenário

O build da imagem Docker parou de funcionar sem que ninguém tivesse tocado no código, bloqueando a publicação de novas imagens e, com ela, os deploys.

A mensagem no CI mostrava apenas o rodapé do buildx, `exit code: 1`; o erro real ficava dezenas de linhas acima, na saída do `pnpm install`.

A causa é externa ao projeto. O Dockerfile instalava o gerenciador de pacotes sem fixar versão, pegando sempre a mais recente publicada. A partir da versão 12, o pnpm passou a **interromper** a instalação ao encontrar dependências com scripts de instalação sem uma decisão explícita sobre elas; até então isso era apenas um aviso. O build quebrou sozinho no dia em que essa versão foi publicada.

## Da Solução

**Declarar as dependências que não executam scripts de instalação.** São quatro, e nenhuma precisa desses scripts aqui: telemetria de instalação, compatibilidade entre Vue 2 e 3 num projeto que usa Vue 3, e compilação de binário nativo que já vem pronto para a plataforma.

Negar, e não liberar, é deliberado: esses scripts já não rodavam. A versão anterior do pnpm também os bloqueava, apenas sem interromper. Negar preserva o comportamento que a imagem em produção já tem; liberar passaria a executar código que hoje não executa.

**Fixar a versão do gerenciador de pacotes no repositório.** Ela passa a ser declarada no `package.json`, ao lado do arquivo de dependências que precisa acompanhar, e a imagem usa o Corepack para respeitá-la. Assim a mesma versão vale no CI, no container de desenvolvimento e para quem roda o comando direto na máquina — antes ela vivia apenas dentro do Dockerfile.

O resultado do build não muda: os dezesseis artefatos gerados saem idênticos byte a byte. A alteração se restringe a arquivos de build.

Verificado construindo a imagem com o conteúdo real do repositório, em cada combinação relevante e com a rede desligada.
