### PR TITLE
Fix/security public api

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ e este projeto adere ao [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 ## [UNRELEASED]
 ### Correções
+- Corrige falha na API pública que permitia a visitantes anônimos listar inscrições privadas e acessar dados pessoais dos proponentes
 - Corrige os filtros de período de inscrição nas listas de oportunidades para enviar o timestamp completo (YYYY-MM-DD HH:mm) em vez de apenas a data, classificando corretamente as inscrições abertas, futuras e encerradas
 
 ### Melhorias

--- a/src/core/ApiQuery.php
+++ b/src/core/ApiQuery.php
@@ -3579,7 +3579,7 @@ class ApiQuery {
             }
         }
         
-        if($class::isPrivateEntity() && !isset($this->apiParams['@permissions'])){
+        if($class::isPrivateEntity() && empty($this->apiParams['@permissions'])){
             $this->_addFilterByPermissions('view');
         }
 

--- a/src/core/ApiQuery.php
+++ b/src/core/ApiQuery.php
@@ -1596,6 +1596,14 @@ class ApiQuery {
                 }
             }
 
+            if($this->permissionCacheClassName && !($permissions[$entity[$this->pk]] ?? false)){
+                foreach(['agentsData', '_spaceData'] as $snapshot){
+                    if(isset($entity[$snapshot])){
+                        $entity[$snapshot] = [];
+                    }
+                }
+            }
+
             foreach($this->_selectingUrls as $action){
                 $entity["{$action}Url"] = $this->entityController->createUrl($action, [$entity[$this->pk]]);
             }

--- a/tests/src/PublicApiRegistrationPrivacyTest.php
+++ b/tests/src/PublicApiRegistrationPrivacyTest.php
@@ -1,0 +1,127 @@
+<?php
+
+namespace Tests;
+
+use MapasCulturais\App;
+use MapasCulturais\ApiQuery;
+use MapasCulturais\Entities\Registration;
+use Tests\Abstract\TestCase;
+use Tests\Enums\ProponentTypes;
+use Tests\Traits\UserDirector;
+use Tests\Traits\AgentDirector;
+use Tests\Traits\OpportunityBuilder;
+use Tests\Traits\RegistrationDirector;
+use Tests\Builders\PhasePeriods\Open;
+
+class PublicApiRegistrationPrivacyTest extends TestCase
+{
+    use OpportunityBuilder,
+        RegistrationDirector,
+        AgentDirector,
+        UserDirector;
+
+    private function createSentRegistration(): Registration
+    {
+        $app = App::i();
+
+        $admin = $this->userDirector->createUser('admin');
+        $this->login($admin);
+
+        $opportunity = $this->opportunityBuilder
+            ->reset(owner: $admin->profile, owner_entity: $admin->profile)
+            ->fillRequiredProperties()
+            ->setProponentTypes()
+            ->save()
+            ->firstPhase()
+                ->setRegistrationPeriod(new Open)
+                ->done()
+            ->save()
+            ->refresh()
+            ->getInstance();
+
+        $app->disableAccessControl();
+        $opportunity->publishRegistrations();
+        $app->enableAccessControl();
+
+        $registration = $this->registrationDirector->createSentRegistrations(
+            $opportunity,
+            number_of_registrations: 1,
+            proponent_type: ProponentTypes::COLETIVO->value
+        )[0];
+
+        return $registration;
+    }
+
+    private function findIds(array $params): array
+    {
+        return array_column((new ApiQuery(Registration::class, $params))->find(), 'id');
+    }
+
+    function testEmptyPermissionsDoesNotExposePrivateRegistrationToGuest()
+    {
+        $app = App::i();
+        $registration = $this->createSentRegistration();
+
+        $app->disableAccessControl();
+        $reachable = $this->findIds(['@select' => 'id']);
+        $app->enableAccessControl();
+        $this->assertContains($registration->id, $reachable, 'a inscrição precisa existir e ser consultável');
+
+        $this->logout();
+        $this->assertTrue($app->isAccessControlEnabled());
+
+        $this->assertNotContains($registration->id, $this->findIds(['@select' => 'id']),
+            'inscrição privada não deve aparecer para anônimo');
+
+        $this->assertNotContains($registration->id, $this->findIds(['@select' => 'id', '@permissions' => '']),
+            '@permissions vazio não deve derrubar a proteção da entidade privada');
+
+        $this->assertNotContains($registration->id, $this->findIds(['@select' => 'id', '@permissions' => '0']),
+            '@permissions=0 não deve derrubar a proteção da entidade privada');
+    }
+
+    function testAgentsDataSnapshotHiddenFromUserWithoutPrivateDataPermission()
+    {
+        $app = App::i();
+        $registration = $this->createSentRegistration();
+
+        $stranger = $this->userDirector->createUser();
+        $this->login($stranger);
+
+        $app->disableAccessControl();
+        $result = (new ApiQuery(Registration::class, ['@select' => 'id,agentsData']))->find();
+        $app->enableAccessControl();
+
+        $row = $this->rowById($result, $registration->id);
+        $this->assertNotNull($row, 'a inscrição precisa estar no resultado para testar o snapshot');
+        $this->assertSame([], $row['agentsData'],
+            'agentsData carrega dado pessoal e deve ser ocultado de quem não pode ver dado privado');
+    }
+
+    function testAgentsDataSnapshotVisibleToAdmin()
+    {
+        $app = App::i();
+        $registration = $this->createSentRegistration();
+
+        $admin = $this->userDirector->createUser('admin');
+        $this->login($admin);
+
+        $app->disableAccessControl();
+        $result = (new ApiQuery(Registration::class, ['@select' => 'id,agentsData']))->find();
+        $app->enableAccessControl();
+
+        $row = $this->rowById($result, $registration->id);
+        $this->assertNotNull($row, 'a inscrição precisa estar no resultado');
+        $this->assertNotEmpty($row['agentsData'], 'admin deve continuar vendo o snapshot');
+    }
+
+    private function rowById(array $result, int $id): ?array
+    {
+        foreach ($result as $row) {
+            if (($row['id'] ?? null) === $id) {
+                return $row;
+            }
+        }
+        return null;
+    }
+}


