### PR TITLE
Corrige 'Resumo do agente' desmarcado que seguia visível ao avaliador

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ e este projeto adere ao [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 ## [UNRELEASED]
 ### Correções
 - Corrige os filtros de período de inscrição nas listas de oportunidades para enviar o timestamp completo (YYYY-MM-DD HH:mm) em vez de apenas a data, classificando corretamente as inscrições abertas, futuras e encerradas
+- Corrige ocultação do resumo do agente ao desmarcar campo visível para avaliadores
 
 ### Melhorias
 - Ajusta tamanho dos cards da seção "Em destaque" na página inicial

--- a/src/core/Controllers/Opportunity.php
+++ b/src/core/Controllers/Opportunity.php
@@ -1482,7 +1482,7 @@ class Opportunity extends EntityController {
         if(!$opportunity->canUser("@control")){
             $avaliableEvaluationFields = (!empty($opportunity->avaliableEvaluationFields) || $opportunity->avaliableEvaluationFields != "") ? $opportunity->avaliableEvaluationFields : [];
             foreach($_result as $key => $res){
-                if(!in_array("agentsSummary", array_keys($avaliableEvaluationFields))){
+                if(!isset($avaliableEvaluationFields['agentsSummary']) || ($avaliableEvaluationFields['agentsSummary'] !== true && $avaliableEvaluationFields['agentsSummary'] !== 'true')){
                     $_result[$key]['registration']['owner'] =  [];
                     $_result[$key]['registration']['agentsData'] =  [];
                 }

--- a/src/core/Entities/Registration.php
+++ b/src/core/Entities/Registration.php
@@ -522,7 +522,7 @@ class Registration extends \MapasCulturais\Entity
         }
 
         $avaliableEvaluationFields = ($this->opportunity->avaliableEvaluationFields != "null") ? $this->opportunity->avaliableEvaluationFields : [];
-        if($avaliableEvaluationFields && in_array($key, array_keys($avaliableEvaluationFields))){
+        if($avaliableEvaluationFields && isset($avaliableEvaluationFields[$key]) && ($avaliableEvaluationFields[$key] === true || $avaliableEvaluationFields[$key] === 'true')){
             return true;
         }
 

--- a/src/modules/Components/assets/js/components-base/Utils.js
+++ b/src/modules/Components/assets/js/components-base/Utils.js
@@ -69,6 +69,11 @@ globalThis.Utils = {
         return false;
     },
 
+    isEvaluationFieldVisible(fields, key) {
+        const value = fields?.[key];
+        return value === true || value === 'true';
+    },
+
     createUrl(controllerId, action_name, args) {
         const shortcuts = $MAPAS.routes.shortcuts;
         const actions = $MAPAS.routes.actions;

--- a/src/modules/Components/components/mc-summary-agent-info/script.js
+++ b/src/modules/Components/components/mc-summary-agent-info/script.js
@@ -27,7 +27,7 @@ app.component('mc-summary-agent-info', {
                 can = true
             }
 
-            if (can && !this.avaliableEvaluationFields[item]) {
+            if (can && !Utils.isEvaluationFieldVisible(this.avaliableEvaluationFields, item)) {
                 can = false;
             }
             

--- a/src/modules/Components/components/mc-summary-agent/script.js
+++ b/src/modules/Components/components/mc-summary-agent/script.js
@@ -25,7 +25,7 @@ app.component('mc-summary-agent', {
                 can = true
             }
 
-            if (can &&!this.avaliableEvaluationFields[item]) {
+            if (can && !Utils.isEvaluationFieldVisible(this.avaliableEvaluationFields, item)) {
                 can = false;
             }
             

--- a/src/modules/Components/components/mc-summary-agents/script.js
+++ b/src/modules/Components/components/mc-summary-agents/script.js
@@ -23,8 +23,8 @@ app.component('mc-summary-agent-info', {
                 can = true
             }
 
-            if (can && !this.avaliableEvaluationFields[item]) {
-                can = true;
+            if (can && !Utils.isEvaluationFieldVisible(this.avaliableEvaluationFields, item)) {
+                can = false;
             }
             
             return can;

--- a/src/modules/Components/components/mc-summary-project/script.js
+++ b/src/modules/Components/components/mc-summary-project/script.js
@@ -27,7 +27,7 @@ app.component('mc-summary-project', {
                 can = true
             }
 
-            if (can &&!this.avaliableEvaluationFields[item]) {
+            if (can && !Utils.isEvaluationFieldVisible(this.avaliableEvaluationFields, item)) {
                 can = false;
             }
             

--- a/src/modules/Components/components/mc-summary-spaces/script.js
+++ b/src/modules/Components/components/mc-summary-spaces/script.js
@@ -28,7 +28,7 @@ app.component('mc-summary-spaces', {
                 can = true
             }
 
-            if (can &&!this.avaliableEvaluationFields[item]) {
+            if (can && !Utils.isEvaluationFieldVisible(this.avaliableEvaluationFields, item)) {
                 can = false;
             }
             

--- a/src/modules/Opportunities/components/opportunity-evaluations-list/script.js
+++ b/src/modules/Opportunities/components/opportunity-evaluations-list/script.js
@@ -122,7 +122,7 @@ app.component('opportunity-evaluations-list', {
                 args['@onlyMe'] = true;
             }
             
-            if(this.entity.opportunity.avaliableEvaluationFields?.['agentsSummary']) {
+            if(Utils.isEvaluationFieldVisible(this.entity.opportunity.avaliableEvaluationFields, 'agentsSummary')) {
                 args['registration:@select']+= ',agentsData';
             }
             

--- a/src/modules/Opportunities/components/opportunity-evaluations-table/script.js
+++ b/src/modules/Opportunities/components/opportunity-evaluations-table/script.js
@@ -139,7 +139,7 @@ app.component('opportunity-evaluations-table', {
                 return true;
             }
             
-            return this.phase.opportunity.avaliableEvaluationFields[field]
+            return Utils.isEvaluationFieldVisible(this.phase.opportunity.avaliableEvaluationFields, field)
         },
         createUrl(entity) {
             let user = this.user;

--- a/src/themes/BaseV1/Theme.php
+++ b/src/themes/BaseV1/Theme.php
@@ -1523,7 +1523,7 @@ class Theme extends MapasCulturais\Theme {
                     $field_name = $field->fieldName;
                     
                     if($reg->canUser("viewUserEvaluation") && !$reg->canUser("@control")){
-                        if(isset($opportunity->avaliableEvaluationFields[$field_name])){
+                        if(isset($opportunity->avaliableEvaluationFields[$field_name]) && ($opportunity->avaliableEvaluationFields[$field_name] === true || $opportunity->avaliableEvaluationFields[$field_name] === 'true')){
                             $this->jsObject['entity']['object']->$field_name = $reg->$field_name;
                         }
                     }else{

--- a/src/themes/BaseV1/layouts/parts/singles/registration--sidebar--left.php
+++ b/src/themes/BaseV1/layouts/parts/singles/registration--sidebar--left.php
@@ -26,8 +26,8 @@ use MapasCulturais\i;
                         <a href="{{::registration.singleUrl}}" rel='noopener noreferrer'>
                             <div class="registration-evaluated"> (<?php i::_e('Avaliação:'); ?> <strong> {{registrationStatus(registration)}}</strong>) </div>
                             <div class="registration-number">{{::registration.number}}</div>
-                            <div class="registration-owner" ng-if="data.avaliableEvaluationFields.agentsSummary">{{::registration.owner.name}}</div>
-                            <div ng-if="registration.category && data.avaliableEvaluationFields.category" class="registration-category">{{::registration.category}}</div>
+                            <div class="registration-owner" ng-if="data.avaliableEvaluationFields.agentsSummary === 'true' || data.avaliableEvaluationFields.agentsSummary === true">{{::registration.owner.name}}</div>
+                            <div ng-if="registration.category && (data.avaliableEvaluationFields.category === 'true' || data.avaliableEvaluationFields.category === true)" class="registration-category">{{::registration.category}}</div>
                         </a>
                     </li>
                 </ul>

--- a/src/themes/BaseV1/layouts/parts/singles/registration-single--header.php
+++ b/src/themes/BaseV1/layouts/parts/singles/registration-single--header.php
@@ -31,7 +31,7 @@
 <?php $this->applyTemplateHook('header-fieldset', 'after');?>
 
 <?php if($entity->projectName): ?>
-    <div class="registration-fieldset" ng-if="data.avaliableEvaluationFields['projectName'] || (data.entity.userHasControl)">
+    <div class="registration-fieldset" ng-if="data.avaliableEvaluationFields['projectName'] === 'true' || data.avaliableEvaluationFields['projectName'] === true || (data.entity.userHasControl)">
         <div class="label"><?php \MapasCulturais\i::_e("Nome do Projeto"); ?> </div>
         <h5> {{data.entity.object.projectName}} </h5>
     </div>


### PR DESCRIPTION
## Summary

Ao desmarcar a opção "Resumo do agente" na modal "Abrir campos" da configuração de avaliação de oportunidades e salvar, o avaliador continuava vendo as informações do agente na tela de avaliação — a desmarcação não se refletia na visualização do avaliador.

Este PR corrige a ocultação do resumo do agente quando o campo é desmarcado como visível para avaliadores.