### PR DESCRIPTION
## Do cenário

`Registration` é entidade privada: a API pública deve devolver zero inscrições para quem não está autenticado. A proteção existia, mas era **condicional e burlável**.

**Vazamento 1 — listar inscrições sem autenticação.** A proteção obrigatória da entidade privada só era aplicada quando o parâmetro `@permissions` estava **ausente** (`!isset`). Passando `@permissions=` **vazio**, o parâmetro contava como presente e escapava da condição; ao mesmo tempo, o valor vazio é falsy e não acionava o filtro de pcache. Sobrava apenas `status > 0` — que quase toda inscrição enviada satisfaz. Um visitante anônimo listava o acervo inteiro de inscrições (no dump local, 76.232).

**Vazamento 2 — dados pessoais do proponente.** A inscrição guarda `agentsData` (e `_spaceData`), um snapshot em JSON gravado no envio com os dados do agente proponente: CPF, documento, CNPJ, RG, CNH, data de nascimento, raça, gênero, e-mail privado, telefones e endereço. Esse snapshot é uma coluna da inscrição, então **não passava pelo filtro de dado privado** que protege os metadados — saía cru para qualquer chamador que alcançasse a inscrição.

## Da Solução

Duas mudanças em `src/core/ApiQuery.php`, cada uma em um commit.

**Trata `@permissions` vazio como ausente.** A guarda da entidade privada passou de `!isset(...)` para `empty(...)`, de modo que valor vazio ou falsy conta como "nenhuma permissão pedida" e o filtro obrigatório de `view` sempre entra. Só afeta entidade privada e só o caso do valor vazio — chamadas com `@permissions=view`/`@control` seguem idênticas. Guest volta a receber zero inscrições.

**Oculta os snapshots de quem não pode ver dado privado.** No pós-processamento da consulta (`processEntities`), `agentsData` e `_spaceData` viram `[]` quando o usuário não tem permissão de ver dado privado — reusando `getViewPrivateDataPermissions`, o mesmo portão que já protege localização e metadado privado. Gestor, avaliador e o próprio proponente continuam vendo o snapshot; quem não tem permissão recebe vazio. Como a subconsulta de relação também passa por `processEntities`, o caminho por relação fica coberto pelo mesmo mecanismo.

## Da verificação

Conferido por requisição anônima no ambiente local:

- `registration/find` com `@permissions=`, `@permissions=0` e `@permissions=view` → todos **count 0** (antes, o vazio devolvia 76.232).
- `agentsData` num mesmo registro: **completo** para admin, **`[]`** para usuário sem permissão.
- `spaceData` (sem `_`) sai sempre `null` — não é caminho de vazamento; só `agentsData` e `_spaceData` carregam dado, e ambos são cobertos.

Teste automatizado novo (`tests/src/PublicApiRegistrationPrivacyTest.php`, 3 casos) travando: guest não lista inscrição privada nem com `@permissions` vazio; `agentsData` oculto de quem não tem permissão; `agentsData` visível para admin.

Suítes relacionadas verdes: `ApiTest`, `AgentApiTest`, `OpportunityApiTest`, `AgentRelatedAgentsApiRegressionTest`, `EvaluationSavePermissionTest`, `PanelEvaluationsComponentTest`, `EvaluatorOwnRegistrationWarningTest`, `EntityMetadataTest`. As 2 falhas de `OpportunityRegistrationsTest` e a de `EvaluationAccessRegressionTest` foram confirmadas como pré-existentes na base `v7.8.X`, sem relação com esta correção.
